### PR TITLE
fix(tgui): live progress preview — no-freeze counter, longer snippets, markdown rendering + gh in image

### DIFF
--- a/adapters/telegram/Dockerfile
+++ b/adapters/telegram/Dockerfile
@@ -30,7 +30,8 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
 
 # --- Runtime stage ------------------------------------------------------------
 # node:22 supplies Node (for the `claude` CLI). Add git/ripgrep/ffmpeg (the CLI
-# shells out to them) + the Docker CLI (talks to the optional dind sidecar).
+# shells out to them), the GitHub CLI (`gh`, for PR creation on github.com) + the
+# Docker CLI (talks to the optional dind sidecar).
 FROM node:22-bookworm-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -43,8 +44,11 @@ RUN set -eux; \
     curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc; \
     chmod a+r /etc/apt/keyrings/docker.asc; \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian $(. /etc/os-release && echo $VERSION_CODENAME) stable" > /etc/apt/sources.list.d/docker.list; \
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /etc/apt/keyrings/githubcli-archive-keyring.gpg; \
+    chmod 0644 /etc/apt/keyrings/githubcli-archive-keyring.gpg; \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list; \
     apt-get update; \
-    apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin; \
+    apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin gh; \
     npm install -g @anthropic-ai/claude-code; \
     npm cache clean --force; \
     apt-get clean; rm -rf /var/lib/apt/lists/*

--- a/internal/telegram/bot.go
+++ b/internal/telegram/bot.go
@@ -69,13 +69,27 @@ func (c *botChat) Edit(ctx context.Context, chatID int64, messageID int, text, s
 // calls update the same preview; an empty text clears it). It is rate-limit-free
 // relative to EditMessageText, so it carries the live run progress while the answer
 // is persisted with Send/Edit. A draft can't hold an inline keyboard, which is why
-// the Stop button rides a separate anchor message.
-func (c *botChat) StreamDraft(ctx context.Context, chatID int64, draftID, text string) error {
-	_, err := c.b.SendMessageDraft(ctx, &bot.SendMessageDraftParams{
+// the Stop button rides a separate anchor message. asMarkdown behaves as for
+// Send/Edit (HTML render with a plain-text fallback on a parse error); it is ignored
+// when text is empty (the clear call).
+func (c *botChat) StreamDraft(ctx context.Context, chatID int64, draftID, text string, asMarkdown bool) error {
+	params := &bot.SendMessageDraftParams{
 		ChatID:  chatID,
 		DraftID: draftID,
 		Text:    text,
-	})
+	}
+	if asMarkdown && text != "" {
+		params.Text = tgui.MarkdownToHTML(text)
+		params.ParseMode = models.ParseModeHTML
+	}
+	_, err := c.b.SendMessageDraft(ctx, params)
+	if err != nil && asMarkdown && text != "" && isParseError(err) {
+		// Telegram rejected our HTML markup: resend the ORIGINAL text as plain so a
+		// formatting glitch never costs the user the live preview.
+		params.Text = text
+		params.ParseMode = ""
+		_, err = c.b.SendMessageDraft(ctx, params)
+	}
 	return err
 }
 

--- a/internal/telegram/run.go
+++ b/internal/telegram/run.go
@@ -61,9 +61,10 @@ type chat interface {
 	// StreamDraft streams text as an ephemeral live "draft" preview keyed by
 	// draftID: repeated calls update the same preview (rate-limit-free, unlike
 	// Edit) and an empty text clears it. Used for live run progress; the answer is
-	// persisted with Send/Edit. Returns an error when the chat can't stream a draft,
+	// persisted with Send/Edit. asMarkdown behaves as for Send/Edit (ignored when
+	// text is empty). Returns an error when the chat can't stream a draft,
 	// so the caller can fall back to editing a normal message.
-	StreamDraft(ctx context.Context, chatID int64, draftID string, text string) error
+	StreamDraft(ctx context.Context, chatID int64, draftID string, text string, asMarkdown bool) error
 	// Delete removes a message; failures are non-fatal to the caller.
 	Delete(ctx context.Context, chatID int64, messageID int) error
 	// SendDocument uploads a file to the chat as a Telegram document. The data is
@@ -359,7 +360,7 @@ func (s *Service) run(ctx context.Context, chatID, userID int64, prompt string, 
 
 	// Seed the live preview immediately so it appears without waiting for a tick.
 	if draftStreaming {
-		if err := s.chat.StreamDraft(ctx, chatID, runID, prog.Frame()); err != nil {
+		if err := s.chat.StreamDraft(ctx, chatID, runID, prog.Frame(), true); err != nil {
 			draftStreaming = false
 			s.log.Debug("draft streaming unsupported; falling back to edits", "error", err)
 		} else {
@@ -378,7 +379,7 @@ func (s *Service) run(ctx context.Context, chatID, userID int64, prompt string, 
 			return
 		}
 		if draftStreaming {
-			if err := s.chat.StreamDraft(ctx, chatID, runID, frame); err != nil {
+			if err := s.chat.StreamDraft(ctx, chatID, runID, frame, true); err != nil {
 				// Drafts unsupported here: edit the anchor for the rest of the run.
 				draftStreaming = false
 				s.log.Debug("draft stream failed; falling back to edits", "error", err)
@@ -398,7 +399,7 @@ func (s *Service) run(ctx context.Context, chatID, userID int64, prompt string, 
 		if !lastEditAt.IsZero() && s.nowFunc().Sub(lastEditAt) < minEditInterval {
 			return
 		}
-		if err := s.chat.Edit(ctx, chatID, progressMsgID, frame, runID, false); err != nil {
+		if err := s.chat.Edit(ctx, chatID, progressMsgID, frame, runID, true); err != nil {
 			if d, ok := retryAfter(err); ok {
 				throttledUntil = s.nowFunc().Add(d)
 			}
@@ -495,7 +496,7 @@ func (s *Service) finish(ctx context.Context, chatID int64, progressMsgID int, r
 	deliverCtx := context.WithoutCancel(ctx)
 	// Clear the live draft preview (empty text) so it doesn't linger beside the
 	// persisted answer. Best-effort; harmless if no draft was ever streamed.
-	_ = s.chat.StreamDraft(deliverCtx, chatID, runID, "")
+	_ = s.chat.StreamDraft(deliverCtx, chatID, runID, "", false)
 	var text string
 	switch {
 	case ctxErr != nil && res == nil && runErr == nil:

--- a/internal/telegram/run.go
+++ b/internal/telegram/run.go
@@ -30,6 +30,15 @@ import (
 // loop), so this only governs the quiet-period cadence.
 const tickInterval = 1 * time.Second
 
+// minEditInterval throttles real edits in the rate-limited fallback path. Drafts
+// (the primary live path) have no Telegram rate limit and refresh every
+// tickInterval; the Edit fallback IS rate-limited, so when a run falls back to
+// editing the anchor we additionally cap real edits to at most one per
+// minEditInterval. A 1s ticker would otherwise hammer the throttled Edit endpoint,
+// drawing 429s whose back-off parks render() and freezes the counter. Drafts are
+// never throttled by this — only the fallback edit branch.
+const minEditInterval = 3 * time.Second
+
 // anchorText is the persistent message sent at the start of a run. It carries the
 // Stop button (which an ephemeral draft can't) and is later edited into the final
 // answer; the live progress streams separately as a draft.
@@ -336,6 +345,10 @@ func (s *Service) run(ctx context.Context, chatID, userID int64, prompt string, 
 	var (
 		lastSent       string
 		throttledUntil time.Time
+		// lastEditAt is the wall-clock time of the last SUCCESSFUL fallback edit; its
+		// zero value lets the first fallback edit fire promptly (so a mid-run flip from
+		// draft to fallback isn't blocked). Only the edit fallback consults it.
+		lastEditAt time.Time
 		// draftStreaming holds while we push live progress as an ephemeral draft (the
 		// rate-limit-free path). The first failed StreamDraft flips it off and the run
 		// falls back to editing the anchor for its remainder.
@@ -379,6 +392,12 @@ func (s *Service) run(ctx context.Context, chatID, userID int64, prompt string, 
 		if !throttledUntil.IsZero() && s.nowFunc().Before(throttledUntil) {
 			return
 		}
+		// Also throttle real edits to one per minEditInterval: the 1s ticker would
+		// otherwise spam the rate-limited Edit endpoint and provoke the 429s above.
+		// The zero value of lastEditAt lets the first fallback edit fire immediately.
+		if !lastEditAt.IsZero() && s.nowFunc().Sub(lastEditAt) < minEditInterval {
+			return
+		}
 		if err := s.chat.Edit(ctx, chatID, progressMsgID, frame, runID, false); err != nil {
 			if d, ok := retryAfter(err); ok {
 				throttledUntil = s.nowFunc().Add(d)
@@ -386,6 +405,7 @@ func (s *Service) run(ctx context.Context, chatID, userID int64, prompt string, 
 			s.log.Debug("edit progress", "error", err)
 			return
 		}
+		lastEditAt = s.nowFunc()
 		lastSent = frame
 	}
 

--- a/internal/telegram/run_test.go
+++ b/internal/telegram/run_test.go
@@ -56,6 +56,8 @@ type fakeChat struct {
 	docs     []string // every SendDocument'd filename, in order
 	drafts   []string // every successful StreamDraft'd text, in order (live preview)
 	draftErr error    // when set, StreamDraft returns it (simulates no draft support)
+	editErr  error    // when set, Edit returns it (e.g. a 429 to exercise throttling)
+	edits    int      // count of Edit calls (progress + final), for the throttle test
 }
 
 func newFakeChat() *fakeChat {
@@ -80,9 +82,20 @@ func (f *fakeChat) Send(_ context.Context, _ int64, text, stopRunID string, _ bo
 func (f *fakeChat) Edit(_ context.Context, _ int64, messageID int, text, stopRunID string, _ bool) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.edits++
+	if f.editErr != nil {
+		return f.editErr
+	}
 	f.texts[messageID] = text
 	f.hasStop[messageID] = stopRunID != ""
 	return nil
+}
+
+// editCount reports how many Edit calls the chat has received.
+func (f *fakeChat) editCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.edits
 }
 
 func (f *fakeChat) StreamDraft(_ context.Context, _ int64, _ string, text string) error {
@@ -398,6 +411,89 @@ func TestRunFallsBackToEditsWhenDraftFails(t *testing.T) {
 	if len(fc.drafts) != 0 {
 		t.Fatalf("no draft should succeed in fallback mode; got %v", fc.drafts)
 	}
+}
+
+// fakeClock is a thread-safe, manually-advanced clock for nowFunc injection.
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func newFakeClock() *fakeClock { return &fakeClock{t: time.Unix(0, 0)} }
+
+func (c *fakeClock) now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *fakeClock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.t = c.t.Add(d)
+}
+
+// TestEditFallbackRespectsMinInterval drives the rate-limited Edit fallback (drafts
+// disabled) with many fast ticks while advancing the injected clock in small steps,
+// and asserts that real edits are bounded to roughly one per minEditInterval window
+// (not one per tick) AND that the rendered counter still advances across windows —
+// i.e. the throttle bounds edits without freezing the counter.
+func TestEditFallbackRespectsMinInterval(t *testing.T) {
+	fc := newFakeChat()
+	fc.draftErr = errors.New("drafts unsupported") // force the edit fallback
+	gate := make(chan struct{})
+	fr := &fakeRunner{
+		events: []claude.Event{{Type: claude.ToolUse, Tool: "Bash"}},
+		gate:   gate, // keep the run in flight while we drive ticks/clock
+	}
+	svc, d := newTestService(t, fr, fc)
+	defer d.Close()
+
+	clk := newFakeClock()
+	svc.nowFunc = clk.now
+	svc.tick = time.Millisecond // tick fast so many ticks land per clock window
+
+	svc.Handle(context.Background(), 100, 100, 1, "go")
+
+	// Wait until the anchor exists (the run is up and in fallback mode).
+	waitUntil(t, func() bool {
+		_, stop := fc.snapshot(1)
+		return stop
+	})
+
+	// Advance the clock across several minEditInterval windows in small sub-interval
+	// steps, giving the fast ticker many chances to edit within each window.
+	const windows = 4
+	step := minEditInterval / 5
+	for i := 0; i < windows*5; i++ {
+		clk.advance(step)
+		time.Sleep(3 * time.Millisecond) // let several real ticks fire at this clock value
+	}
+
+	// Edits during the run are throttled to ~one per window: with `windows` windows
+	// (plus the prompt first-edit) we expect far fewer than the hundreds of ticks.
+	progressEdits := fc.editCount()
+	if progressEdits > windows+2 {
+		t.Fatalf("edits not throttled: %d edits across %d windows", progressEdits, windows)
+	}
+	if progressEdits == 0 {
+		t.Fatal("no edits happened in fallback mode; counter would be frozen")
+	}
+
+	// The counter advanced across windows: the anchor text shows the elapsed seconds
+	// climbing past the first window, proving the throttle didn't park render().
+	text, _ := fc.snapshot(1)
+	if !strings.Contains(text, "Working") {
+		t.Fatalf("anchor not showing progress: %q", text)
+	}
+	wantSecs := int((windows*5 * int(step)) / int(time.Second))
+	if wantSecs > 0 && !strings.Contains(text, "("+strconv.Itoa(wantSecs)+"s)") &&
+		!strings.Contains(text, "("+strconv.Itoa(wantSecs-1)+"s)") &&
+		!strings.Contains(text, "("+strconv.Itoa(wantSecs-2)+"s)") {
+		t.Fatalf("counter did not advance to ~%ds: %q", wantSecs, text)
+	}
+
+	close(gate)
 }
 
 func TestRunChunksLongFinal(t *testing.T) {

--- a/internal/telegram/run_test.go
+++ b/internal/telegram/run_test.go
@@ -486,7 +486,7 @@ func TestEditFallbackRespectsMinInterval(t *testing.T) {
 	if !strings.Contains(text, "Working") {
 		t.Fatalf("anchor not showing progress: %q", text)
 	}
-	wantSecs := int((windows*5 * int(step)) / int(time.Second))
+	wantSecs := int((windows * 5 * int(step)) / int(time.Second))
 	if wantSecs > 0 && !strings.Contains(text, "("+strconv.Itoa(wantSecs)+"s)") &&
 		!strings.Contains(text, "("+strconv.Itoa(wantSecs-1)+"s)") &&
 		!strings.Contains(text, "("+strconv.Itoa(wantSecs-2)+"s)") {

--- a/internal/telegram/run_test.go
+++ b/internal/telegram/run_test.go
@@ -55,6 +55,7 @@ type fakeChat struct {
 	sent     []string // every Send'd text, in order
 	docs     []string // every SendDocument'd filename, in order
 	drafts   []string // every successful StreamDraft'd text, in order (live preview)
+	draftMD  []bool   // asMarkdown flag for each successful StreamDraft, parallel to drafts
 	draftErr error    // when set, StreamDraft returns it (simulates no draft support)
 	editErr  error    // when set, Edit returns it (e.g. a 429 to exercise throttling)
 	edits    int      // count of Edit calls (progress + final), for the throttle test
@@ -98,13 +99,14 @@ func (f *fakeChat) editCount() int {
 	return f.edits
 }
 
-func (f *fakeChat) StreamDraft(_ context.Context, _ int64, _ string, text string) error {
+func (f *fakeChat) StreamDraft(_ context.Context, _ int64, _ string, text string, asMarkdown bool) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.draftErr != nil {
 		return f.draftErr
 	}
 	f.drafts = append(f.drafts, text)
+	f.draftMD = append(f.draftMD, asMarkdown)
 	return nil
 }
 
@@ -379,9 +381,18 @@ func TestRunStreamsProgressAsDraftThenClears(t *testing.T) {
 	if len(fc.drafts) == 0 || !strings.Contains(fc.drafts[0], "Working") {
 		t.Fatalf("progress not streamed as a draft; drafts=%v", fc.drafts)
 	}
+	// ...rendered as markdown/HTML so `code` and **bold** don't show as raw text.
+	if !fc.draftMD[0] {
+		t.Fatalf("progress draft not pushed with asMarkdown=true; draftMD=%v", fc.draftMD)
+	}
 	// ...and the draft is cleared (empty) once the answer is finalized.
-	if last := fc.drafts[len(fc.drafts)-1]; last != "" {
-		t.Fatalf("draft not cleared on finish; last draft = %q", last)
+	last := len(fc.drafts) - 1
+	if fc.drafts[last] != "" {
+		t.Fatalf("draft not cleared on finish; last draft = %q", fc.drafts[last])
+	}
+	// The clear is plain (no formatting) — empty text carries no markdown.
+	if fc.draftMD[last] {
+		t.Fatalf("draft clear should be plain (asMarkdown=false); draftMD=%v", fc.draftMD)
 	}
 }
 

--- a/internal/tgui/progress.go
+++ b/internal/tgui/progress.go
@@ -193,6 +193,9 @@ func (p *Progress) Frame() string {
 			break
 		}
 	}
+	// The header is tiny (≈20 runes) and frameBudgetMax is in the thousands, so
+	// budget is always comfortably positive; the clamp is pure defense so a future
+	// outsized header can never make capLine's budget non-positive.
 	budget := frameBudgetMax - overhead
 	if budget < 1 {
 		budget = 1

--- a/internal/tgui/progress.go
+++ b/internal/tgui/progress.go
@@ -33,6 +33,10 @@ const (
 // a progress frame is always a single Telegram message with ~596 runes of
 // headroom for markup/encoding slack; Frame() drops oldest ring lines (and, in the
 // extreme, hard-truncates the most recent line) to honor it.
+//
+// The budget is measured on the markdown SOURCE runes; the live frame is rendered
+// via MarkdownToHTML, which only adds tags/escapes, so the VISIBLE length (all
+// Telegram's 4096 limit counts) is <= source length. The limit therefore still holds.
 const frameBudgetMax = 3500
 
 // Activity-line prefixes: a thought balloon for the model's text, a wrench for a

--- a/internal/tgui/progress.go
+++ b/internal/tgui/progress.go
@@ -17,10 +17,23 @@ import (
 // defaultRingSize is how many recent activity lines the progress frame shows.
 const defaultRingSize = 5
 
-// activitySnippetMax bounds the TEXT of a single rendered activity line so a long
-// tool input or thought can't blow up the frame, while still showing enough to
-// read. The line's emoji prefix is added on top of this budget.
-const activitySnippetMax = 240
+// These bound the TEXT of rendered activity lines (the emoji prefix is added on
+// top of each budget) so a long tool input or thought can't blow up the frame,
+// while still showing enough to read. The cap is POSITIONAL: the most recent ring
+// line gets the larger recentSnippetMax so the current activity is readable, and
+// older lines get the tighter olderSnippetMax since they are just context. The
+// caps are applied at Frame() assembly time, not when the line is stored.
+const (
+	recentSnippetMax = 800
+	olderSnippetMax  = 400
+)
+
+// frameBudgetMax bounds the WHOLE assembled frame (header + blank + ring lines)
+// in runes. It stays comfortably below TelegramMaxMessage (4096, see chunk.go) so
+// a progress frame is always a single Telegram message with ~596 runes of
+// headroom for markup/encoding slack; Frame() drops oldest ring lines (and, in the
+// extreme, hard-truncates the most recent line) to honor it.
+const frameBudgetMax = 3500
 
 // Activity-line prefixes: a thought balloon for the model's text, a wrench for a
 // tool call.
@@ -74,7 +87,10 @@ func (p *Progress) Observe(e claude.Event) bool {
 }
 
 // activityLine renders the one-line activity summary for an event, or false if
-// the event contributes no visible activity.
+// the event contributes no visible activity. The TEXT is capped at a generous
+// upper bound (recentSnippetMax) when stored — enough for any ring position — and
+// Frame() re-caps it tighter per recency. The emoji prefix is added on top of the
+// text budget, so it is never split or counted against the cap.
 func activityLine(e claude.Event) (string, bool) {
 	switch e.Type {
 	case claude.ToolUse:
@@ -82,17 +98,29 @@ func activityLine(e claude.Event) (string, bool) {
 		if tool == "" {
 			tool = "tool"
 		}
-		return toolPrefix + truncateRunes(tool, activitySnippetMax), true
+		return toolPrefix + truncateRunes(tool, recentSnippetMax), true
 	case claude.Text:
 		snippet := collapseWhitespace(e.Text)
 		if snippet == "" {
 			return "", false
 		}
-		return thoughtPrefix + truncateRunes(snippet, activitySnippetMax), true
+		return thoughtPrefix + truncateRunes(snippet, recentSnippetMax), true
 	default:
 		// SystemInit, ToolResult, Result, RunError: no activity line.
 		return "", false
 	}
+}
+
+// capLine re-caps a stored activity line's TEXT to maxText runes, preserving its
+// emoji prefix (which is added on top of the budget, never split or counted). A
+// line without a known prefix is capped whole.
+func capLine(line string, maxText int) string {
+	for _, prefix := range []string{thoughtPrefix, toolPrefix} {
+		if strings.HasPrefix(line, prefix) {
+			return prefix + truncateRunes(line[len(prefix):], maxText)
+		}
+	}
+	return truncateRunes(line, maxText)
 }
 
 // push appends a line to the bounded ring, evicting the oldest when full.
@@ -117,15 +145,59 @@ func (p *Progress) Frame() string {
 	if len(p.ring) == 0 {
 		return header
 	}
-	var b strings.Builder
-	b.WriteString(header)
-	// A blank line sets the activity ("thoughts") apart from the Working header.
-	b.WriteString("\n")
-	for _, line := range p.ring {
-		b.WriteByte('\n')
-		b.WriteString(line)
+
+	// Re-cap each ring line by recency: the last (most recent) line gets the
+	// generous recentSnippetMax, all earlier lines the tighter olderSnippetMax.
+	lines := make([]string, len(p.ring))
+	for i, line := range p.ring {
+		maxText := olderSnippetMax
+		if i == len(p.ring)-1 {
+			maxText = recentSnippetMax
+		}
+		lines[i] = capLine(line, maxText)
 	}
-	return b.String()
+
+	// Enforce the overall frame budget. assemble joins the header (always kept),
+	// a blank separator, and the given ring lines; its rune count must not exceed
+	// frameBudgetMax. Drop the OLDEST lines first until it fits.
+	assemble := func(ringLines []string) string {
+		var b strings.Builder
+		b.WriteString(header)
+		// A blank line sets the activity ("thoughts") apart from the Working header.
+		b.WriteString("\n")
+		for _, line := range ringLines {
+			b.WriteByte('\n')
+			b.WriteString(line)
+		}
+		return b.String()
+	}
+	for len(lines) > 1 && utf8.RuneCountInString(assemble(lines)) > frameBudgetMax {
+		lines = lines[1:]
+	}
+
+	frame := assemble(lines)
+	if utf8.RuneCountInString(frame) <= frameBudgetMax {
+		return frame
+	}
+
+	// A single surviving line (the most recent) still blows the budget on its own.
+	// Hard-truncate it so the frame is always <= frameBudgetMax, but never emit an
+	// empty frame: keep the header + a blank + the truncated line. The header, the
+	// two separating newlines, and the line's emoji prefix all ride on top of the
+	// text budget, so subtract them so capLine's TEXT cap keeps the whole frame in
+	// bounds.
+	overhead := utf8.RuneCountInString(header) + 2
+	for _, prefix := range []string{thoughtPrefix, toolPrefix} {
+		if strings.HasPrefix(lines[0], prefix) {
+			overhead += utf8.RuneCountInString(prefix)
+			break
+		}
+	}
+	budget := frameBudgetMax - overhead
+	if budget < 1 {
+		budget = 1
+	}
+	return assemble([]string{capLine(lines[0], budget)})
 }
 
 // Final renders the terminal message text for a successful run result. A

--- a/internal/tgui/progress_test.go
+++ b/internal/tgui/progress_test.go
@@ -90,7 +90,9 @@ func TestObserveTextAndIgnoredEvents(t *testing.T) {
 func TestActivitySnippetTruncated(t *testing.T) {
 	var elapsed time.Duration
 	p := NewProgress(fakeClock(&elapsed), 5)
-	long := strings.Repeat("a", 500)
+	// A single (hence most-recent) line longer than recentSnippetMax is capped at
+	// recentSnippetMax; the emoji prefix rides on top of that text budget.
+	long := strings.Repeat("a", recentSnippetMax+200)
 	p.Observe(claude.Event{Type: claude.Text, Text: long})
 	frame := p.Frame()
 	prefixRunes := utf8.RuneCountInString(thoughtPrefix)
@@ -100,9 +102,8 @@ func TestActivitySnippetTruncated(t *testing.T) {
 			continue
 		}
 		sawActivity = true
-		// The text is capped at activitySnippetMax; the emoji prefix rides on top.
-		if n := utf8.RuneCountInString(line); n > activitySnippetMax+prefixRunes {
-			t.Fatalf("snippet exceeded max: %d runes (cap %d + prefix %d)", n, activitySnippetMax, prefixRunes)
+		if n := utf8.RuneCountInString(line); n > recentSnippetMax+prefixRunes {
+			t.Fatalf("snippet exceeded max: %d runes (cap %d + prefix %d)", n, recentSnippetMax, prefixRunes)
 		}
 	}
 	if !sawActivity {
@@ -110,6 +111,96 @@ func TestActivitySnippetTruncated(t *testing.T) {
 	}
 	if !strings.Contains(frame, "…") {
 		t.Fatalf("expected ellipsis on truncated snippet: %q", frame)
+	}
+}
+
+// TestPositionalSnippetCaps asserts the per-line cap is positional by recency:
+// the most-recent ring line gets recentSnippetMax (so a line between olderSnippetMax
+// and recentSnippetMax stays untruncated when newest) while an older line of the
+// same length is truncated to olderSnippetMax.
+func TestPositionalSnippetCaps(t *testing.T) {
+	var elapsed time.Duration
+	p := NewProgress(fakeClock(&elapsed), 5)
+
+	// Length is longer than olderSnippetMax but shorter than recentSnippetMax, so
+	// it is untruncated only while it is the most-recent line.
+	mid := olderSnippetMax + 100
+	older := strings.Repeat("o", mid)
+	newer := strings.Repeat("n", mid)
+	p.Observe(claude.Event{Type: claude.Text, Text: older})
+	p.Observe(claude.Event{Type: claude.Text, Text: newer})
+
+	prefixRunes := utf8.RuneCountInString(thoughtPrefix)
+	var olderLine, newerLine string
+	for _, line := range strings.Split(p.Frame(), "\n") {
+		switch {
+		case strings.HasPrefix(line, thoughtPrefix+"o"):
+			olderLine = line
+		case strings.HasPrefix(line, thoughtPrefix+"n"):
+			newerLine = line
+		}
+	}
+	if olderLine == "" || newerLine == "" {
+		t.Fatalf("missing ring lines: older=%q newer=%q", olderLine, newerLine)
+	}
+
+	// The newer (most-recent) line fits within recentSnippetMax untruncated.
+	if n := utf8.RuneCountInString(newerLine) - prefixRunes; n != mid {
+		t.Fatalf("most-recent line truncated: %d text runes, want %d (no ellipsis)", n, mid)
+	}
+	if strings.Contains(newerLine, "…") {
+		t.Fatalf("most-recent line should not be truncated: %q", newerLine)
+	}
+	// The older line is capped to olderSnippetMax and shows an ellipsis.
+	if n := utf8.RuneCountInString(olderLine) - prefixRunes; n != olderSnippetMax {
+		t.Fatalf("older line text = %d runes, want olderSnippetMax %d", n, olderSnippetMax)
+	}
+	if !strings.Contains(olderLine, "…") {
+		t.Fatalf("older line should be truncated with an ellipsis: %q", olderLine)
+	}
+}
+
+// TestFrameBudgetNeverExceedsLimit pushes many maximal-length lines and asserts the
+// assembled frame stays within frameBudgetMax (and therefore below TelegramMaxMessage).
+func TestFrameBudgetNeverExceedsLimit(t *testing.T) {
+	var elapsed time.Duration
+	p := NewProgress(fakeClock(&elapsed), 5)
+	for i := 0; i < 5; i++ {
+		p.Observe(claude.Event{Type: claude.Text, Text: strings.Repeat("x", recentSnippetMax+500)})
+	}
+	frame := p.Frame()
+	if n := utf8.RuneCountInString(frame); n > frameBudgetMax {
+		t.Fatalf("frame exceeded budget: %d runes (max %d)", n, frameBudgetMax)
+	}
+	if utf8.RuneCountInString(frame) >= TelegramMaxMessage {
+		t.Fatalf("frame not below Telegram limit %d", TelegramMaxMessage)
+	}
+}
+
+// TestSingleOversizedLineHardTruncated covers the extreme: one line alone far
+// larger than frameBudgetMax must be hard-truncated so the frame still contains the
+// header + that line, is non-empty, and stays within budget. We push a pre-built
+// oversized ring entry directly (same package) because the public Observe path caps
+// stored text at recentSnippetMax, which is below the frame budget by design.
+func TestSingleOversizedLineHardTruncated(t *testing.T) {
+	var elapsed time.Duration
+	p := NewProgress(fakeClock(&elapsed), 5)
+	p.push(thoughtPrefix + strings.Repeat("z", frameBudgetMax+2000))
+	frame := p.Frame()
+	if frame == "" {
+		t.Fatal("frame is empty")
+	}
+	if !strings.HasPrefix(frame, spinnerFrames[0]) {
+		t.Fatalf("frame missing header: %.40q", frame)
+	}
+	if !strings.Contains(frame, thoughtPrefix) {
+		t.Fatalf("frame missing the activity line: %.60q", frame)
+	}
+	if !strings.Contains(frame, "…") {
+		t.Fatalf("oversized single line should be hard-truncated with an ellipsis")
+	}
+	if n := utf8.RuneCountInString(frame); n > frameBudgetMax {
+		t.Fatalf("frame exceeded budget: %d runes (max %d)", n, frameBudgetMax)
 	}
 }
 

--- a/internal/tgui/progress_test.go
+++ b/internal/tgui/progress_test.go
@@ -2,6 +2,7 @@ package tgui
 
 import (
 	"errors"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -201,6 +202,41 @@ func TestSingleOversizedLineHardTruncated(t *testing.T) {
 	}
 	if n := utf8.RuneCountInString(frame); n > frameBudgetMax {
 		t.Fatalf("frame exceeded budget: %d runes (max %d)", n, frameBudgetMax)
+	}
+}
+
+// TestFrameBudgetDropsOldestLines exercises the drop-oldest loop in Frame(): with a
+// ring larger than the default, the positionally-capped lines together exceed
+// frameBudgetMax, so Frame() must drop the OLDEST lines until the frame fits while
+// keeping the most recent ones. (At the default ring size of 5 the per-line caps
+// alone keep the frame well under budget, so the loop never triggers there.)
+func TestFrameBudgetDropsOldestLines(t *testing.T) {
+	var elapsed time.Duration
+	const ring = 20
+	p := NewProgress(fakeClock(&elapsed), ring)
+	// Each line is a max-length older snippet tagged with its index at the FRONT, so
+	// the tag survives end-truncation and lets us tell which lines were kept.
+	for i := 0; i < ring; i++ {
+		p.push(thoughtPrefix + "L" + strconv.Itoa(i) + " " + strings.Repeat("x", olderSnippetMax))
+	}
+	frame := p.Frame()
+	if n := utf8.RuneCountInString(frame); n > frameBudgetMax {
+		t.Fatalf("frame exceeded budget: %d runes (max %d)", n, frameBudgetMax)
+	}
+	// The drop loop must have run: fewer activity lines than pushed.
+	kept := strings.Count(frame, thoughtPrefix)
+	if kept >= ring {
+		t.Fatalf("drop loop did not run: kept %d of %d lines", kept, ring)
+	}
+	if kept < 1 {
+		t.Fatal("frame kept no activity lines")
+	}
+	// Newest survives, oldest is dropped.
+	if !strings.Contains(frame, "L"+strconv.Itoa(ring-1)+" ") {
+		t.Fatalf("most recent line was dropped: %.80q", frame)
+	}
+	if strings.Contains(frame, "L0 ") {
+		t.Fatalf("oldest line should have been dropped first: %.80q", frame)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes to the live **"Working… (Ns)"** Telegram progress preview and its runtime image.

### Issue A — the elapsed counter freezes during a long, silent tool call
In chats where business-draft streaming is unavailable, the run uses the **rate-limited `Edit` fallback**. The wall-clock ticker (recently dropped 2s→1s in `e8b448c`) edited the anchor message every second, which Telegram throttles with `429`s; the back-off then parks `render()` and the counter visibly freezes for the whole retry-after window.

**Fix:** a `minEditInterval` (3s) throttle applied **only** to the `Edit` fallback branch in `internal/telegram/run.go`. It sits after the existing `throttledUntil` skip and keys off `lastEditAt`, which is set only on a *successful* edit (a failed/429 edit doesn't start the clock; the zero value lets the first fallback edit fire promptly). The draft path (`StreamDraft`) is left untouched, so the per-event/per-tick liveliness from `e8b448c` is **not** regressed.

### Issue B — activity snippet lines were truncated too aggressively
Each thought/tool line was cut to 240 runes.

**Fix (`internal/tgui/progress.go`):** positional per-line budgets — the **most recent** ring line gets `recentSnippetMax` (800), older lines `olderSnippetMax` (400). `Frame()` then enforces an overall `frameBudgetMax` (3500 runes): it drops the oldest lines first and, in the extreme, hard-truncates the most recent line — so an assembled frame is **always** a single Telegram message below `TelegramMaxMessage` (4096), with headroom.

### Issue C — markdown not rendered in the live preview
The progress frame was sent as **plain text**, so the model's markdown (`` `code` ``, `**bold**`) showed up as raw characters in the live preview — even though the final answer already renders as Telegram HTML.

**Fix:** render the live frame as Telegram HTML on **both** transports, reusing the existing `tgui.MarkdownToHTML` + plain-text-on-parse-error pattern. `botChat.StreamDraft` gains an `asMarkdown` param (the library's `SendMessageDraftParams` supports `ParseMode`); the two progress draft pushes and the edit fallback now render HTML, while the draft-clear stays plain. The parse-error retry lives **inside** `StreamDraft`, so a formatting glitch degrades to plain text without flipping the run out of draft mode. The `frameBudgetMax` (3500 source runes) keeps both the HTML and plain paths under Telegram's 4096 visible-text limit (HTML tags/entities don't count toward it).

### Issue D — `gh` missing from the runtime image
The Go-rewrite image (`adapters/telegram/Dockerfile`, node:22 base) shells out to `gh` for PR creation on github.com, but the GitHub CLI was never carried over from the previous `Dockerfile.python` — so `gh` was absent at runtime (PRs had to be created via the raw GitHub API).

**Fix:** add the official GitHub CLI apt repo + the `gh` package alongside the existing `docker-ce-cli` install, mirroring `Dockerfile.python`. Verified `gh` installs and runs (v2.93.0) on `node:22-bookworm-slim`.

## Acceptance criteria

- [x] **AC1** — edit fallback edits at most ~once per `minEditInterval`; no 429 storm; existing `throttledUntil` skip preserved.
- [x] **AC2** — draft mode not regressed: the throttle touches only the `Edit` branch; `StreamDraft` still pushes per-event and per-tick.
- [x] **AC3** — most-recent line budget (800) > older lines (400), both well above the old 240; under-cap snippets shown untruncated.
- [x] **AC4** — `Frame()` rune count always ≤ `frameBudgetMax` (< 4096), even with many maximal lines or one oversized line; never emits an empty frame.
- [x] **AC5** — the live progress frame renders markdown (HTML) on both draft and edit transports, with a plain-text fallback on parse error; the draft-clear stays plain.
- [x] **AC6** — `gh` is present on PATH in the runtime image.

## How it was verified

- Full suite: `go test ./...` — green (Docker `golang:1.23`, mirroring the Makefile/CI).
- Lint: `golangci-lint run` (`golangci/golangci-lint:v1.61.0`) — clean.
- Tests: `TestEditFallbackRespectsMinInterval`, `TestPositionalSnippetCaps`, `TestFrameBudgetNeverExceedsLimit`, `TestSingleOversizedLineHardTruncated`, `TestFrameBudgetDropsOldestLines`, and `TestRunStreamsProgressAsDraftThenClears` (extended to assert `asMarkdown=true` on the progress push and `false` on the clear). `MarkdownToHTML` itself stays covered by `internal/tgui/html_test.go`.
- Image: the `gh` apt block executed on `node:22-bookworm-slim` → `gh version 2.93.0`.

## Risks

- Fallback counter now updates every ~3s instead of every 1s — the deliberate trade to stop the 429 freeze; draft mode stays 1s.
- A pathological/unbalanced markdown snippet may degrade a frame to plain text (HTML rejected) — acceptable; the fallback never errors.
- The image gains one apt repo + package (`gh`); build time grows marginally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
