### PR TITLE
fix(telegram): keep the live preview on the rate-limit-free draft path when HTML is rejected

### DIFF
--- a/internal/telegram/bot.go
+++ b/internal/telegram/bot.go
@@ -69,9 +69,10 @@ func (c *botChat) Edit(ctx context.Context, chatID int64, messageID int, text, s
 // calls update the same preview; an empty text clears it). It is rate-limit-free
 // relative to EditMessageText, so it carries the live run progress while the answer
 // is persisted with Send/Edit. A draft can't hold an inline keyboard, which is why
-// the Stop button rides a separate anchor message. asMarkdown behaves as for
-// Send/Edit (HTML render with a plain-text fallback on a parse error); it is ignored
-// when text is empty (the clear call).
+// the Stop button rides a separate anchor message. When asMarkdown is set the frame
+// is rendered as HTML, but — unlike Send/Edit — it falls back to a plain draft on ANY
+// error (not just a parse error) so enabling markup can never knock the preview off
+// the rate-limit-free draft path. asMarkdown is ignored when text is empty (clear).
 func (c *botChat) StreamDraft(ctx context.Context, chatID int64, draftID, text string, asMarkdown bool) error {
 	params := &bot.SendMessageDraftParams{
 		ChatID:  chatID,
@@ -83,9 +84,14 @@ func (c *botChat) StreamDraft(ctx context.Context, chatID int64, draftID, text s
 		params.ParseMode = models.ParseModeHTML
 	}
 	_, err := c.b.SendMessageDraft(ctx, params)
-	if err != nil && asMarkdown && text != "" && isParseError(err) {
-		// Telegram rejected our HTML markup: resend the ORIGINAL text as plain so a
-		// formatting glitch never costs the user the live preview.
+	if err != nil && asMarkdown && text != "" {
+		// The HTML attempt failed — retry as PLAIN text, UNCONDITIONALLY (not only on
+		// an isParseError). The draft transport may reject parse_mode with an error that
+		// doesn't mention "parse", or not support it at all; if that error propagates,
+		// the run loop flips draftStreaming off and drops to the rate-limited edit
+		// fallback for the rest of the run (smooth ~1s preview -> throttled ~3s steps).
+		// A plain draft keeps the preview on the rate-limit-free path; worst case it is
+		// an unformatted but still-live frame.
 		params.Text = text
 		params.ParseMode = ""
 		_, err = c.b.SendMessageDraft(ctx, params)


### PR DESCRIPTION
## Summary

Fixes a cadence regression introduced when the live "Working… (Ns)" preview started rendering as HTML (PR #1, Issue C).

### Symptom
The live progress counter went from a smooth **~1s** update to throttled **~3–4s** steps.

### Root cause
The live frame is pushed via `sendMessageDraft` (the rate-limit-free draft transport). PR #1 added `parse_mode=HTML` to that push. In chats where the draft transport rejects `parse_mode`, `botChat.StreamDraft` returned that error, the run loop flipped `draftStreaming` off, and the **rest of the run fell back to the rate-limited `Edit` path** — which this branch's earlier work throttles to one edit per `minEditInterval` (3s). So enabling markup silently knocked the preview off the fast path onto the slow one.

`StreamDraft` already had a plain-text retry, but it only fired on an `isParseError` — too narrow: the draft rejection need not contain the word "parse".

### Fix
Retry the draft as **plain text on ANY error** from the HTML attempt (drop the `&& isParseError(err)` condition, with an explanatory comment). Enabling markup can no longer push the preview off the rate-limit-free draft path:

- HTML accepted → markup **and** ~1s cadence;
- HTML rejected → plain draft, unformatted but still ~1s;
- genuine draft-unsupported error → still falls through to the edit fallback (unchanged).

`Send`/`Edit` (the final answer) keep the narrow `isParseError` retry on purpose — there, surfacing a real non-parse error matters more than latency.

## Verification
- `go test ./...` — green (Docker `golang:1.23`, mirroring CI).
- `golangci-lint run` (`v1.61.0`) — clean.
- `gofmt -s` — clean.

Note: `botChat.StreamDraft` wraps the live `*bot.Bot`, so (like `Send`/`Edit`) its adapter path isn't unit-tested; the change is a one-line widening of an existing fallback.

## Follow-up (not in this PR)
If the draft transport rejects `parse_mode` outright, the live preview stays **unformatted** (markup still renders in the final answer). Formatted drafts would require sending `entities` (offset/length) instead of `parse_mode`, or a business-connection draft — a larger change to scope separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
