### PR TITLE
build(telegram): bump runtime base to node:24 (LTS) instead of node:26

### DIFF
--- a/adapters/telegram/Dockerfile
+++ b/adapters/telegram/Dockerfile
@@ -27,10 +27,10 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build -buildvcs=false -trimpath -ldflags "-s -w" -o /out/flock-telegram ./cmd/flock-telegram
 
 # --- Runtime stage ------------------------------------------------------------
-# node:22 supplies Node (for the `claude` CLI). Add git/ripgrep/ffmpeg (the CLI
-# shells out to them), the GitHub CLI (`gh`, for PR creation on github.com) + the
-# Docker CLI (talks to the optional dind sidecar).
-FROM node:22-bookworm-slim
+# node:24 (current LTS) supplies Node (for the `claude` CLI). Add git/ripgrep/ffmpeg
+# (the CLI shells out to them), the GitHub CLI (`gh`, for PR creation on github.com)
+# + the Docker CLI (talks to the optional dind sidecar).
+FROM node:24-bookworm-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
## Summary

Bumps the Telegram bot runtime base image from `node:22-bookworm-slim` to `node:24-bookworm-slim` (current Node **LTS**), instead of the `node:26` that Dependabot proposed in #7 — node 26 is the non-LTS *Current* line until October 2026, which is riskier for a production runtime that hosts the `claude` CLI.

Supersedes #7.

## Why not just merge #7 (node 26)?

- The PR CI (`ci.yml`) only runs the Go lint/tests/build — it does **not** build the Docker image (that lives in `publish-telegram.yml`, main/tags only). So a green PR says nothing about whether the new runtime base actually works; breakage would only surface post-merge at publish/deploy.
- node 26 is **Current (non-LTS)** until Oct 2026; node 24 is the current **LTS**. LTS is the right target for the runtime that runs `@anthropic-ai/claude-code`.

## How it was verified

Built/ran the runtime base locally (the change only affects the runtime stage; the Go build stage is unaffected):

- `node:24-bookworm-slim` → node **24.16.0**
- `npm install -g @anthropic-ai/claude-code` → installs clean; `claude --version` → **2.1.169 (Claude Code)**

## Risks

- **Low.** Single-line base-image bump to an LTS line; the `claude` CLI verified working on it. Go code untouched.
