### PR TITLE
ci: build the telegram image on PRs (no push) to catch image breakage pre-merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,3 +71,34 @@ jobs:
           severity: "CRITICAL,HIGH"
           exit-code: "1"
           format: "table"
+
+  image:
+    name: Build telegram image (no push)
+    runs-on: ubuntu-latest
+    # PR-only dry run: prove the runtime image still builds before merge. The Go
+    # lint/tests above never touch the Dockerfile, so a base-image/dependency bump
+    # (e.g. a Node major) could land green here yet break the real build — which
+    # otherwise only runs post-merge in publish-telegram.yml. This mirrors that
+    # workflow's build EXACTLY (same context/file/platforms/cache) but with
+    # push: false, so it catches multi-arch breakage (incl. the QEMU-emulated
+    # arm64 path) on the PR. On push to main the actual publish covers it.
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build telegram image (no push)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./adapters/telegram/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

Closes the "green PR ≠ working image" gap that bit the Node bump (#7/#8): the Telegram runtime image is built **only** in `publish-telegram.yml` on push to `main`, while PR CI (`ci.yml`) exercises Go alone. So a base-image or dependency change (a Node major, an apt source, etc.) can pass every PR check and only break post-merge at publish time.

Adds a PR-only `image` job to `ci.yml` that builds the image as a **dry run (no push)**, mirroring `publish-telegram.yml`'s build exactly:

- same `context: .`, `file: ./adapters/telegram/Dockerfile`
- same `platforms: linux/amd64,linux/arm64` (so it also exercises the QEMU-emulated arm64 path the Dockerfile has historically had memory trouble with)
- same `cache-from/to: type=gha` (shared cache → fast, incremental)
- `push: false`, and gated `if: github.event_name == 'pull_request'` (on push to `main` the real publish already covers it)

## How it was verified

This PR triggers the new job on itself — the `Build telegram image (no push)` check on this PR is the validation that the job is wired correctly and the current image builds on both arches.

## Risks

- **Low.** CI-only addition; no app/runtime/Dockerfile change. Worst case the job needs a tweak, visible right here on the PR. Adds build minutes per PR, mitigated by the shared GHA layer cache.

## Note

This is option (1) from the discussion. Optionally we could also restrict it with path filters (only run when image-relevant files change) or have Dependabot ignore Docker base-image majors — say the word and I'll follow up.
