### PR TITLE
feat: suggest starring the project after each task (GitHub, one-press star)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,24 @@ git host can't reach the bot (e.g. cross-border network filtering), because the 
 *out*. Inbound webhooks + a Caddy TLS proxy are an optional alternative (`--profile caddy`,
 see `.env.example`).
 
+## GitHub star nudge (optional, GitHub-only)
+
+When the bot is wired to a GitHub account (`GIT_HOST=github.com` + `GIT_TOKEN`) that has not
+yet starred the project, it sends a short message after each successful run inviting you to
+star it, with an inline button. Pressing the button stars the repo from the deployment's own
+account and the nudge then stops for good. It is GitHub-only and **auto-off** everywhere else
+(the gate is the off switch — no separate flag); it runs entirely off the hot path, so it
+never delays or breaks a run.
+
+```ini
+STAR_NUDGE_REPO=duckbugio/flock   # owner/repo to nudge for / star
+# STAR_NUDGE_STORE_PATH=          # default <APPROVED_DIRECTORY>/star_nudge.json
+```
+
+The button needs a token with **star-write scope**: a classic PAT with `public_repo`, or a
+fine-grained token with the "Starring" account permission. Without it the star simply fails
+softly (the run is unaffected).
+
 ## Voice messages (optional)
 
 ```ini

--- a/adapters/telegram/.env.example
+++ b/adapters/telegram/.env.example
@@ -45,6 +45,16 @@ GIT_AUTHOR_EMAIL=ai@example.com
 GITEA_API_URL=                 # e.g. https://git.example.com/api/v1
 GITEA_POLL_INTERVAL=90
 
+# ===== GITHUB STAR NUDGE (optional, GitHub-only) =====
+# After each successful run the bot invites you to star the project on GitHub, with
+# an inline button that stars it from the GIT_TOKEN account. Auto-ON only when
+# GIT_HOST=github.com AND GIT_TOKEN is set; OFF for every other host (the gate is the
+# off switch — no separate flag). The button needs a token with star-write scope:
+# a classic PAT with `public_repo`, or a fine-grained token with the "Starring"
+# account permission. Once the repo is starred the nudge stops permanently.
+STAR_NUDGE_REPO=duckbugio/flock   # owner/repo to nudge for / star
+# STAR_NUDGE_STORE_PATH=          # JSON flag store; default <APPROVED_DIRECTORY>/star_nudge.json
+
 # ===== VOICE (optional) — transcribe voice messages =====
 ENABLE_VOICE_MESSAGES=true
 VOICE_PROVIDER=mistral         # mistral | openai | local

--- a/cmd/flock-telegram/main.go
+++ b/cmd/flock-telegram/main.go
@@ -25,7 +25,9 @@ import (
 	"github.com/duckbugio/flock/core/claude"
 	"github.com/duckbugio/flock/core/cost"
 	"github.com/duckbugio/flock/core/dispatch"
+	"github.com/duckbugio/flock/core/ghstar"
 	"github.com/duckbugio/flock/core/gitsetup"
+	"github.com/duckbugio/flock/core/nudge"
 	"github.com/duckbugio/flock/core/poller"
 	"github.com/duckbugio/flock/core/ratelimit"
 	"github.com/duckbugio/flock/core/session"
@@ -214,6 +216,14 @@ func run() int {
 	// empty/absent.
 	outbox := telegram.NewSweeper(ws, cfg.MaxOutboxBytes, cfg.MaxOutboxFiles, logger)
 
+	// Post-task GitHub star nudge (core/ghstar + core/nudge). GitHub-only and OFF
+	// for every other deploy: the gate IS the off switch (StarNudgeEnabled needs
+	// github.com + a token + a valid STAR_NUDGE_REPO). When disabled, the config is
+	// left zero-valued so the Service no-ops the whole path. A nudge-store open
+	// failure is non-fatal, like the rest of the best-effort startup wiring: log
+	// and disable the feature rather than crash-loop the bot.
+	starNudge := buildStarNudge(cfg, logger)
+
 	svc = telegram.New(telegram.Config{
 		Runner:     runner,
 		Chat:       telegram.NewBotChat(b),
@@ -222,12 +232,16 @@ func run() int {
 		Sessions:   sessions,
 		Costs:      costs,
 		Outbox:     outbox,
+		StarNudge:  starNudge,
 		Opts:       opts,
 		Timeout:    cfg.ClaudeTimeout(),
 		Logger:     logger,
 	})
 
 	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, telegram.CallbackMatch(), bot.MatchTypePrefix, stopHandler(cfg, svc))
+	b.RegisterHandler(
+		bot.HandlerTypeCallbackQueryData, telegram.StarCallbackPrefix(), bot.MatchTypePrefix, starHandler(cfg, svc),
+	)
 
 	// Slash commands. Registered handlers match BEFORE the default text handler.
 	// We match via telegram.CommandName (a bot_command entity at offset 0, with
@@ -631,6 +645,83 @@ func stopHandler(cfg config.Config, svc *telegram.Service) bot.HandlerFunc {
 			Text:            text,
 		}); err != nil {
 			slog.Debug("answer stop callback", "error", err)
+		}
+	}
+}
+
+// buildStarNudge assembles the post-task star-nudge config. It returns a
+// zero-valued (disabled) config when the feature is off (non-GitHub deploy,
+// missing token, or bad STAR_NUDGE_REPO) or when the durable flag store cannot be
+// opened — both leave the Service path inert. A GitHub client and the nudge store
+// are only constructed when the feature is fully enabled.
+func buildStarNudge(cfg config.Config, logger *slog.Logger) telegram.StarNudgeConfig {
+	if !cfg.StarNudgeEnabled() {
+		return telegram.StarNudgeConfig{}
+	}
+	owner, repo, ok := cfg.StarNudgeRepoParts()
+	if !ok {
+		// Should not happen (StarNudgeEnabled already validated the shape), but stay
+		// fail-safe rather than trust the invariant.
+		return telegram.StarNudgeConfig{}
+	}
+	store, err := nudge.Open(cfg.StarNudgeStoreFile())
+	if err != nil {
+		logger.Error("open star-nudge store; nudge disabled", "path", cfg.StarNudgeStoreFile(), "error", err)
+		return telegram.StarNudgeConfig{}
+	}
+	logger.Info("star nudge enabled", "repo", cfg.StarNudgeRepo)
+	return telegram.StarNudgeConfig{
+		Enabled: true,
+		Owner:   owner,
+		Repo:    repo,
+		Client:  ghstar.New(ghstar.Config{Token: cfg.GitToken, Logger: logger}),
+		Store:   store,
+	}
+}
+
+// starHandler handles a press of the star-nudge confirm button: it stars the repo
+// from the deployment account (Service.StarPress), answers the callback with a
+// short toast, and on success edits the nudge message into the confirmation
+// (clearing the button). It is gated by the same allow-list as the Stop callback
+// so a disallowed sender cannot trigger the star. Every failure is soft: the run
+// is never affected.
+func starHandler(cfg config.Config, svc *telegram.Service) bot.HandlerFunc {
+	return func(ctx context.Context, b *bot.Bot, update *models.Update) {
+		cq := update.CallbackQuery
+		if cq == nil {
+			return
+		}
+		if cq.From.ID == 0 || !cfg.IsAllowed(cq.From.ID) {
+			slog.Debug("ignoring star callback from disallowed user", "user_id", cq.From.ID)
+			if _, err := b.AnswerCallbackQuery(ctx, &bot.AnswerCallbackQueryParams{
+				CallbackQueryID: cq.ID,
+				Text:            "Not available.",
+			}); err != nil {
+				slog.Debug("answer disallowed star callback", "error", err)
+			}
+			return
+		}
+
+		// StarPress detaches its own bounded context so the star completes even if
+		// this short callback ctx is already done.
+		//nolint:contextcheck // intentionally detached; see StarPress.
+		toast, ok := svc.StarPress()
+		if _, err := b.AnswerCallbackQuery(ctx, &bot.AnswerCallbackQueryParams{
+			CallbackQueryID: cq.ID,
+			Text:            toast,
+		}); err != nil {
+			slog.Debug("answer star callback", "error", err)
+		}
+		// On success, edit the nudge message into the confirmation and drop the
+		// button. Best-effort: a failed edit never undoes the star.
+		if ok && cq.Message.Message != nil {
+			if _, err := b.EditMessageText(ctx, &bot.EditMessageTextParams{
+				ChatID:    cq.Message.Message.Chat.ID,
+				MessageID: cq.Message.Message.ID,
+				Text:      telegram.StarDoneText(),
+			}); err != nil {
+				slog.Debug("edit star nudge message", "error", err)
+			}
 		}
 	}
 }

--- a/core/ghstar/ghstar.go
+++ b/core/ghstar/ghstar.go
@@ -1,0 +1,153 @@
+// Package ghstar is a minimal GitHub "stars" client used by the post-task star
+// nudge: it can check whether the deployment's own account (the GIT_TOKEN owner)
+// has starred a repository and, on an explicit user action, star it. It speaks
+// only the two endpoints the nudge needs and is styled like core/poller: a small
+// Config with an injectable BaseURL + HTTPClient for tests, context-bound
+// requests, and explicit per-status handling so callers can log distinctly.
+package ghstar
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+// DefaultBaseURL is the GitHub REST API root used when Config.BaseURL is empty.
+const DefaultBaseURL = "https://api.github.com"
+
+// apiVersion pins the GitHub REST API version, sent on every request per
+// GitHub's recommendation.
+const apiVersion = "2022-11-28"
+
+// defaultClientTimeout is the request timeout for the default HTTP client used
+// when Config.HTTPClient is nil.
+const defaultClientTimeout = 15 * time.Second
+
+// ErrUnauthorized is returned by Star when GitHub rejects the token with 401 or
+// 403, which almost always means the token lacks the star-write scope (a classic
+// token needs public_repo; a fine-grained token needs the "Starring" account
+// permission). Callers can errors.Is against it to log that distinctly without
+// crashing the run.
+var ErrUnauthorized = errors.New("ghstar: token unauthorized (missing star-write scope?)")
+
+// Config configures a Client.
+type Config struct {
+	// BaseURL is the GitHub REST API root (trailing slash trimmed). Empty uses
+	// DefaultBaseURL; tests inject an httptest.Server URL.
+	BaseURL string
+	// Token is the GitHub PAT sent as "Authorization: Bearer <token>".
+	Token string
+	// HTTPClient is injectable for tests; nil yields a client with
+	// defaultClientTimeout.
+	HTTPClient *http.Client
+	// Logger defaults to slog.Default() when nil.
+	Logger *slog.Logger
+}
+
+// Client talks to the GitHub stars endpoints. It is safe for concurrent use (it
+// holds only immutable config and an *http.Client).
+type Client struct {
+	base   string
+	token  string
+	client *http.Client
+	log    *slog.Logger
+}
+
+// New builds a Client from cfg, applying the BaseURL/HTTPClient/Logger defaults.
+func New(cfg Config) *Client {
+	base := cfg.BaseURL
+	if base == "" {
+		base = DefaultBaseURL
+	}
+	base = trimTrailingSlash(base)
+	client := cfg.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: defaultClientTimeout}
+	}
+	log := cfg.Logger
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Client{base: base, token: cfg.Token, client: client, log: log}
+}
+
+// trimTrailingSlash drops a single trailing slash so the joined path is clean
+// regardless of how BaseURL was supplied.
+func trimTrailingSlash(s string) string {
+	if s != "" && s[len(s)-1] == '/' {
+		return s[:len(s)-1]
+	}
+	return s
+}
+
+// IsStarred reports whether the authenticated account has starred owner/repo.
+// GitHub answers GET /user/starred/{owner}/{repo} with 204 (starred) or 404 (not
+// starred); any other status is surfaced as an error so the caller can log it and
+// skip the nudge rather than guess.
+func (c *Client) IsStarred(ctx context.Context, owner, repo string) (bool, error) {
+	status, err := c.do(ctx, http.MethodGet, owner, repo)
+	if err != nil {
+		return false, err
+	}
+
+	switch status {
+	case http.StatusNoContent:
+		return true, nil
+	case http.StatusNotFound:
+		return false, nil
+	default:
+		return false, fmt.Errorf("ghstar: check star: unexpected status %d", status)
+	}
+}
+
+// Star stars owner/repo for the authenticated account via
+// PUT /user/starred/{owner}/{repo}. GitHub returns 204 on success. A 401/403 is
+// mapped to ErrUnauthorized (missing scope) so the caller can log it distinctly;
+// any other status is a generic error. Star never panics on a nil body.
+func (c *Client) Star(ctx context.Context, owner, repo string) error {
+	status, err := c.do(ctx, http.MethodPut, owner, repo)
+	if err != nil {
+		return err
+	}
+
+	switch status {
+	case http.StatusNoContent:
+		return nil
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return fmt.Errorf("%w: status %d", ErrUnauthorized, status)
+	default:
+		return fmt.Errorf("ghstar: star repo: unexpected status %d", status)
+	}
+}
+
+// do builds and sends a request to /user/starred/{owner}/{repo} with the shared
+// GitHub headers, returning the response status code and draining+closing the
+// body (the endpoints return no body the caller needs). The PUT carries an
+// explicit zero Content-Length, as the stars endpoint expects an empty body.
+func (c *Client) do(ctx context.Context, method, owner, repo string) (int, error) {
+	url := c.base + "/user/starred/" + owner + "/" + repo
+	req, err := http.NewRequestWithContext(ctx, method, url, http.NoBody)
+	if err != nil {
+		return 0, fmt.Errorf("ghstar: build request: %w", err)
+	}
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", apiVersion)
+	if method == http.MethodPut {
+		req.Header.Set("Content-Length", "0")
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("ghstar: %s request: %w", method, err)
+	}
+	// Drain + close so the connection can be reused; the body is unused.
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+	return resp.StatusCode, nil
+}

--- a/core/ghstar/ghstar.go
+++ b/core/ghstar/ghstar.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	neturl "net/url"
 	"time"
 )
 
@@ -129,7 +130,7 @@ func (c *Client) Star(ctx context.Context, owner, repo string) error {
 // body (the endpoints return no body the caller needs). The PUT carries an
 // explicit zero Content-Length, as the stars endpoint expects an empty body.
 func (c *Client) do(ctx context.Context, method, owner, repo string) (int, error) {
-	url := c.base + "/user/starred/" + owner + "/" + repo
+	url := c.base + "/user/starred/" + neturl.PathEscape(owner) + "/" + neturl.PathEscape(repo)
 	req, err := http.NewRequestWithContext(ctx, method, url, http.NoBody)
 	if err != nil {
 		return 0, fmt.Errorf("ghstar: build request: %w", err)

--- a/core/ghstar/ghstar_test.go
+++ b/core/ghstar/ghstar_test.go
@@ -1,0 +1,126 @@
+package ghstar_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/duckbugio/flock/core/ghstar"
+)
+
+const (
+	testOwner = "duckbugio"
+	testRepo  = "flock"
+	testToken = "tok-123"
+)
+
+// assertHeaders checks the shared GitHub headers every request must carry.
+func assertHeaders(t *testing.T, r *http.Request) {
+	t.Helper()
+	if got := r.Header.Get("Authorization"); got != "Bearer "+testToken {
+		t.Errorf("Authorization = %q; want Bearer %s", got, testToken)
+	}
+	if got := r.Header.Get("Accept"); got != "application/vnd.github+json" {
+		t.Errorf("Accept = %q; want application/vnd.github+json", got)
+	}
+	if got := r.Header.Get("X-GitHub-Api-Version"); got != "2022-11-28" {
+		t.Errorf("X-GitHub-Api-Version = %q; want 2022-11-28", got)
+	}
+}
+
+func TestIsStarred(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		status  int
+		want    bool
+		wantErr bool
+	}{
+		{name: "starred", status: http.StatusNoContent, want: true},
+		{name: "not starred", status: http.StatusNotFound, want: false},
+		{name: "server error", status: http.StatusInternalServerError, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet {
+					t.Errorf("method = %s; want GET", r.Method)
+				}
+				if r.URL.Path != "/user/starred/"+testOwner+"/"+testRepo {
+					t.Errorf("path = %s", r.URL.Path)
+				}
+				assertHeaders(t, r)
+				w.WriteHeader(tc.status)
+			}))
+			defer srv.Close()
+
+			c := ghstar.New(ghstar.Config{BaseURL: srv.URL, Token: testToken})
+			got, err := c.IsStarred(context.Background(), testOwner, testRepo)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("IsStarred: want error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("IsStarred: unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("IsStarred = %v; want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStarSuccess(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("method = %s; want PUT", r.Method)
+		}
+		assertHeaders(t, r)
+		if got := r.Header.Get("Content-Length"); got != "0" {
+			t.Errorf("Content-Length = %q; want 0", got)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c := ghstar.New(ghstar.Config{BaseURL: srv.URL, Token: testToken})
+	if err := c.Star(context.Background(), testOwner, testRepo); err != nil {
+		t.Fatalf("Star: unexpected error: %v", err)
+	}
+}
+
+func TestStarUnauthorized(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	c := ghstar.New(ghstar.Config{BaseURL: srv.URL, Token: testToken})
+	err := c.Star(context.Background(), testOwner, testRepo)
+	if !errors.Is(err, ghstar.ErrUnauthorized) {
+		t.Fatalf("Star(403) error = %v; want ErrUnauthorized", err)
+	}
+}
+
+func TestContextCancellation(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	c := ghstar.New(ghstar.Config{BaseURL: srv.URL, Token: testToken})
+	if _, err := c.IsStarred(ctx, testOwner, testRepo); err == nil {
+		t.Fatal("IsStarred with cancelled context: want error, got nil")
+	}
+}

--- a/core/nudge/nudge.go
+++ b/core/nudge/nudge.go
@@ -1,0 +1,136 @@
+// Package nudge persists a single, durable "starred resolved" flag for the
+// deployment's GitHub account so the post-task star nudge stops once the repo is
+// known to be starred (whether observed via the API or set by a successful
+// button press). A deployment authenticates as ONE account, so this is a single
+// boolean, not a per-chat map. It is shaped like core/session.FileStore: a tiny
+// JSON file rewritten atomically (temp file + rename) under a mutex. A missing
+// file means "not yet starred".
+package nudge
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// dirPerm is the owner-only permission for bot-created directories.
+const dirPerm os.FileMode = 0o750
+
+// state is the on-disk JSON shape, e.g. {"starred":true}.
+type state struct {
+	Starred bool `json:"starred"`
+}
+
+// Store persists the global "starred resolved" flag durably. It is safe for
+// concurrent use.
+type Store struct {
+	path string
+
+	mu      sync.Mutex
+	starred bool
+}
+
+// Open loads (or creates) a Store at path. A missing file yields an unstarred
+// store; a present file is parsed for the flag. The parent directory is created
+// if needed. Reopening the SAME path reflects whatever was last persisted, which
+// is how the resolved state survives a process restart.
+func Open(path string) (*Store, error) {
+	if path == "" {
+		return nil, errors.New("nudge: store path is empty")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), dirPerm); err != nil {
+		return nil, fmt.Errorf("nudge: create store dir: %w", err)
+	}
+	s := &Store{path: path}
+	if err := s.load(); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// load reads and decodes the backing file. A non-existent or empty file is not
+// an error (a fresh, unstarred store).
+func (s *Store) load() error {
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("nudge: read store: %w", err)
+	}
+	if len(data) == 0 {
+		return nil
+	}
+	var st state
+	if err := json.Unmarshal(data, &st); err != nil {
+		return fmt.Errorf("nudge: parse store %s: %w", s.path, err)
+	}
+	s.starred = st.Starred
+	return nil
+}
+
+// Starred reports whether the repo has been resolved as starred. A nil store is
+// treated as "not starred" so callers can stay nil-safe.
+func (s *Store) Starred() bool {
+	if s == nil {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.starred
+}
+
+// MarkStarred records that the repo is starred and persists the change
+// atomically. It is idempotent: marking an already-starred store is a no-op that
+// avoids a needless rewrite. A nil store is a no-op.
+func (s *Store) MarkStarred() error {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.starred {
+		return nil
+	}
+	s.starred = true
+	return s.persistLocked()
+}
+
+// persistLocked writes the state to a temp file in the same directory and
+// renames it over the target, so a crash mid-write never leaves a half-written
+// store (rename is atomic on the same filesystem). The caller must hold s.mu.
+func (s *Store) persistLocked() error {
+	data, err := json.Marshal(state{Starred: s.starred})
+	if err != nil {
+		return fmt.Errorf("nudge: encode store: %w", err)
+	}
+
+	dir := filepath.Dir(s.path)
+	tmp, err := os.CreateTemp(dir, ".nudge-*.tmp")
+	if err != nil {
+		return fmt.Errorf("nudge: create temp store: %w", err)
+	}
+	tmpName := tmp.Name()
+	// Best-effort cleanup if we bail before the rename; after a successful rename
+	// the temp name no longer exists so the Remove is a harmless no-op.
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("nudge: write temp store: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("nudge: sync temp store: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("nudge: close temp store: %w", err)
+	}
+	if err := os.Rename(tmpName, s.path); err != nil {
+		return fmt.Errorf("nudge: rename store into place: %w", err)
+	}
+	return nil
+}

--- a/core/nudge/nudge_test.go
+++ b/core/nudge/nudge_test.go
@@ -1,0 +1,96 @@
+package nudge_test
+
+import (
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/duckbugio/flock/core/nudge"
+)
+
+func TestMissingFileIsUnstarred(t *testing.T) {
+	t.Parallel()
+	s, err := nudge.Open(filepath.Join(t.TempDir(), "nudge.json"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if s.Starred() {
+		t.Fatal("fresh store reports starred; want not starred")
+	}
+}
+
+func TestMarkAndReloadAcrossRestart(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "nudge.json")
+
+	s1, err := nudge.Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := s1.MarkStarred(); err != nil {
+		t.Fatalf("MarkStarred: %v", err)
+	}
+	if !s1.Starred() {
+		t.Fatal("after MarkStarred, Starred() = false")
+	}
+
+	// A fresh store opened from the SAME path must reflect the persisted flag,
+	// proving the state survives a process restart.
+	s2, err := nudge.Open(path)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	if !s2.Starred() {
+		t.Fatal("reopened store does not reflect MarkStarred")
+	}
+}
+
+func TestMarkStarredIdempotent(t *testing.T) {
+	t.Parallel()
+	s, err := nudge.Open(filepath.Join(t.TempDir(), "nudge.json"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := s.MarkStarred(); err != nil {
+		t.Fatalf("first MarkStarred: %v", err)
+	}
+	if err := s.MarkStarred(); err != nil {
+		t.Fatalf("second MarkStarred: %v", err)
+	}
+	if !s.Starred() {
+		t.Fatal("Starred() = false after marking")
+	}
+}
+
+func TestNilStoreSafe(t *testing.T) {
+	t.Parallel()
+	var s *nudge.Store
+	if s.Starred() {
+		t.Fatal("nil store reports starred")
+	}
+	if err := s.MarkStarred(); err != nil {
+		t.Fatalf("nil MarkStarred: %v", err)
+	}
+}
+
+func TestConcurrentAccess(t *testing.T) {
+	t.Parallel()
+	s, err := nudge.Open(filepath.Join(t.TempDir(), "nudge.json"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	const goroutines = 16
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			_ = s.MarkStarred()
+			_ = s.Starred()
+		}()
+	}
+	wg.Wait()
+	if !s.Starred() {
+		t.Fatal("after concurrent marks, Starred() = false")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -99,6 +99,21 @@ type Config struct {
 	GiteaAPIURL       string `env:"GITEA_API_URL"`
 	GiteaPollInterval int    `env:"GITEA_POLL_INTERVAL" envDefault:"90"`
 
+	// StarNudgeRepo is the "owner/repo" the post-task star nudge targets. The
+	// nudge invites the user to star the project on GitHub and is GitHub-only: it
+	// is active only when GIT_HOST is github.com and a GIT_TOKEN is set (see
+	// StarNudgeEnabled). The token must have star-write scope for the button to
+	// work (classic public_repo, or a fine-grained token with the "Starring"
+	// account permission).
+	StarNudgeRepo string `env:"STAR_NUDGE_REPO" envDefault:"duckbugio/flock"`
+
+	// StarNudgeStorePath is the JSON file persisting the global "starred resolved"
+	// flag so the nudge stops once the repo is known starred. When empty it
+	// defaults to <APPROVED_DIRECTORY>/star_nudge.json (see StarNudgeStoreFile),
+	// alongside the session/cost stores under the workspace data dir, never inside
+	// a repo.
+	StarNudgeStorePath string `env:"STAR_NUDGE_STORE_PATH"`
+
 	// Voice transcription (core/voice). Disabled by default; when enabled,
 	// VoiceProvider selects the transcription backend and the matching key/command
 	// must be set. Mirrors the VOICE_* keys in adapters/telegram/.env.example.
@@ -238,6 +253,55 @@ func (c Config) GiteaPollDuration() time.Duration {
 // review enabled AND the API URL + token configured AND a positive interval.
 func (c Config) PollerEnabled() bool {
 	return c.PRReviewEnabled() && c.GiteaAPIURL != "" && c.GitToken != "" && c.GiteaPollInterval > 0
+}
+
+// gitHubHost is the GIT_HOST value (case-insensitive) that enables the
+// GitHub-only star nudge.
+const gitHubHost = "github.com"
+
+// starRepoParts is the number of "/"-separated segments a STAR_NUDGE_REPO must
+// have: exactly "owner/repo".
+const starRepoParts = 2
+
+// StarNudgeStoreFile returns the path to the JSON star-nudge flag store,
+// defaulting to <ApprovedDirectory>/star_nudge.json when STAR_NUDGE_STORE_PATH is
+// unset so it lives under the workspace data dir alongside the session/cost
+// stores, never inside any repo.
+func (c Config) StarNudgeStoreFile() string {
+	if strings.TrimSpace(c.StarNudgeStorePath) != "" {
+		return c.StarNudgeStorePath
+	}
+	return filepath.Join(c.ApprovedDirectory, "star_nudge.json")
+}
+
+// StarNudgeRepoParts splits StarNudgeRepo into owner and repo, returning ok=false
+// when it is not a well-formed "owner/repo" (e.g. empty, missing slash, or a
+// blank segment). Surrounding whitespace is trimmed.
+func (c Config) StarNudgeRepoParts() (owner, repo string, ok bool) {
+	parts := strings.Split(strings.TrimSpace(c.StarNudgeRepo), "/")
+	if len(parts) != starRepoParts {
+		return "", "", false
+	}
+	owner, repo = strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
+	if owner == "" || repo == "" {
+		return "", "", false
+	}
+	return owner, repo, true
+}
+
+// StarNudgeEnabled reports whether the post-task star nudge should run: the
+// deployment is wired to github.com, a GIT_TOKEN is set, and STAR_NUDGE_REPO
+// parses as "owner/repo". Any other host (Gitea/GitLab) or a missing token turns
+// the feature off — the gate IS the off switch, so no separate flag is needed.
+func (c Config) StarNudgeEnabled() bool {
+	if !strings.EqualFold(strings.TrimSpace(c.GitHost), gitHubHost) {
+		return false
+	}
+	if c.GitToken == "" {
+		return false
+	}
+	_, _, ok := c.StarNudgeRepoParts()
+	return ok
 }
 
 // IsAllowed reports whether the given Telegram user ID is in the allow-list.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -421,3 +421,73 @@ func TestCostStoreFile(t *testing.T) {
 		t.Errorf("CostStoreFile() = %q, want /workspace/costs.json", got)
 	}
 }
+
+func TestStarNudgeStoreFile(t *testing.T) {
+	// Explicit path wins.
+	c := Config{StarNudgeStorePath: "/var/lib/duck/s.json", ApprovedDirectory: "/workspace"}
+	if got := c.StarNudgeStoreFile(); got != "/var/lib/duck/s.json" {
+		t.Errorf("StarNudgeStoreFile() = %q, want explicit path", got)
+	}
+	// Otherwise derive from APPROVED_DIRECTORY.
+	c = Config{ApprovedDirectory: "/workspace"}
+	if got := c.StarNudgeStoreFile(); got != "/workspace/star_nudge.json" {
+		t.Errorf("StarNudgeStoreFile() = %q, want /workspace/star_nudge.json", got)
+	}
+}
+
+func TestStarNudgeRepoParts(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		repo      string
+		wantOwner string
+		wantRepo  string
+		wantOK    bool
+	}{
+		{name: "valid", repo: "duckbugio/flock", wantOwner: "duckbugio", wantRepo: "flock", wantOK: true},
+		{name: "trims spaces", repo: " duckbugio / flock ", wantOwner: "duckbugio", wantRepo: "flock", wantOK: true},
+		{name: "empty", repo: "", wantOK: false},
+		{name: "no slash", repo: "flock", wantOK: false},
+		{name: "too many parts", repo: "a/b/c", wantOK: false},
+		{name: "blank owner", repo: "/flock", wantOK: false},
+		{name: "blank repo", repo: "duckbugio/", wantOK: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			c := Config{StarNudgeRepo: tt.repo}
+			owner, repo, ok := c.StarNudgeRepoParts()
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if ok && (owner != tt.wantOwner || repo != tt.wantRepo) {
+				t.Errorf("parts = %q/%q, want %q/%q", owner, repo, tt.wantOwner, tt.wantRepo)
+			}
+		})
+	}
+}
+
+func TestStarNudgeEnabled(t *testing.T) {
+	base := Config{GitHost: "github.com", GitToken: "tok", StarNudgeRepo: "duckbugio/flock"}
+	if !base.StarNudgeEnabled() {
+		t.Errorf("StarNudgeEnabled() = false, want true when fully configured")
+	}
+	// Host match is case-insensitive.
+	c := base
+	c.GitHost = "GitHub.com"
+	if !c.StarNudgeEnabled() {
+		t.Errorf("StarNudgeEnabled() = false for case-variant host, want true")
+	}
+	for _, tt := range []struct {
+		name   string
+		mutate func(*Config)
+	}{
+		{"gitea host", func(c *Config) { c.GitHost = "git.example.com" }},
+		{"empty host", func(c *Config) { c.GitHost = "" }},
+		{"no token", func(c *Config) { c.GitToken = "" }},
+		{"bad repo", func(c *Config) { c.StarNudgeRepo = "flock" }},
+	} {
+		c := base
+		tt.mutate(&c)
+		if c.StarNudgeEnabled() {
+			t.Errorf("StarNudgeEnabled() = true for %q, want false", tt.name)
+		}
+	}
+}

--- a/internal/telegram/bot.go
+++ b/internal/telegram/bot.go
@@ -126,6 +126,21 @@ func (c *botChat) SendDocument(ctx context.Context, chatID int64, name string, d
 	return err
 }
 
+// SendStarNudge posts the post-task star-nudge message with the inline confirm
+// button (a callback button). It sends plain text (the nudge copy carries no
+// markup) and returns the new message id.
+func (c *botChat) SendStarNudge(ctx context.Context, chatID int64, text string) (int, error) {
+	msg, err := c.b.SendMessage(ctx, &bot.SendMessageParams{
+		ChatID:      chatID,
+		Text:        text,
+		ReplyMarkup: starMarkup(),
+	})
+	if err != nil {
+		return 0, err
+	}
+	return msg.ID, nil
+}
+
 // stopMarkup returns an inline keyboard with a single Stop button bound to
 // runID, or nil when runID is empty (final messages carry no markup).
 func stopMarkup(runID string) models.ReplyMarkup {

--- a/internal/telegram/nudge.go
+++ b/internal/telegram/nudge.go
@@ -1,0 +1,219 @@
+package telegram
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/go-telegram/bot/models"
+)
+
+// starCallbackPrefix is the inline-button callback_data prefix for the star
+// nudge's confirm button. It mirrors stopCallbackPrefix: a press routes to the
+// Service via the bot's callback handler, which calls StarPress.
+const starCallbackPrefix = "star:"
+
+// starCallbackData is the full callback_data carried by the star button. The
+// nudge is a single global account action (no per-run id), so a fixed token is
+// enough — unlike the Stop button which embeds a run id.
+const starCallbackData = starCallbackPrefix + "confirm"
+
+// nudgeText is the post-task invitation to star the project. It is short and
+// lightly Duck-flavoured; the duck touch is optional seasoning, not required.
+const nudgeText = "Если flock пригодился — можно поддержать проект звездой на GitHub 🦆"
+
+// starButtonText labels the confirm button. Pressing it triggers the server-side
+// star (a callback button, not a URL button).
+const starButtonText = "⭐ Поставить звезду"
+
+// starDoneText replaces the nudge message after a successful star.
+const starDoneText = "⭐ Спасибо! Звезда поставлена"
+
+// starFailToast is the soft callback answer shown when starring fails (e.g. the
+// token lacks scope); it never crashes the run.
+const starFailToast = "Не удалось поставить звезду"
+
+// starOpTimeout bounds a single GitHub stars API call made off the hot path.
+const starOpTimeout = 20 * time.Second
+
+// starrer checks and sets the deployment account's star on a repo. *ghstar.Client
+// satisfies it; tests use a fake. Methods take owner/repo so the same client can
+// serve any target.
+type starrer interface {
+	IsStarred(ctx context.Context, owner, repo string) (bool, error)
+	Star(ctx context.Context, owner, repo string) error
+}
+
+// nudgeStore persists the global "starred resolved" flag so the nudge stops once
+// the repo is known starred. *nudge.Store satisfies it; tests use a fake. A nil
+// store is a safe no-op (treated as not-yet-starred).
+type nudgeStore interface {
+	Starred() bool
+	MarkStarred() error
+}
+
+// StarNudgeConfig configures the post-task GitHub star nudge injected into the
+// Service. When Enabled is false the whole path is inert (the default for
+// non-GitHub deploys); Client and Store may then be nil.
+type StarNudgeConfig struct {
+	// Enabled gates the entire feature. The cmd wires this from
+	// config.StarNudgeEnabled(), so a non-GitHub deploy or a missing token leaves
+	// it false and every nudge call is a no-op.
+	Enabled bool
+	// Owner and Repo identify the repository to star (from STAR_NUDGE_REPO).
+	Owner string
+	Repo  string
+	// Client performs the GitHub stars API calls. May be nil when disabled.
+	Client starrer
+	// Store persists the resolved-starred flag. May be nil when disabled.
+	Store nudgeStore
+}
+
+// starNudge holds the resolved runtime state for the post-task star nudge. A nil
+// *starNudge is a valid no-op (all methods guard on it), so callers need not nil-
+// check before invoking it.
+type starNudge struct {
+	enabled bool
+	owner   string
+	repo    string
+	client  starrer
+	store   nudgeStore
+	chat    chat
+	log     *slog.Logger
+}
+
+// newStarNudge builds a starNudge from cfg. When cfg.Enabled is false (or its
+// dependencies are missing) it returns a disabled nudge whose methods no-op, so
+// the Service can wire it unconditionally.
+func newStarNudge(cfg StarNudgeConfig, c chat, log *slog.Logger) *starNudge {
+	enabled := cfg.Enabled && cfg.Client != nil && cfg.Store != nil && cfg.Owner != "" && cfg.Repo != ""
+	return &starNudge{
+		enabled: enabled,
+		owner:   cfg.Owner,
+		repo:    cfg.Repo,
+		client:  cfg.Client,
+		store:   cfg.Store,
+		chat:    c,
+		log:     log,
+	}
+}
+
+// active reports whether the nudge should do any work: it is enabled and the repo
+// is not already known starred. A nil receiver is inactive.
+func (n *starNudge) active() bool {
+	return n != nil && n.enabled && !n.store.Starred()
+}
+
+// maybeNudge runs the post-task nudge for chatID fully off the hot path: it spawns
+// a detached goroutine (so it never delays the run), recovers any panic, and
+// swallows every error at debug level (so it never breaks a run). It is called
+// only after a cleanly successful run. When the repo is already known starred, or
+// the feature is disabled, it does nothing.
+func (n *starNudge) maybeNudge(chatID int64) {
+	if !n.active() {
+		return
+	}
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				n.log.Debug("star nudge panic recovered", "recover", r)
+			}
+		}()
+		n.runNudge(chatID)
+	}()
+}
+
+// runNudge checks the live star state and either records it (already starred →
+// stop nudging, send nothing) or sends the invitation with a confirm button. All
+// failures are logged at debug and swallowed.
+func (n *starNudge) runNudge(chatID int64) {
+	// A fresh root context is deliberate: the nudge runs in a detached goroutine
+	// AFTER the run's own ctx may have been cancelled (Stop/timeout), and must not
+	// be torn down with it. It is independently bounded by starOpTimeout.
+	ctx, cancel := context.WithTimeout(context.Background(), starOpTimeout)
+	defer cancel()
+
+	starred, err := n.client.IsStarred(ctx, n.owner, n.repo)
+	if err != nil {
+		n.log.Debug("star nudge: check failed", "error", err)
+		return
+	}
+	if starred {
+		// Already starred out-of-band: record it so we never nudge or hit the API
+		// again, and send nothing.
+		if mErr := n.store.MarkStarred(); mErr != nil {
+			n.log.Debug("star nudge: mark starred failed", "error", mErr)
+		}
+		return
+	}
+	if _, sErr := n.chat.SendStarNudge(ctx, chatID, nudgeText); sErr != nil {
+		n.log.Debug("star nudge: send failed", "error", sErr)
+	}
+}
+
+// StarPress handles a press of the star confirm button: it stars the repo from
+// the deployment account, and on success records the resolved flag so the nudge
+// stops. It returns a short toast for the callback answer and whether the star
+// succeeded (so the caller can decide whether to edit the message into the
+// confirmation). It never panics and never blocks the caller beyond starOpTimeout;
+// a disabled/already-starred nudge reports success without an API call so a stale
+// button press is handled gracefully.
+func (s *Service) StarPress() (toast string, ok bool) {
+	return s.nudge.handlePress()
+}
+
+// handlePress performs the star and resolves the flag. A nil/disabled nudge, or
+// an already-resolved one, reports success with the done text so a late press of
+// a lingering button still confirms cleanly. A token-scope failure (or any other
+// error) reports the soft toast and false.
+func (n *starNudge) handlePress() (toast string, ok bool) {
+	if n == nil || !n.enabled {
+		return starDoneText, true
+	}
+	if n.store.Starred() {
+		return starDoneText, true
+	}
+
+	// A fresh root context is deliberate: the star must complete even if the short
+	// per-callback context is already done. It is bounded by starOpTimeout.
+	ctx, cancel := context.WithTimeout(context.Background(), starOpTimeout)
+	defer cancel()
+
+	if err := n.client.Star(ctx, n.owner, n.repo); err != nil {
+		// The ghstar client surfaces a 401/403 (missing star-write scope) with a
+		// descriptive wrapped error, so a single debug log is enough here; we never
+		// crash the run on a failed star.
+		n.log.Debug("star nudge: star failed", "error", err)
+		return starFailToast, false
+	}
+	if mErr := n.store.MarkStarred(); mErr != nil {
+		n.log.Debug("star nudge: mark starred failed", "error", mErr)
+	}
+	return starDoneText, true
+}
+
+// starMarkup returns the inline keyboard with the single confirm button used on a
+// nudge message.
+func starMarkup() models.ReplyMarkup {
+	return &models.InlineKeyboardMarkup{
+		InlineKeyboard: [][]models.InlineKeyboardButton{{
+			{Text: starButtonText, CallbackData: starCallbackData},
+		}},
+	}
+}
+
+// IsStarCallback reports whether callback data is a star-confirm callback this
+// Service should handle. Used as the prefix for the bot's callback handler, the
+// same way CallbackMatch drives the Stop handler.
+func IsStarCallback(data string) bool {
+	return strings.HasPrefix(data, starCallbackPrefix)
+}
+
+// StarCallbackPrefix is the callback_data prefix the cmd registers the star
+// handler against (bot.MatchTypePrefix), mirroring CallbackMatch for Stop.
+func StarCallbackPrefix() string { return starCallbackPrefix }
+
+// StarDoneText is the confirmation text the callback handler edits the nudge
+// message into after a successful star (the button is removed at the same time).
+func StarDoneText() string { return starDoneText }

--- a/internal/telegram/nudge_test.go
+++ b/internal/telegram/nudge_test.go
@@ -1,0 +1,294 @@
+//nolint:testpackage // intentionally whitebox to test unexported telegram nudge internals
+package telegram
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/duckbugio/flock/core/claude"
+	"github.com/duckbugio/flock/core/dispatch"
+)
+
+const (
+	nudgeOwner = "duckbugio"
+	nudgeRepo  = "flock"
+)
+
+// fakeStarrer is an in-memory starrer recording IsStarred/Star calls so a test
+// can assert what the nudge did. starred is the value IsStarred reports; starErr
+// (when set) makes Star fail.
+type fakeStarrer struct {
+	mu          sync.Mutex
+	starred     bool
+	isStarErr   error
+	starErr     error
+	isStarCalls int
+	starCalls   int
+}
+
+func (f *fakeStarrer) IsStarred(_ context.Context, _, _ string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.isStarCalls++
+	return f.starred, f.isStarErr
+}
+
+func (f *fakeStarrer) Star(_ context.Context, _, _ string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.starCalls++
+	if f.starErr != nil {
+		return f.starErr
+	}
+	f.starred = true
+	return nil
+}
+
+func (f *fakeStarrer) calls() (isStar, star int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.isStarCalls, f.starCalls
+}
+
+// fakeNudgeStore is an in-memory nudgeStore.
+type fakeNudgeStore struct {
+	mu      sync.Mutex
+	starred bool
+}
+
+func (s *fakeNudgeStore) Starred() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.starred
+}
+
+func (s *fakeNudgeStore) MarkStarred() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.starred = true
+	return nil
+}
+
+// newNudgeService builds a Service wired to the star nudge over a real Dispatcher
+// and fakes. cfg.Chat is the supplied fake chat.
+func newNudgeService(
+	t *testing.T, r claude.Runner, c chat, cfg StarNudgeConfig,
+) (*Service, *dispatch.Dispatcher) {
+	t.Helper()
+	d := dispatch.New(4)
+	s := New(Config{
+		Runner:     r,
+		Chat:       c,
+		Dispatcher: d,
+		Workspace:  &fakeWorkspace{},
+		StarNudge:  cfg,
+		Logger:     slog.New(slog.DiscardHandler),
+	})
+	s.tick = 5 * time.Millisecond
+	return s, d
+}
+
+func successRunner() *fakeRunner {
+	return &fakeRunner{events: []claude.Event{
+		{Type: claude.SystemInit, SessionID: "s1"},
+		{Type: claude.Result, Result: &claude.RunResult{Text: finalAnswer, SessionID: "s1"}},
+	}}
+}
+
+func enabledNudgeConfig(st *fakeStarrer, store nudgeStore) StarNudgeConfig {
+	return StarNudgeConfig{
+		Enabled: true,
+		Owner:   nudgeOwner,
+		Repo:    nudgeRepo,
+		Client:  st,
+		Store:   store,
+	}
+}
+
+// TestNudgeFiresAfterSuccessWhenUnstarred asserts the nudge message is sent after
+// a cleanly successful run when the repo is not starred.
+func TestNudgeFiresAfterSuccessWhenUnstarred(t *testing.T) {
+	fc := newFakeChat()
+	st := &fakeStarrer{starred: false}
+	svc, d := newNudgeService(t, successRunner(), fc, enabledNudgeConfig(st, &fakeNudgeStore{}))
+	defer d.Close()
+
+	svc.Handle(context.Background(), testChatID, testChatID, 1, "hello")
+
+	waitUntil(t, func() bool {
+		return len(fc.sentNudges()) == 1
+	})
+}
+
+// TestNudgeDoesNotFireOnError asserts a failed run (RunError) never nudges.
+func TestNudgeDoesNotFireOnError(t *testing.T) {
+	fc := newFakeChat()
+	st := &fakeStarrer{}
+	fr := &fakeRunner{events: []claude.Event{
+		{Type: claude.SystemInit, SessionID: "s1"},
+		{Type: claude.RunError, Err: errors.New("boom")},
+	}}
+	svc, d := newNudgeService(t, fr, fc, enabledNudgeConfig(st, &fakeNudgeStore{}))
+	defer d.Close()
+
+	svc.Handle(context.Background(), testChatID, testChatID, 1, "hello")
+
+	// Wait for the error to be delivered, then assert no nudge / no API call.
+	waitUntil(t, func() bool {
+		text, _ := fc.snapshot()
+		return text != "" && text != anchorText
+	})
+	time.Sleep(20 * time.Millisecond)
+	if got := fc.sentNudges(); len(got) != 0 {
+		t.Fatalf("nudge fired on error run: %v", got)
+	}
+	if is, _ := st.calls(); is != 0 {
+		t.Fatalf("IsStarred called on error run: %d", is)
+	}
+}
+
+// TestNudgeMarksWhenAlreadyStarredAndSendsNothing asserts that when the API
+// reports the repo already starred, the store is marked and no message is sent.
+func TestNudgeMarksWhenAlreadyStarredAndSendsNothing(t *testing.T) {
+	fc := newFakeChat()
+	st := &fakeStarrer{starred: true}
+	store := &fakeNudgeStore{}
+	svc, d := newNudgeService(t, successRunner(), fc, enabledNudgeConfig(st, store))
+	defer d.Close()
+
+	svc.Handle(context.Background(), testChatID, testChatID, 1, "hello")
+
+	waitUntil(t, func() bool {
+		return store.Starred()
+	})
+	if got := fc.sentNudges(); len(got) != 0 {
+		t.Fatalf("nudge sent though already starred: %v", got)
+	}
+}
+
+// TestNudgeSkippedWhenKnownStarred asserts a store already marked starred short-
+// circuits the nudge entirely (no API call, no message).
+func TestNudgeSkippedWhenKnownStarred(t *testing.T) {
+	fc := newFakeChat()
+	st := &fakeStarrer{}
+	store := &fakeNudgeStore{starred: true}
+	svc, d := newNudgeService(t, successRunner(), fc, enabledNudgeConfig(st, store))
+	defer d.Close()
+
+	svc.Handle(context.Background(), testChatID, testChatID, 1, "hello")
+
+	waitUntil(t, func() bool {
+		text, _ := fc.snapshot()
+		return text == finalAnswer
+	})
+	time.Sleep(20 * time.Millisecond)
+	if is, _ := st.calls(); is != 0 {
+		t.Fatalf("IsStarred called though store already starred: %d", is)
+	}
+	if got := fc.sentNudges(); len(got) != 0 {
+		t.Fatalf("nudge sent though store already starred: %v", got)
+	}
+}
+
+// TestNudgeDisabledIsInert asserts a disabled nudge never touches the API or chat.
+func TestNudgeDisabledIsInert(t *testing.T) {
+	fc := newFakeChat()
+	st := &fakeStarrer{}
+	svc, d := newNudgeService(t, successRunner(), fc, StarNudgeConfig{Enabled: false})
+	defer d.Close()
+
+	svc.Handle(context.Background(), testChatID, testChatID, 1, "hello")
+
+	waitUntil(t, func() bool {
+		text, _ := fc.snapshot()
+		return text == finalAnswer
+	})
+	time.Sleep(20 * time.Millisecond)
+	if is, star := st.calls(); is != 0 || star != 0 {
+		t.Fatalf("disabled nudge hit API: is=%d star=%d", is, star)
+	}
+	if got := fc.sentNudges(); len(got) != 0 {
+		t.Fatalf("disabled nudge sent a message: %v", got)
+	}
+}
+
+// TestStarPressStarsAndConfirms asserts a button press stars the repo, marks the
+// store, and reports the confirmation toast.
+func TestStarPressStarsAndConfirms(t *testing.T) {
+	fc := newFakeChat()
+	st := &fakeStarrer{starred: false}
+	store := &fakeNudgeStore{}
+	svc, d := newNudgeService(t, successRunner(), fc, enabledNudgeConfig(st, store))
+	defer d.Close()
+
+	toast, ok := svc.StarPress()
+	if !ok {
+		t.Fatalf("StarPress ok = false, toast = %q", toast)
+	}
+	if toast != starDoneText {
+		t.Errorf("toast = %q, want %q", toast, starDoneText)
+	}
+	if _, star := st.calls(); star != 1 {
+		t.Errorf("Star calls = %d, want 1", star)
+	}
+	if !store.Starred() {
+		t.Error("store not marked starred after successful press")
+	}
+}
+
+// TestStarPressFailureIsGraceful asserts a failed Star reports the soft toast,
+// does not mark the store, and never panics.
+func TestStarPressFailureIsGraceful(t *testing.T) {
+	fc := newFakeChat()
+	st := &fakeStarrer{starErr: errors.New("403 forbidden")}
+	store := &fakeNudgeStore{}
+	svc, d := newNudgeService(t, successRunner(), fc, enabledNudgeConfig(st, store))
+	defer d.Close()
+
+	toast, ok := svc.StarPress()
+	if ok {
+		t.Fatal("StarPress ok = true on Star failure, want false")
+	}
+	if toast != starFailToast {
+		t.Errorf("toast = %q, want %q", toast, starFailToast)
+	}
+	if store.Starred() {
+		t.Error("store marked starred despite Star failure")
+	}
+}
+
+// TestStarPressDisabledConfirms asserts a press against a disabled nudge (a stale
+// button on a redeployed/non-GitHub bot) confirms cleanly without an API call.
+func TestStarPressDisabledConfirms(t *testing.T) {
+	fc := newFakeChat()
+	st := &fakeStarrer{}
+	svc, d := newNudgeService(t, successRunner(), fc, StarNudgeConfig{Enabled: false})
+	defer d.Close()
+
+	toast, ok := svc.StarPress()
+	if !ok || toast != starDoneText {
+		t.Fatalf("disabled StarPress = %q,%v; want %q,true", toast, ok, starDoneText)
+	}
+	if _, star := st.calls(); star != 0 {
+		t.Errorf("disabled press hit Star API: %d", star)
+	}
+}
+
+// TestNudgeRefiresEachUnstarredRun asserts the nudge fires again on a second
+// successful run while the repo remains unstarred (re-nudge until resolved).
+func TestNudgeRefiresEachUnstarredRun(t *testing.T) {
+	fc := newFakeChat()
+	st := &fakeStarrer{starred: false}
+	svc, d := newNudgeService(t, successRunner(), fc, enabledNudgeConfig(st, &fakeNudgeStore{}))
+	defer d.Close()
+
+	svc.Handle(context.Background(), testChatID, testChatID, 1, "first")
+	waitUntil(t, func() bool { return len(fc.sentNudges()) == 1 })
+
+	svc.Handle(context.Background(), testChatID, testChatID, 2, "second")
+	waitUntil(t, func() bool { return len(fc.sentNudges()) == 2 })
+}

--- a/internal/telegram/run.go
+++ b/internal/telegram/run.go
@@ -72,6 +72,11 @@ type chat interface {
 	// URL is ever constructed for it. Used by the outbox sweeper to deliver files
 	// a run produced.
 	SendDocument(ctx context.Context, chatID int64, name string, data io.Reader) error
+	// SendStarNudge posts the post-task star-nudge message carrying the inline
+	// confirm button (a callback button, so pressing it triggers the server-side
+	// star). It is a separate seam from Send because the nudge needs the star
+	// markup, not the Stop markup. Returns the new message id.
+	SendStarNudge(ctx context.Context, chatID int64, text string) (messageID int, err error)
 }
 
 // workspaceEnsurer resolves a chat's isolated workspace path, creating it (and
@@ -113,6 +118,7 @@ type Service struct {
 	sessions  sessionStore
 	costs     *cost.Store
 	outbox    *Sweeper
+	nudge     *starNudge
 	opts      claude.Options
 	timeout   time.Duration
 	log       *slog.Logger
@@ -142,7 +148,10 @@ type Config struct {
 	// and delivers any files a run produced as Telegram documents. Nil disables
 	// the feature: the text-only finish path stays byte-identical.
 	Outbox *Sweeper
-	Opts   claude.Options // Model/MaxTurns/Env for every run; Workdir is set per chat
+	// StarNudge configures the post-task GitHub star nudge. When its Enabled flag
+	// is false (the default for non-GitHub deploys) the whole nudge path is inert.
+	StarNudge StarNudgeConfig
+	Opts      claude.Options // Model/MaxTurns/Env for every run; Workdir is set per chat
 	// Timeout bounds a single run's delivery; 0 means no deadline. On timeout the
 	// run is cancelled but the captured session_id is still stored (plan §7.3).
 	Timeout time.Duration
@@ -163,6 +172,7 @@ func New(cfg Config) *Service {
 		sessions:  cfg.Sessions,
 		costs:     cfg.Costs,
 		outbox:    cfg.Outbox,
+		nudge:     newStarNudge(cfg.StarNudge, cfg.Chat, log),
 		opts:      cfg.Opts,
 		timeout:   cfg.Timeout,
 		log:       log,
@@ -462,6 +472,17 @@ loop:
 	s.recordCost(userID, finalResult)
 
 	s.finish(ctx, chatID, progressMsgID, runID, finalResult, finalErr, ctx.Err())
+
+	// Post-task GitHub star nudge. Fire ONLY on a cleanly successful run (a
+	// terminal Result with no error and no cancel/timeout) so a failed, stopped,
+	// or timed-out run never nudges. The nudge runs fully off the hot path (its
+	// own detached goroutine, recovering any panic) so it can never delay or break
+	// a run; a nil/disabled nudge makes this a no-op.
+	if finalResult != nil && finalErr == nil && ctx.Err() == nil {
+		// maybeNudge detaches its own context (it outlives this run's ctx by design).
+		//nolint:contextcheck // intentionally detached; the nudge runs post-completion.
+		s.nudge.maybeNudge(chatID)
+	}
 }
 
 // recordCost accumulates a completed run's USD cost onto userID's running total

--- a/internal/telegram/run_test.go
+++ b/internal/telegram/run_test.go
@@ -66,6 +66,7 @@ type fakeChat struct {
 	deleted  map[int]bool
 	sent     []string // every Send'd text, in order
 	docs     []string // every SendDocument'd filename, in order
+	nudges   []string // every SendStarNudge'd text, in order
 	drafts   []string // every successful StreamDraft'd text, in order (live preview)
 	draftMD  []bool   // asMarkdown flag for each successful StreamDraft, parallel to drafts
 	draftErr error    // when set, StreamDraft returns it (simulates no draft support)
@@ -139,10 +140,26 @@ func (f *fakeChat) SendDocument(_ context.Context, _ int64, name string, data io
 	return nil
 }
 
+func (f *fakeChat) SendStarNudge(_ context.Context, _ int64, text string) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.nextID++
+	id := f.nextID
+	f.texts[id] = text
+	f.nudges = append(f.nudges, text)
+	return id, nil
+}
+
 func (f *fakeChat) sentDocs() []string {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return append([]string(nil), f.docs...)
+}
+
+func (f *fakeChat) sentNudges() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.nudges...)
 }
 
 func (f *fakeChat) snapshot() (string, bool) {


### PR DESCRIPTION
## Summary

Adds an optional, GitHub-only feature: when the deployment's GitHub account (the `GIT_TOKEN` owner) has **not** starred the flock repo, the bot — **after each successfully completed task** in a chat — sends a light suggestion with an inline **confirm button**. Pressing it stars `duckbugio/flock` from the deployment account (`PUT /user/starred`) and stops further nudges. Off by default for non-GitHub deployments; never blocks, delays, or breaks a run; never auto-stars without an explicit press.

## Behaviour

- **Enabled when** `GIT_HOST == github.com` **and** `GIT_TOKEN` is set **and** `STAR_NUDGE_REPO` parses as `owner/repo` (`StarNudgeEnabled()`). Gitea / empty host / no token → fully inert.
- **Trigger:** only on a cleanly completed run (terminal `claude.Result`, no error, no cancel/timeout) — never on stop/error/timeout. Re-nudges after each completed task **while unstarred**.
- **Button press → star:** the only `PUT /user/starred` lives in the gated callback handler; on success the message is edited to a confirmation and the durable flag is set, so the bot never nudges or calls the API again (across restarts too).
- **Security:** the `star:` callback enforces the **same `ALLOWED_USERS` gate** as the `stop:` button — an un-allowed / zero sender cannot trigger the star. The token is only ever sent as a `Bearer` header, never logged.
- **Fail-safe:** the post-task check runs in a detached goroutine with `recover()`; every API/store error (incl. 401/403 missing scope, rate-limit) is swallowed + logged at debug. A missing-scope press surfaces a soft toast, never a crash.

## Acceptance criteria

- [x] **AC1** — `StarNudgeEnabled()` gate (github.com + token + valid repo); inert otherwise (table tests).
- [x] **AC2** — `core/ghstar`: `IsStarred` (GET 204/404) + `Star` (PUT 204; 401/403 → `ErrUnauthorized`), Bearer/Accept/API-version headers, injectable base URL + client (httptest unit tests, incl. context cancellation).
- [x] **AC3** — post-success, per-task nudge while unstarred; stops once starred (API-observed or button press), durable across restart (`core/nudge`).
- [x] **AC4** — button press stars from the account, confirms, and disables further nudges; gated by allow-list.
- [x] **AC5** — fully fail-safe & off the hot path; never blocks/breaks a run.

## New / changed

- New: `core/ghstar` (stars client), `core/nudge` (durable starred flag), `internal/telegram/nudge.go` — all with tests.
- Changed: `internal/config` (`StarNudgeEnabled/StarNudgeRepo/StarNudgeStoreFile/StarNudgeRepoParts`), `internal/telegram/run.go` + `bot.go` (trigger + `SendStarNudge` + `star:` callback), `cmd/flock-telegram/main.go` (wiring + `starHandler`, mirroring the `stop:` registration), `adapters/telegram/.env.example` + `README.md`.

## How it was verified

Inside the pinned dev-tools image:

- `golangci-lint run` → **0 issues**
- `go test -race ./...` → **all 15 packages pass** (incl. new `core/ghstar`, `core/nudge`, and the telegram nudge/callback tests)
- `go build ./cmd/flock-telegram` → ok · `go mod tidy` → clean

## Config / ops note

- `STAR_NUDGE_REPO` (default `duckbugio/flock`) and optional `STAR_NUDGE_STORE_PATH` documented in `.env.example` + README.
- The button's star action needs a token with star-write scope (classic `public_repo`, or a fine-grained token with the **Starring** account permission). Without it the press fails softly (a toast) — the rest of the bot is unaffected.

## Risks

- **Low.** Single repo, gated off for non-GitHub deploys, detached + fail-safe; blast radius is one extra GitHub API call per successful run while unstarred. No data/migration/cross-service impact.
