### PR TITLE
tgui: humanize the Working timer and show +N earlier elided lines

### DIFF
--- a/internal/tgui/progress.go
+++ b/internal/tgui/progress.go
@@ -50,6 +50,18 @@ const (
 	toolPrefix    = "🔧 "
 )
 
+// elidedFormat renders the "+N earlier" indicator prepended to the activity block
+// when older lines have scrolled off above the visible window. It is plain English
+// to match the rest of the UI ("Working…", "Stop").
+const elidedFormat = "+%d earlier"
+
+// Units used by formatElapsed to humanize the elapsed counter.
+const (
+	secondsPerMinute = 60
+	minutesPerHour   = 60
+	secondsPerHour   = secondsPerMinute * minutesPerHour
+)
+
 // spinnerFrames animate the "Working" header. The frame is selected from the
 // wall-clock elapsed seconds, so the header visibly ticks alongside the counter
 // even during a long, silent tool call.
@@ -64,6 +76,9 @@ type Progress struct {
 	elapsed  func() time.Duration
 	ring     []string
 	ringSize int
+	// total counts every activity line ever pushed (not no-op/ignored events), so
+	// Frame can show how many lines have scrolled off above the visible window.
+	total int
 }
 
 // NewProgress returns a Progress whose header counter reads from elapsed, the
@@ -131,14 +146,36 @@ func capLine(line string, maxText int) string {
 	return truncateRunes(line, maxText)
 }
 
-// push appends a line to the bounded ring, evicting the oldest when full.
+// push appends a line to the bounded ring, evicting the oldest when full. It also
+// bumps total, the running count of every activity line ever pushed.
 func (p *Progress) push(line string) {
+	p.total++
 	if len(p.ring) == p.ringSize {
 		copy(p.ring, p.ring[1:])
 		p.ring[len(p.ring)-1] = line
 		return
 	}
 	p.ring = append(p.ring, line)
+}
+
+// formatElapsed humanizes an elapsed-seconds count, showing hours and minutes
+// only when present and zero-padding sub-units: "45s", "21m 21s", "1h 02m 05s".
+// Negative input is clamped to "0s".
+func formatElapsed(secs int64) string {
+	if secs < 0 {
+		secs = 0
+	}
+	switch {
+	case secs < secondsPerMinute:
+		return fmt.Sprintf("%ds", secs)
+	case secs < secondsPerHour:
+		return fmt.Sprintf("%dm %02ds", secs/secondsPerMinute, secs%secondsPerMinute)
+	default:
+		h := secs / secondsPerHour
+		m := (secs % secondsPerHour) / secondsPerMinute
+		s := secs % secondsPerMinute
+		return fmt.Sprintf("%dh %02dm %02ds", h, m, s)
+	}
 }
 
 // Frame renders the current progress message: a header line driven by the
@@ -149,7 +186,7 @@ func (p *Progress) Frame() string {
 		secs = 0
 	}
 	spin := spinnerFrames[secs%int64(len(spinnerFrames))]
-	header := fmt.Sprintf("%s Working… (%ds)", spin, secs)
+	header := fmt.Sprintf("%s Working… (%s)", spin, formatElapsed(secs))
 	if len(p.ring) == 0 {
 		return header
 	}
@@ -166,13 +203,22 @@ func (p *Progress) Frame() string {
 	}
 
 	// Enforce the overall frame budget. assemble joins the header (always kept),
-	// a blank separator, and the given ring lines; its rune count must not exceed
-	// frameBudgetMax. Drop the OLDEST lines first until it fits.
+	// a blank separator, the "+N earlier" indicator (when lines have scrolled off
+	// above the shown window), and the given ring lines; its rune count must not
+	// exceed frameBudgetMax. Drop the OLDEST lines first until it fits.
+	//
+	// hidden is computed from the lines being SHOWN in this call (p.total minus the
+	// shown count), so each dropped line raises N by one — keeping the indicator
+	// self-consistent with the drop loop below.
 	assemble := func(ringLines []string) string {
 		var b strings.Builder
 		_, _ = b.WriteString(header)
 		// A blank line sets the activity ("thoughts") apart from the Working header.
 		_, _ = b.WriteString("\n")
+		if hidden := p.total - len(ringLines); hidden > 0 {
+			_ = b.WriteByte('\n')
+			_, _ = fmt.Fprintf(&b, elidedFormat, hidden)
+		}
 		for _, line := range ringLines {
 			_ = b.WriteByte('\n')
 			_, _ = b.WriteString(line)
@@ -191,10 +237,14 @@ func (p *Progress) Frame() string {
 	// A single surviving line (the most recent) still blows the budget on its own.
 	// Hard-truncate it so the frame is always <= frameBudgetMax, but never emit an
 	// empty frame: keep the header + a blank + the truncated line. The header, the
-	// two separating newlines, and the line's emoji prefix all ride on top of the
-	// text budget, so subtract them so capLine's TEXT cap keeps the whole frame in
-	// bounds.
+	// two separating newlines, the optional "+N earlier" indicator line, and the
+	// line's emoji prefix all ride on top of the text budget, so subtract them so
+	// capLine's TEXT cap keeps the whole frame in bounds.
 	overhead := utf8.RuneCountInString(header) + separatorRunes
+	if hidden := p.total - 1; hidden > 0 {
+		// The indicator line plus its leading newline.
+		overhead += 1 + utf8.RuneCountInString(fmt.Sprintf(elidedFormat, hidden))
+	}
 	for _, prefix := range []string{thoughtPrefix, toolPrefix} {
 		if strings.HasPrefix(lines[0], prefix) {
 			overhead += utf8.RuneCountInString(prefix)

--- a/internal/tgui/progress_test.go
+++ b/internal/tgui/progress_test.go
@@ -54,9 +54,13 @@ func TestActivityRingBounded(t *testing.T) {
 	}
 	frame := p.Frame()
 	lines := strings.Split(frame, "\n")
-	// 1 header + 1 blank separator + at most 3 activity lines.
-	if len(lines) != 5 {
-		t.Fatalf("expected header + blank + 3 ring lines, got %d lines: %q", len(lines), frame)
+	// 1 header + 1 blank separator + 1 "+2 earlier" indicator + 3 activity lines.
+	if len(lines) != 6 {
+		t.Fatalf("expected header + blank + indicator + 3 ring lines, got %d lines: %q", len(lines), frame)
+	}
+	// Five pushed, three shown: two scrolled off above the window.
+	if !strings.Contains(frame, "+2 earlier") {
+		t.Fatalf("expected +2 earlier indicator: %q", frame)
 	}
 	// Oldest two ("Read", "Grep") evicted; newest three retained in order.
 	if !strings.Contains(frame, "Edit") || !strings.Contains(frame, "Bash") || !strings.Contains(frame, "Write") {
@@ -238,6 +242,105 @@ func TestFrameBudgetDropsOldestLines(t *testing.T) {
 	}
 	if strings.Contains(frame, "L0 ") {
 		t.Fatalf("oldest line should have been dropped first: %.80q", frame)
+	}
+}
+
+func TestFormatElapsed(t *testing.T) {
+	cases := []struct {
+		secs int64
+		want string
+	}{
+		{-5, "0s"},
+		{0, "0s"},
+		{45, "45s"},
+		{60, "1m 00s"},
+		{185, "3m 05s"},
+		{1281, "21m 21s"},
+		{3600, "1h 00m 00s"},
+		{3725, "1h 02m 05s"},
+	}
+	for _, tc := range cases {
+		if got := formatElapsed(tc.secs); got != tc.want {
+			t.Errorf("formatElapsed(%d) = %q, want %q", tc.secs, got, tc.want)
+		}
+	}
+}
+
+// TestFormatElapsedInHeader confirms the humanized form reaches the rendered header.
+func TestFormatElapsedInHeader(t *testing.T) {
+	var elapsed time.Duration
+	p := NewProgress(fakeClock(&elapsed), 5)
+	elapsed = 1281 * time.Second
+	if got := p.Frame(); !strings.Contains(got, "Working… (21m 21s)") {
+		t.Fatalf("header not humanized: %q", got)
+	}
+}
+
+// TestElidedIndicatorHiddenWhenAllShown asserts no "+N earlier" line appears while
+// the number of pushed lines is within the visible ring.
+func TestElidedIndicatorHiddenWhenAllShown(t *testing.T) {
+	var elapsed time.Duration
+	const ring = 5
+	p := NewProgress(fakeClock(&elapsed), ring)
+	for i := 0; i < ring; i++ {
+		p.Observe(claude.Event{Type: claude.ToolUse, Tool: "Bash"})
+	}
+	if frame := p.Frame(); strings.Contains(frame, "earlier") {
+		t.Fatalf("indicator shown when nothing elided: %q", frame)
+	}
+}
+
+// TestElidedIndicatorShownWhenEvicted asserts that pushing more than ringSize lines
+// renders "+K earlier" as the FIRST activity line, with the last ringSize lines kept.
+func TestElidedIndicatorShownWhenEvicted(t *testing.T) {
+	var elapsed time.Duration
+	const ring = 5
+	const extra = 37
+	p := NewProgress(fakeClock(&elapsed), ring)
+	for i := 0; i < ring+extra; i++ {
+		p.Observe(claude.Event{Type: claude.ToolUse, Tool: "Bash"})
+	}
+	frame := p.Frame()
+	if !strings.Contains(frame, "+"+strconv.Itoa(extra)+" earlier") {
+		t.Fatalf("expected +%d earlier indicator: %q", extra, frame)
+	}
+	// The indicator must be the FIRST line of the activity block: header, blank,
+	// then the indicator.
+	lines := strings.Split(frame, "\n")
+	if len(lines) < 3 || lines[2] != "+"+strconv.Itoa(extra)+" earlier" {
+		t.Fatalf("indicator not first activity line: %q", frame)
+	}
+	// Exactly ringSize activity lines are kept below the indicator.
+	if kept := strings.Count(frame, toolPrefix); kept != ring {
+		t.Fatalf("kept %d activity lines, want %d", kept, ring)
+	}
+}
+
+// TestElidedIndicatorCountsBudgetDrops asserts N reflects lines dropped by the frame
+// budget loop, not just ring eviction: with a large ring of long lines the budget
+// loop drops some shown lines, and each drop must raise N by one.
+func TestElidedIndicatorCountsBudgetDrops(t *testing.T) {
+	var elapsed time.Duration
+	const ring = 20
+	p := NewProgress(fakeClock(&elapsed), ring)
+	for i := 0; i < ring; i++ {
+		p.push(thoughtPrefix + "L" + strconv.Itoa(i) + " " + strings.Repeat("x", olderSnippetMax))
+	}
+	frame := p.Frame()
+	if n := utf8.RuneCountInString(frame); n > frameBudgetMax {
+		t.Fatalf("frame exceeded budget: %d runes (max %d)", n, frameBudgetMax)
+	}
+	kept := strings.Count(frame, thoughtPrefix)
+	if kept >= ring {
+		t.Fatalf("budget loop did not drop any lines: kept %d of %d", kept, ring)
+	}
+	// total == ring; hidden == total - kept, and that must be the rendered N.
+	hidden := ring - kept
+	if !strings.Contains(frame, "+"+strconv.Itoa(hidden)+" earlier") {
+		t.Fatalf("indicator N=%d not reflected after budget drops: %.80q", hidden, frame)
+	}
+	if hidden <= 0 {
+		t.Fatalf("expected some lines hidden, got N=%d", hidden)
 	}
 }
 


### PR DESCRIPTION
## Summary

Two tweaks to the live "Working…" progress frame (`internal/tgui/progress.go`), pure rendering — no decoder/event changes.

1. **Humanized elapsed timer.** The header counter now shows hours/minutes when present instead of raw seconds:
   - `45s`, `21m 21s` (was `1281s`), `1h 02m 05s` — sub-units zero-padded; sub-60s unchanged.
2. **"+N earlier" elided-lines indicator.** The activity ring only keeps the last few lines; older ones used to vanish silently. The frame now shows how many activity lines have scrolled off above the visible window, as the first line of the activity block (only when N > 0):

```
⠋ Working… (21m 21s)

+37 earlier
🔧 Bash
🔧 Bash
💭 …
🔧 Bash
🔧 Bash
```

The indicator text is English to match the rest of the UI (`Working…`, `Stop`).

## Notes on correctness

- `total` counts every activity line ever pushed (ignored/no-op events never count). N = `total − (lines actually shown)`, computed **inside** the frame-budget assembler so dropping a line to fit `frameBudgetMax` grows N by exactly one — self-consistent with the existing drop-oldest loop. The single-line hard-truncate branch also accounts for the indicator's runes.

## Acceptance criteria

- [x] **AC1** — `formatElapsed`: 0→`0s`, 45→`45s`, 60→`1m 00s`, 185→`3m 05s`, 1281→`21m 21s`, 3600→`1h 00m 00s`, 3725→`1h 02m 05s` (table test).
- [x] **AC2** — header renders the humanized form (`Working… (21m 21s)`).
- [x] **AC3** — ≤ ringSize lines → no indicator; ringSize+K → `+K earlier` as the first activity line with the last ringSize lines kept; budget-dropped lines increase N (tests).

## Verification (dev-tools image)

- `golangci-lint run` → **0 issues**
- `go test -race ./...` → all packages pass (incl. `internal/tgui` with the new tests)
- `go build ./cmd/flock-telegram` → ok · `go mod tidy` → clean

## Risks

- **Low.** Pure presentation change in one package; budget/truncation invariants preserved and covered by tests.
