### PR TITLE
feat(vk): VK (VKontakte) community-bot adapter (P1)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,15 @@ updates:
       - dependencies
       - docker
 
+  - package-ecosystem: docker
+    directory: /adapters/vk
+    schedule:
+      interval: weekly
+      day: monday
+    labels:
+      - dependencies
+      - docker
+
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,3 +102,32 @@ jobs:
           push: false
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  vk-image:
+    name: Build vk image (no push)
+    runs-on: ubuntu-latest
+    # PR-only dry run: prove the VK runtime image still builds before merge, the same
+    # way the telegram image job does (a base-image/dependency bump could land green in
+    # the Go lint/tests yet break the Dockerfile, which otherwise only runs post-merge
+    # in publish-vk.yml). Mirrors that workflow's build EXACTLY (same context/file/
+    # platforms/cache) but with push: false. On push to main the actual publish covers it.
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build vk image (no push)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./adapters/vk/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/publish-vk.yml
+++ b/.github/workflows/publish-vk.yml
@@ -1,0 +1,73 @@
+name: Publish vk image
+
+# Builds the self-contained VK bot image and pushes it to GitHub Container
+# Registry (ghcr.io/duckbugio/flock-vk) so adopters can just `docker compose up`.
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+    # Only rebuild when something that actually lands in the image changes: the Go
+    # sources (cmd/, internal/, core/, go.mod/go.sum) or the adapter build
+    # (Dockerfile/.dockerignore). Docs and the Ansible deploy dir don't affect the
+    # image, so they don't trigger a build.
+    paths:
+      - 'cmd/**'
+      - 'internal/**'
+      - 'core/**'
+      - 'go.mod'
+      - 'go.sum'
+      - 'adapters/vk/**'
+      - '!adapters/vk/deploy/**'
+      - '.dockerignore'
+      - '.github/workflows/publish-vk.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Image metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/duckbugio/flock-vk
+          # Tags produced per build:
+          #   :latest              — rolling, default branch only (what deploys track)
+          #   :0.1.<run_number>    — ordered, human-readable auto-version for every main
+          #                          build (no manual step); the number increments per
+          #                          publish run so images sort and read sanely
+          #   :vX.Y.Z              — milestone release: push a git tag vX.Y.Z and it lands
+          #   :sha-<commit>        — exact, immutable pin for traceability/rollback
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=0.1.${{ github.run_number }},enable={{is_default_branch}}
+            type=ref,event=tag
+            type=sha,format=short
+
+      - name: Build & push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./adapters/vk/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/adapters/vk/.env.example
+++ b/adapters/vk/.env.example
@@ -1,0 +1,67 @@
+# ── Copy to .env and fill in. Only the REQUIRED block is needed to start. ──────────
+# These are the variables the (Go) VK bot actually reads; see internal/config/config.go.
+
+# ===== REQUIRED =====
+VK_BOT_TOKEN=                  # community access token (VK community → Manage → API usage → access token)
+VK_GROUP_ID=                   # your community's numeric id (used for the long-poll server + mention parse)
+VK_ALLOWED_USERS=              # comma-separated VK user IDs allowed to use the bot
+
+# Claude auth — Pro/Max subscription token from `claude setup-token` (recommended; no per-token cost).
+# Leave ANTHROPIC_API_KEY empty when using this (the key would take precedence).
+CLAUDE_CODE_OAUTH_TOKEN=
+ANTHROPIC_API_KEY=            # alternative: pay-per-token Console key (sk-ant-...)
+
+# ===== CORE (sensible defaults) =====
+CLAUDE_MODEL=claude-opus-4-8
+APPROVED_DIRECTORY=/workspace
+CLAUDE_MAX_TURNS=250
+CLAUDE_TIMEOUT_SECONDS=10800    # 3h per run — big team builds run long in a single turn
+CLAUDE_MAX_COST_PER_USER=1000.0 # cumulative per-user USD cap (0 disables)
+RATE_LIMIT_REQUESTS=30          # per-user; 0 (or window 0) disables the rate limit
+RATE_LIMIT_WINDOW=60            # seconds
+# Chats answered in PARALLEL (each chat stays serial). Caps memory — 1 = fully serial.
+MAX_CONCURRENT_CHAT_RUNS=4
+# Dev-team loop limits (rendered into the workspace CLAUDE.md at start).
+PRE_PR_CYCLES=5
+PR_REVIEW_CYCLES=10
+# Group chats: false (default) = answer every message; true = only on @mention/reply.
+# A VK community mention is [club<VK_GROUP_ID>|name]; the bot strips it before the run.
+REQUIRE_GROUP_MENTION=false
+# Published-PR review/fix loop (Gitea poller + on-PR review). false (default) = off: build +
+# open a PR, then stop. true = react to PR comments and run the on-PR review loop.
+ENABLE_PR_REVIEW=false
+BOT_MEM_LIMIT=3g                # consumed by docker-compose mem_limit, not the bot
+
+# ===== GIT (optional) — clone repos + open PRs from chat. Works with Gitea/GitHub/GitLab. =====
+GIT_HOST=                      # e.g. git.example.com or github.com (empty = git disabled)
+GIT_SCHEME=https
+GIT_USER=
+GIT_TOKEN=
+# For github.com: also set GH_TOKEN (= your GIT_TOKEN) so the `gh` CLI can open PRs.
+# GH_TOKEN=
+GIT_AUTHOR_NAME=AI Team
+GIT_AUTHOR_EMAIL=ai@example.com
+# PR poller — reacts to PR comments (no inbound webhook needed). Active when ENABLE_PR_REVIEW=true
+# and this is set to <scheme>://<host>/api/v1 (Gitea). GITEA_POLL_INTERVAL=0 disables.
+GITEA_API_URL=                 # e.g. https://git.example.com/api/v1
+GITEA_POLL_INTERVAL=90
+
+# ===== GITHUB STAR NUDGE (optional, GitHub-only) =====
+# After each successful run the bot invites you to star the project on GitHub, with
+# an inline button that stars it from the GIT_TOKEN account. Auto-ON only when
+# GIT_HOST=github.com AND GIT_TOKEN is set; OFF for every other host (the gate is the
+# off switch — no separate flag). The button needs a token with star-write scope.
+STAR_NUDGE_REPO=duckbugio/flock   # owner/repo to nudge for / star
+# STAR_NUDGE_STORE_PATH=          # JSON flag store; default <APPROVED_DIRECTORY>/star_nudge.json
+
+# ===== VOICE (optional) — transcribe voice messages =====
+ENABLE_VOICE_MESSAGES=true
+VOICE_PROVIDER=mistral         # mistral | openai | local
+MISTRAL_API_KEY=               # for VOICE_PROVIDER=mistral (console.mistral.ai)
+# OPENAI_API_KEY=              # for VOICE_PROVIDER=openai
+
+# ===== DOCKER-IN-DOCKER (optional, with `--profile dind`) — dockerized linters/tests for the team =====
+# DOCKER_HOST=tcp://dind:2375
+
+# ===== MISC =====
+LOG_LEVEL=INFO                 # DEBUG | INFO | WARN | ERROR

--- a/adapters/vk/Dockerfile
+++ b/adapters/vk/Dockerfile
@@ -1,0 +1,91 @@
+# Self-contained image for the DuckFlock AI dev-team VK (VKontakte) bot (Go).
+# A multi-stage build: compile the static Go binary, then assemble a slim runtime
+# with Node + the `claude` CLI and the tools the team shells out to.
+# Behaviour is toggled at RUNTIME via env (see .env.example).
+# Built & published by .github/workflows/publish-vk.yml -> ghcr.io/duckbugio/flock-vk
+# Build context is the REPO ROOT (COPY paths are root-relative): docker build -f adapters/vk/Dockerfile .
+
+# --- Build stage: compile the Go binary ---------------------------------------
+# Build on the native BUILDPLATFORM and cross-compile to TARGETARCH (CGO off), so
+# multi-arch builds don't pay for emulation.
+FROM --platform=$BUILDPLATFORM golang:1.26-bookworm AS build
+
+WORKDIR /src
+
+# Cache module downloads on go.mod/go.sum alone.
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Then the sources the binary needs. cmd/duck-vk imports adapters/vk, so adapters/
+# MUST be copied alongside cmd/core/internal (a missing adapters/ broke the
+# telegram image build before — see the commit history).
+COPY cmd/ ./cmd/
+COPY core/ ./core/
+COPY adapters/ ./adapters/
+COPY internal/ ./internal/
+
+ARG TARGETOS
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build -buildvcs=false -trimpath -ldflags "-s -w" -o /out/duck-vk ./cmd/duck-vk
+
+# --- Runtime stage ------------------------------------------------------------
+# node:24 (current LTS) supplies Node (for the `claude` CLI). Add git/ripgrep/ffmpeg
+# (the CLI shells out to them), the GitHub CLI (`gh`, for PR creation on github.com)
+# + the Docker CLI (talks to the optional dind sidecar).
+FROM node:24-bookworm-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        ca-certificates curl gnupg git ripgrep ffmpeg; \
+    install -m 0755 -d /etc/apt/keyrings; \
+    curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc; \
+    chmod a+r /etc/apt/keyrings/docker.asc; \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian $(. /etc/os-release && echo $VERSION_CODENAME) stable" > /etc/apt/sources.list.d/docker.list; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin; \
+    npm install -g @anthropic-ai/claude-code; \
+    npm cache clean --force; \
+    apt-get clean; rm -rf /var/lib/apt/lists/*
+
+# GitHub CLI (gh) for PR creation on github.com — installed from the official release
+# tarball, NOT the apt repo: that extra apt source tipped the QEMU-emulated arm64
+# build over its memory limit during `apt-get update` (OOM: "Cannot allocate
+# memory"). One arch-matched binary is far lighter and keeps the multi-arch build
+# green. Uses the latest release, falling back to a pinned version if the GitHub API
+# is unreachable/rate-limited at build time.
+RUN set -eux; \
+    arch="$(dpkg --print-architecture)"; \
+    ver="$(curl -fsSL https://api.github.com/repos/cli/cli/releases/latest 2>/dev/null | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p')"; \
+    [ -n "$ver" ] || ver="2.45.0"; \
+    curl -fsSL "https://github.com/cli/cli/releases/download/v${ver}/gh_${ver}_linux_${arch}.tar.gz" -o /tmp/gh.tgz; \
+    tar -xzf /tmp/gh.tgz -C /tmp; \
+    install -m 0755 "/tmp/gh_${ver}_linux_${arch}/bin/gh" /usr/local/bin/gh; \
+    rm -rf /tmp/gh.tgz "/tmp/gh_${ver}_linux_${arch}"
+
+# Non-root runtime user; pre-create writable dirs so named volumes inherit uid 1000.
+# /app/data is kept for volume-layout parity with the previous image. The node base
+# image already occupies uid 1000 (the `node` user), so drop it and re-create `claude`
+# at the SAME uid 1000 the existing volumes are owned by.
+RUN userdel -r node 2>/dev/null || true; \
+    useradd -m -u 1000 -s /bin/bash claude \
+ && mkdir -p /workspace /app/data /home/claude/.claude /opt/duck/agents \
+ && chown -R claude:claude /workspace /app /home/claude/.claude /opt/duck
+
+# The compiled bot.
+COPY --from=build /out/duck-vk /usr/local/bin/duck-vk
+
+# Shared team config — rendered per chat into the workspace by core/workspace at runtime.
+COPY --chown=claude:claude core/agents/*.md /opt/duck/agents/
+COPY --chown=claude:claude core/CLAUDE.workspace.md.tmpl /opt/duck/CLAUDE.workspace.md.tmpl
+
+USER claude
+ENV HOME=/home/claude \
+    PATH=/home/claude/.local/bin:$PATH
+
+WORKDIR /app
+# The Go binary wires git + renders the workspace itself (no shell entrypoint needed).
+ENTRYPOINT ["/usr/local/bin/duck-vk"]

--- a/adapters/vk/api.go
+++ b/adapters/vk/api.go
@@ -89,7 +89,21 @@ func (e *apiError) Error() string {
 const (
 	errCodeTooManyRequests = 6
 	errCodeFloodControl    = 9
+	// errBotFeatureDisabled is VK error 912 ("This is a chat bot feature, change
+	// this status in settings") — returned for a messages.send/messages.edit that
+	// carries an inline keyboard when the community's "Bot abilities" toggle is OFF.
+	// The same call without a keyboard succeeds, so the Send/Edit paths use this to
+	// retry once without the keyboard (verified live against a real community).
+	errBotFeatureDisabled = 912
 )
+
+// isBotFeatureDisabled reports whether err is a VK *apiError with code 912 (bot
+// keyboards disabled for the community). The Send/Edit paths use it to fall back
+// to a keyboard-less resend.
+func isBotFeatureDisabled(err error) bool {
+	var ae *apiError
+	return errors.As(err, &ae) && ae.Code == errBotFeatureDisabled
+}
 
 // call invokes a VK API method with the given params, decoding the "response"
 // field of the envelope into out (which may be nil to discard it). The access

--- a/adapters/vk/api.go
+++ b/adapters/vk/api.go
@@ -1,0 +1,339 @@
+// Package vk is the VKontakte (VK) community-bot transport adapter for the
+// core/chat conversation layer. It is a hand-rolled net/http client against the
+// VK API (https://api.vk.com/method/<method>, v=5.199) — deliberately NO VK SDK,
+// to keep the dependency tree minimal (net/http only). It implements
+// core/chat.Transport (Send/Edit/Delete/SendDocument/StreamDraft/SendStarNudge/
+// Capabilities) over messages.send/messages.edit/messages.delete and the
+// docs.* upload dance, classifies VK flood/rate errors for the RetryAfter seam,
+// renders the inline Stop keyboard, runs the Bots Long Poll receive loop, maps
+// VK updates onto the neutral Service, parses the [club<id>|...] community
+// mention for the gate, and downloads inbound docs/photos/voice (with URL
+// redaction). The transport-neutral run loop lives in core/chat; this package
+// holds only VK-specific glue.
+package vk
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// apiBase is the default VK API method endpoint. It is a struct field on Client
+// (not a hardcoded constant in the call path) so unit tests can point it at an
+// httptest.Server.
+const apiBase = "https://api.vk.com/method/"
+
+// apiVersion is the VK API version every call carries (v=). Pinned per the locked
+// tech decision (§3 of docs/multi-transport-plan.md).
+const apiVersion = "5.199"
+
+// Client is a tiny VK API client over net/http. BaseURL and HTTPClient are
+// injectable (default to the real endpoint / http.DefaultClient) so tests drive
+// it against a fake server; Token is the community access token sent as the
+// access_token POST form field on every call.
+type Client struct {
+	// Token is the VK community access token. It is sent as a POST form field, never
+	// embedded in a URL, so it does not leak into a logged request line.
+	Token string
+	// BaseURL is the VK API method endpoint (defaults to apiBase). Tests override it
+	// to an httptest.Server URL (with a trailing slash).
+	BaseURL string
+	// HTTPClient performs the requests (defaults to http.DefaultClient). Tests inject
+	// a server-scoped client.
+	HTTPClient *http.Client
+}
+
+// NewClient builds a Client for token, defaulting BaseURL to the real VK endpoint
+// and HTTPClient to http.DefaultClient.
+func NewClient(token string) *Client {
+	return &Client{Token: token, BaseURL: apiBase, HTTPClient: http.DefaultClient}
+}
+
+// base returns the configured BaseURL or the default endpoint.
+func (c *Client) base() string {
+	if c.BaseURL != "" {
+		return c.BaseURL
+	}
+	return apiBase
+}
+
+// httpClient returns the configured HTTPClient or http.DefaultClient.
+func (c *Client) httpClient() *http.Client {
+	if c.HTTPClient != nil {
+		return c.HTTPClient
+	}
+	return http.DefaultClient
+}
+
+// apiError is a VK API error envelope ({"error":{"error_code":N,...}}). It
+// satisfies error so callers can errors.As it (RetryAfter inspects the code).
+type apiError struct {
+	Code int    `json:"error_code"` //nolint:tagliatelle // VK API uses snake_case.
+	Msg  string `json:"error_msg"`  //nolint:tagliatelle // VK API uses snake_case.
+}
+
+func (e *apiError) Error() string {
+	return fmt.Sprintf("vk api error %d: %s", e.Code, e.Msg)
+}
+
+// VK flood/rate-limit error codes. Code 6 ("Too many requests per second") and
+// code 9 ("Flood control") are the throttle signals the RetryAfter seam maps to a
+// fixed back-off (VK returns no Retry-After header).
+const (
+	errCodeTooManyRequests = 6
+	errCodeFloodControl    = 9
+)
+
+// call invokes a VK API method with the given params, decoding the "response"
+// field of the envelope into out (which may be nil to discard it). The access
+// token and version are added automatically. A VK error envelope is returned as
+// an *apiError; a transport/HTTP error has its URL redacted (it carries no token,
+// but stays consistent with the upload seam's discipline).
+func (c *Client) call(ctx context.Context, method string, params url.Values, out any) error {
+	if params == nil {
+		params = url.Values{}
+	}
+	params.Set("access_token", c.Token)
+	params.Set("v", apiVersion)
+
+	endpoint := c.base() + method
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(params.Encode()))
+	if err != nil {
+		return fmt.Errorf("build %s request: %w", method, err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := c.httpClient().Do(req)
+	if err != nil {
+		return fmt.Errorf("%s: %w", method, redactURLError(err))
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxAPIResponseBytes))
+	if err != nil {
+		return fmt.Errorf("read %s response: %w", method, err)
+	}
+	return decodeEnvelope(method, body, out)
+}
+
+// maxAPIResponseBytes caps an API response body read so a misbehaving endpoint
+// can't exhaust memory. VK method responses are small JSON; Long Poll responses
+// (read by the receive loop, which uses its own reader) are bounded separately.
+const maxAPIResponseBytes = 8 << 20 // 8 MiB
+
+// envelope is the common VK response shape: exactly one of response/error.
+type envelope struct {
+	Response json.RawMessage `json:"response"`
+	Error    *apiError       `json:"error"`
+}
+
+// decodeEnvelope unmarshals a VK response body, surfacing a VK error envelope as
+// an *apiError and otherwise decoding the response field into out.
+func decodeEnvelope(method string, body []byte, out any) error {
+	var env envelope
+	if err := json.Unmarshal(body, &env); err != nil {
+		return fmt.Errorf("decode %s response: %w", method, err)
+	}
+	if env.Error != nil {
+		return env.Error
+	}
+	if out == nil {
+		return nil
+	}
+	if err := json.Unmarshal(env.Response, out); err != nil {
+		return fmt.Errorf("decode %s response payload: %w", method, err)
+	}
+	return nil
+}
+
+// MessagesSend posts a message to peerID. randomID MUST be unique per logical
+// send within ~1h (VK silently dedupes a repeated random_id); keyboard is the
+// JSON inline keyboard (empty = none) and attachment is the optional attachment
+// spec (e.g. "doc{owner}_{id}"; empty = none). It returns the GLOBAL message id
+// VK assigns, which is what Edit/Delete address (using the global message_id is
+// the least error-prone path — VK's messages.edit accepts message_id directly,
+// avoiding the conversation_message_id round-trip).
+func (c *Client) MessagesSend(
+	ctx context.Context, peerID int64, message string, randomID int64, keyboard, attachment string,
+) (int64, error) {
+	params := url.Values{}
+	params.Set("peer_id", strconv.FormatInt(peerID, 10))
+	params.Set("message", message)
+	params.Set("random_id", strconv.FormatInt(randomID, 10))
+	if keyboard != "" {
+		params.Set("keyboard", keyboard)
+	}
+	if attachment != "" {
+		params.Set("attachment", attachment)
+	}
+	// messages.send returns the bare message id as the "response" value.
+	var msgID int64
+	if err := c.call(ctx, "messages.send", params, &msgID); err != nil {
+		return 0, err
+	}
+	return msgID, nil
+}
+
+// MessagesEdit edits messageID (a GLOBAL message id from MessagesSend) in peerID.
+// keyboard replaces the inline keyboard (empty clears it). VK allows editing
+// within 24h; throttling is handled by core/chat.Service.
+func (c *Client) MessagesEdit(ctx context.Context, peerID, messageID int64, message, keyboard string) error {
+	params := url.Values{}
+	params.Set("peer_id", strconv.FormatInt(peerID, 10))
+	params.Set("message_id", strconv.FormatInt(messageID, 10))
+	params.Set("message", message)
+	// Always set keyboard (empty string clears markup on the final answer).
+	params.Set("keyboard", keyboard)
+	return c.call(ctx, "messages.edit", params, nil)
+}
+
+// MessagesDelete deletes messageID (a GLOBAL message id) in peerID for everyone
+// (delete_for_all=1).
+func (c *Client) MessagesDelete(ctx context.Context, peerID, messageID int64) error {
+	params := url.Values{}
+	params.Set("peer_id", strconv.FormatInt(peerID, 10))
+	params.Set("message_ids", strconv.FormatInt(messageID, 10))
+	params.Set("delete_for_all", "1")
+	return c.call(ctx, "messages.delete", params, nil)
+}
+
+// SendMessageEventAnswer acknowledges a callback-button press (a message_event
+// update) so VK clears the button's loading spinner. It carries no visible
+// payload (the Stop action is handled server-side by the Service).
+func (c *Client) SendMessageEventAnswer(ctx context.Context, eventID string, userID, peerID int64) error {
+	params := url.Values{}
+	params.Set("event_id", eventID)
+	params.Set("user_id", strconv.FormatInt(userID, 10))
+	params.Set("peer_id", strconv.FormatInt(peerID, 10))
+	return c.call(ctx, "messages.sendMessageEventAnswer", params, nil)
+}
+
+// docUploadServer is the docs.getMessagesUploadServer response.
+type docUploadServer struct {
+	UploadURL string `json:"upload_url"` //nolint:tagliatelle // VK API uses snake_case.
+}
+
+// docSaved is the docs.save response: a typed wrapper around the saved doc.
+type docSaved struct {
+	Type string `json:"type"`
+	Doc  struct {
+		ID      int64 `json:"id"`
+		OwnerID int64 `json:"owner_id"` //nolint:tagliatelle // VK API uses snake_case.
+	} `json:"doc"`
+}
+
+// UploadDocument runs VK's three-step document upload for a message attachment:
+// docs.getMessagesUploadServer (type=doc, peer_id) → multipart POST the streamed
+// file to upload_url as field "file" → docs.save. It returns the attachment spec
+// "doc{owner_id}_{id}" to pass to MessagesSend. The file is STREAMED (io.Reader),
+// never written to a token-bearing URL.
+func (c *Client) UploadDocument(ctx context.Context, peerID int64, name string, data io.Reader) (string, error) {
+	server, err := c.docsGetMessagesUploadServer(ctx, peerID)
+	if err != nil {
+		return "", err
+	}
+	uploaded, err := c.uploadFile(ctx, server.UploadURL, name, data)
+	if err != nil {
+		return "", err
+	}
+	saved, err := c.docsSave(ctx, uploaded)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("doc%d_%d", saved.Doc.OwnerID, saved.Doc.ID), nil
+}
+
+// docsGetMessagesUploadServer fetches a one-shot document upload URL for peerID.
+func (c *Client) docsGetMessagesUploadServer(ctx context.Context, peerID int64) (docUploadServer, error) {
+	params := url.Values{}
+	params.Set("type", "doc")
+	params.Set("peer_id", strconv.FormatInt(peerID, 10))
+	var server docUploadServer
+	if err := c.call(ctx, "docs.getMessagesUploadServer", params, &server); err != nil {
+		return docUploadServer{}, err
+	}
+	return server, nil
+}
+
+// uploadFileResult is the upload server's response: an opaque "file" token passed
+// on to docs.save.
+type uploadFileResult struct {
+	File  string `json:"file"`
+	Error string `json:"error"`
+}
+
+// uploadFile POSTs data as multipart field "file" to the (one-shot, non-token)
+// upload URL, returning the opaque file token for docs.save. The upload URL is a
+// short-lived VK CDN URL with its own key — it carries no community token — but
+// any transport error still has its URL redacted for consistency.
+func (c *Client) uploadFile(ctx context.Context, uploadURL, name string, data io.Reader) (uploadFileResult, error) {
+	pr, pw := io.Pipe()
+	mw := multipart.NewWriter(pw)
+	go func() {
+		part, err := mw.CreateFormFile("file", name)
+		if err != nil {
+			_ = pw.CloseWithError(err)
+			return
+		}
+		if _, err := io.Copy(part, data); err != nil {
+			_ = pw.CloseWithError(err)
+			return
+		}
+		_ = pw.CloseWithError(mw.Close())
+	}()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, uploadURL, pr)
+	if err != nil {
+		return uploadFileResult{}, fmt.Errorf("build upload request: %w", redactURLError(err))
+	}
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+
+	resp, err := c.httpClient().Do(req)
+	if err != nil {
+		return uploadFileResult{}, fmt.Errorf("upload file: %w", redactURLError(err))
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxAPIResponseBytes))
+	if err != nil {
+		return uploadFileResult{}, fmt.Errorf("read upload response: %w", err)
+	}
+	var out uploadFileResult
+	if err := json.Unmarshal(body, &out); err != nil {
+		return uploadFileResult{}, fmt.Errorf("decode upload response: %w", err)
+	}
+	if out.File == "" {
+		return uploadFileResult{}, fmt.Errorf("upload returned no file token (error=%q)", out.Error)
+	}
+	return out, nil
+}
+
+// docsSave persists the uploaded file token, returning the saved doc descriptor
+// used to build the attachment spec.
+func (c *Client) docsSave(ctx context.Context, uploaded uploadFileResult) (docSaved, error) {
+	params := url.Values{}
+	params.Set("file", uploaded.File)
+	var saved docSaved
+	if err := c.call(ctx, "docs.save", params, &saved); err != nil {
+		return docSaved{}, err
+	}
+	return saved, nil
+}
+
+// redactURLError replaces a *url.Error (whose Error() includes the request URL)
+// with its underlying cause so a URL never reaches a log or a user-facing error.
+// Mirrors adapters/telegram/voice.go's discipline.
+func redactURLError(err error) error {
+	var ue *url.Error
+	if errors.As(err, &ue) && ue.Err != nil {
+		return ue.Err
+	}
+	return err
+}

--- a/adapters/vk/api_test.go
+++ b/adapters/vk/api_test.go
@@ -1,0 +1,209 @@
+//nolint:testpackage // intentionally whitebox to test unexported VK client internals
+package vk
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// testBodyLimit bounds request bodies in the fake servers (keeps gosec G120 happy
+// and matches the tiny payloads the tests send).
+const testBodyLimit = 4 << 20 // 4 MiB
+
+// recordingServer is a fake api.vk.com that records each method call's form
+// params and replies with a canned JSON envelope keyed by method name.
+type recordingServer struct {
+	srv     *httptest.Server
+	mu      chan struct{} // serializes access to calls (1-buffered as a mutex)
+	calls   map[string][]url.Values
+	replies map[string]string
+}
+
+func newRecordingServer(t *testing.T, replies map[string]string) *recordingServer {
+	t.Helper()
+	rs := &recordingServer{
+		calls:   map[string][]url.Values{},
+		replies: replies,
+		mu:      make(chan struct{}, 1),
+	}
+	rs.mu <- struct{}{}
+	rs.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		method := strings.TrimPrefix(r.URL.Path, "/")
+		r.Body = http.MaxBytesReader(w, r.Body, testBodyLimit)
+		_ = r.ParseForm()
+		<-rs.mu
+		rs.calls[method] = append(rs.calls[method], r.Form)
+		reply, ok := rs.replies[method]
+		rs.mu <- struct{}{}
+		if !ok {
+			http.Error(w, "no canned reply for "+method, http.StatusInternalServerError)
+			return
+		}
+		_, _ = io.WriteString(w, reply)
+	}))
+	t.Cleanup(rs.srv.Close)
+	return rs
+}
+
+// client returns a Client pointed at the fake server (trailing slash so method
+// names append cleanly).
+func (rs *recordingServer) client(token string) *Client {
+	return &Client{Token: token, BaseURL: rs.srv.URL + "/", HTTPClient: rs.srv.Client()}
+}
+
+// last returns the most recent recorded params for method.
+func (rs *recordingServer) last(method string) url.Values {
+	<-rs.mu
+	defer func() { rs.mu <- struct{}{} }()
+	c := rs.calls[method]
+	if len(c) == 0 {
+		return nil
+	}
+	return c[len(c)-1]
+}
+
+func (rs *recordingServer) count(method string) int {
+	<-rs.mu
+	defer func() { rs.mu <- struct{}{} }()
+	return len(rs.calls[method])
+}
+
+func TestMessagesSendParams(t *testing.T) {
+	rs := newRecordingServer(t, map[string]string{
+		"messages.send": `{"response": 4242}`,
+	})
+	c := rs.client("secret-token")
+
+	msgID, err := c.MessagesSend(context.Background(), 100, "hello", 777, `{"inline":true}`, "")
+	if err != nil {
+		t.Fatalf("MessagesSend: %v", err)
+	}
+	if msgID != 4242 {
+		t.Errorf("message id = %d, want 4242", msgID)
+	}
+	got := rs.last("messages.send")
+	if got.Get("peer_id") != "100" {
+		t.Errorf("peer_id = %q, want 100", got.Get("peer_id"))
+	}
+	if got.Get("message") != "hello" {
+		t.Errorf("message = %q, want hello", got.Get("message"))
+	}
+	if got.Get("random_id") != "777" {
+		t.Errorf("random_id = %q, want 777", got.Get("random_id"))
+	}
+	if got.Get("keyboard") != `{"inline":true}` {
+		t.Errorf("keyboard = %q, want the inline JSON", got.Get("keyboard"))
+	}
+	if got.Get("access_token") != "secret-token" {
+		t.Errorf("access_token form field = %q, want secret-token", got.Get("access_token"))
+	}
+	if got.Get("v") != apiVersion {
+		t.Errorf("v = %q, want %s", got.Get("v"), apiVersion)
+	}
+}
+
+func TestMessagesEditAndDeleteParams(t *testing.T) {
+	rs := newRecordingServer(t, map[string]string{
+		"messages.edit":   `{"response": 1}`,
+		"messages.delete": `{"response": {"123": 1}}`,
+	})
+	c := rs.client("tok")
+
+	if err := c.MessagesEdit(context.Background(), 100, 55, "edited", ""); err != nil {
+		t.Fatalf("MessagesEdit: %v", err)
+	}
+	edit := rs.last("messages.edit")
+	if edit.Get("peer_id") != "100" || edit.Get("message_id") != "55" || edit.Get("message") != "edited" {
+		t.Errorf("edit params = %v, want peer_id=100 message_id=55 message=edited", edit)
+	}
+	// Empty keyboard must still be SENT (clears markup on the final answer).
+	if _, ok := edit["keyboard"]; !ok {
+		t.Error("edit did not send a keyboard field; empty keyboard must be sent to clear markup")
+	}
+
+	if err := c.MessagesDelete(context.Background(), 100, 55); err != nil {
+		t.Fatalf("MessagesDelete: %v", err)
+	}
+	del := rs.last("messages.delete")
+	if del.Get("message_ids") != "55" || del.Get("delete_for_all") != "1" {
+		t.Errorf("delete params = %v, want message_ids=55 delete_for_all=1", del)
+	}
+}
+
+func TestAPIErrorEnvelope(t *testing.T) {
+	rs := newRecordingServer(t, map[string]string{
+		"messages.send": `{"error": {"error_code": 9, "error_msg": "Flood control"}}`,
+	})
+	c := rs.client("tok")
+	_, err := c.MessagesSend(context.Background(), 1, "x", 1, "", "")
+	if err == nil {
+		t.Fatal("MessagesSend on error envelope = nil, want *apiError")
+	}
+	var ae *apiError
+	if !errors.As(err, &ae) {
+		t.Fatalf("error = %T, want *apiError", err)
+	}
+	if ae.Code != 9 {
+		t.Errorf("error code = %d, want 9", ae.Code)
+	}
+}
+
+func TestUploadDocumentThreeStepDance(t *testing.T) {
+	rs := newRecordingServer(t, nil)
+	// The upload server is a separate endpoint; point docs.getMessagesUploadServer
+	// at it.
+	uploadSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Assert the multipart "file" field is present and streamed.
+		r.Body = http.MaxBytesReader(w, r.Body, testBodyLimit)
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		f, _, err := r.FormFile("file")
+		if err != nil {
+			http.Error(w, "no file field", http.StatusBadRequest)
+			return
+		}
+		defer func() { _ = f.Close() }()
+		_, _ = io.WriteString(w, `{"file": "uploaded-file-token"}`)
+	}))
+	t.Cleanup(uploadSrv.Close)
+
+	rs.replies = map[string]string{
+		"docs.getMessagesUploadServer": `{"response": {"upload_url": "` + uploadSrv.URL + `"}}`,
+		"docs.save":                    `{"response": {"type": "doc", "doc": {"id": 555, "owner_id": -100}}}`,
+		"messages.send":                `{"response": 9001}`,
+	}
+	c := rs.client("tok")
+
+	attachment, err := c.UploadDocument(context.Background(), 200, "report.pdf", strings.NewReader("FILEDATA"))
+	if err != nil {
+		t.Fatalf("UploadDocument: %v", err)
+	}
+	if attachment != "doc-100_555" {
+		t.Errorf("attachment = %q, want doc-100_555", attachment)
+	}
+	if rs.count("docs.getMessagesUploadServer") != 1 || rs.count("docs.save") != 1 {
+		t.Errorf("expected one getMessagesUploadServer + one docs.save, got %d + %d",
+			rs.count("docs.getMessagesUploadServer"), rs.count("docs.save"))
+	}
+	if got := rs.last("docs.save").Get("file"); got != "uploaded-file-token" {
+		t.Errorf("docs.save file token = %q, want uploaded-file-token", got)
+	}
+}
+
+// mustUnmarshal is a guard that JSON we build parses back to the expected shape
+// (used by bot_test for the keyboard JSON).
+func mustUnmarshal(t *testing.T, data string, v any) {
+	t.Helper()
+	if err := json.Unmarshal([]byte(data), v); err != nil {
+		t.Fatalf("unmarshal %q: %v", data, err)
+	}
+}

--- a/adapters/vk/bot.go
+++ b/adapters/vk/bot.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"log/slog"
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -32,6 +34,10 @@ type botChat struct {
 	groupID  int64
 	randSeed int64
 	randSeq  atomic.Uint64
+	// kbDisabledOnce guards the one-shot WARN log emitted the first time the VK
+	// "Bot abilities" toggle (error 912) forces a keyboard-less resend, so a
+	// misconfigured community does not spam the log on every progress message.
+	kbDisabledOnce sync.Once
 }
 
 // NewBotChat adapts a VK *Client to the core/chat.Transport interface. groupID is
@@ -89,7 +95,17 @@ func parseMessageID(messageID chat.MessageID) int64 {
 func (c *botChat) Send(
 	ctx context.Context, chatID chat.ChatID, text, stopRunID string, _ bool,
 ) (chat.MessageID, error) {
-	msgID, err := c.api.MessagesSend(ctx, parsePeerID(chatID), text, c.nextRandomID(), stopKeyboard(stopRunID), "")
+	peerID := parsePeerID(chatID)
+	keyboard := stopKeyboard(stopRunID)
+	msgID, err := c.api.MessagesSend(ctx, peerID, text, c.nextRandomID(), keyboard, "")
+	// VK error 912: the community has "Bot abilities" OFF, so a keyboard'd send is
+	// rejected while the same send WITHOUT a keyboard succeeds. Retry once without
+	// the keyboard (Stop then falls back to the /stop text command); the message
+	// must still be delivered. Only retry when a keyboard was actually attached.
+	if err != nil && keyboard != "" && isBotFeatureDisabled(err) {
+		c.warnKeyboardsDisabled()
+		msgID, err = c.api.MessagesSend(ctx, peerID, text, c.nextRandomID(), "", "")
+	}
 	if err != nil {
 		return "", err
 	}
@@ -102,7 +118,29 @@ func (c *botChat) Send(
 func (c *botChat) Edit(
 	ctx context.Context, chatID chat.ChatID, messageID chat.MessageID, text, stopRunID string, _ bool,
 ) error {
-	return c.api.MessagesEdit(ctx, parsePeerID(chatID), parseMessageID(messageID), text, stopKeyboard(stopRunID))
+	peerID := parsePeerID(chatID)
+	msgID := parseMessageID(messageID)
+	keyboard := stopKeyboard(stopRunID)
+	err := c.api.MessagesEdit(ctx, peerID, msgID, text, keyboard)
+	// VK error 912: see Send. Retry the edit once without the keyboard so progress
+	// keeps updating even when the community's "Bot abilities" toggle is OFF. Only
+	// retry when a keyboard was actually attached (an empty keyboard clears markup
+	// and never triggers 912).
+	if err != nil && keyboard != "" && isBotFeatureDisabled(err) {
+		c.warnKeyboardsDisabled()
+		err = c.api.MessagesEdit(ctx, peerID, msgID, text, "")
+	}
+	return err
+}
+
+// warnKeyboardsDisabled logs a single WARN line the first time error 912 forces a
+// keyboard-less resend, pointing at the community-side fix. The sync.Once keeps a
+// misconfigured community from spamming the log on every progress message.
+func (c *botChat) warnKeyboardsDisabled() {
+	c.kbDisabledOnce.Do(func() {
+		slog.Default().Warn("vk: bot keyboards disabled for this community (error 912); " +
+			"sending without Stop button — enable 'Bot abilities' in community settings")
+	})
 }
 
 // StreamDraft is unsupported on VK: it has no ephemeral live-draft primitive, so

--- a/adapters/vk/bot.go
+++ b/adapters/vk/bot.go
@@ -1,0 +1,214 @@
+package vk
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"strconv"
+	"sync/atomic"
+	"time"
+
+	"github.com/duckbugio/flock/core/chat"
+)
+
+// vkMaxMessageRunes is VK's per-message length cap in runes, reported via
+// Capabilities so the neutral chunker is parameterized rather than hardcoded.
+// VK's documented limit is 4096; this is a §6 UNKNOWN to live-confirm with a
+// real token (see the report / .team/memory.md).
+const vkMaxMessageRunes = 4096
+
+// floodBackoff is the fixed delay the RetryAfter seam asks the Service to wait
+// after a VK flood/rate error (codes 6/9). VK returns no Retry-After header, so a
+// small fixed back-off is used; the Service caps and retries terminal delivery.
+const floodBackoff = time.Second
+
+// botChat implements core/chat.Transport over a VK *Client. It converts VK's
+// native int64 peer/message ids to and from the string ChatID/MessageID the
+// neutral layer uses, renders the Stop inline keyboard, and generates a unique
+// random_id per send.
+type botChat struct {
+	api      *Client
+	groupID  int64
+	randSeed int64
+	randSeq  atomic.Uint64
+}
+
+// NewBotChat adapts a VK *Client to the core/chat.Transport interface. groupID is
+// the community id (used elsewhere for the mention parse); randSeed seeds the
+// per-adapter random_id generator — production passes a monotonic seed, tests
+// pass a fixed seed for deterministic random_ids (VK dedupes a repeated random_id
+// within ~1h, so it only needs to be unique, not unpredictable).
+func NewBotChat(api *Client, groupID, randSeed int64) chat.Transport {
+	return &botChat{api: api, groupID: groupID, randSeed: randSeed}
+}
+
+// Capabilities reports VK's feature set: it can edit messages (messages.edit),
+// render an inline Stop button (callback keyboard + message_event), send
+// documents (the docs.* dance), and its message cap is 4096 runes. With every
+// flag true the neutral Service drives the full live-progress + Stop-button +
+// outbox path, exactly as on Telegram.
+func (c *botChat) Capabilities() chat.Capabilities {
+	return chat.Capabilities{
+		CanEditMessages: true,
+		CanInlineStop:   true,
+		CanSendDocument: true,
+		MaxMessageRunes: vkMaxMessageRunes,
+	}
+}
+
+// nextRandomID returns a process-unique int64 random_id: the per-adapter seed
+// mixed with a monotonic counter, so two sends never collide (VK silently
+// dedupes a repeated random_id within ~1h). It is deterministic given a fixed
+// seed, which keeps tests reproducible.
+func (c *botChat) nextRandomID() int64 {
+	n := c.randSeq.Add(1)
+	//nolint:gosec // G115: deliberate wrap into the signed random_id space; uniqueness, not range, is what matters.
+	return c.randSeed + int64(n)
+}
+
+// parsePeerID converts the neutral string chat id back to VK's int64 peer id. A
+// non-numeric id (which VK never produces) maps to 0, surfacing the misuse rather
+// than silently targeting peer 0.
+func parsePeerID(chatID chat.ChatID) int64 {
+	id, _ := strconv.ParseInt(chatID, 10, 64)
+	return id
+}
+
+// parseMessageID converts the neutral string message id back to VK's int64
+// global message id.
+func parseMessageID(messageID chat.MessageID) int64 {
+	id, _ := strconv.ParseInt(messageID, 10, 64)
+	return id
+}
+
+// Send posts a new message to chatID. When stopRunID is non-empty it renders the
+// inline Stop keyboard bound to that run; empty sends no keyboard. asMarkdown is
+// IGNORED — VK has no HTML/Markdown parse mode, so the text is always sent
+// verbatim. It returns the GLOBAL message id (what Edit/Delete address).
+func (c *botChat) Send(
+	ctx context.Context, chatID chat.ChatID, text, stopRunID string, _ bool,
+) (chat.MessageID, error) {
+	msgID, err := c.api.MessagesSend(ctx, parsePeerID(chatID), text, c.nextRandomID(), stopKeyboard(stopRunID), "")
+	if err != nil {
+		return "", err
+	}
+	return strconv.FormatInt(msgID, 10), nil
+}
+
+// Edit updates messageID in place. A non-empty stopRunID keeps the Stop keyboard;
+// empty clears it (the final answer carries no markup). asMarkdown is IGNORED
+// (VK has no parse mode).
+func (c *botChat) Edit(
+	ctx context.Context, chatID chat.ChatID, messageID chat.MessageID, text, stopRunID string, _ bool,
+) error {
+	return c.api.MessagesEdit(ctx, parsePeerID(chatID), parseMessageID(messageID), text, stopKeyboard(stopRunID))
+}
+
+// StreamDraft is unsupported on VK: it has no ephemeral live-draft primitive, so
+// this returns an error unconditionally. The Service treats that as "drafts
+// unsupported" and falls back to editing the anchor message (the rate-limited
+// progress path), exactly as on a platform without drafts.
+func (c *botChat) StreamDraft(_ context.Context, _ chat.ChatID, _, _ string, _ bool) error {
+	return errDraftUnsupported
+}
+
+// errDraftUnsupported signals the Service that VK cannot stream an ephemeral
+// draft, so it should drive progress via Edit instead.
+var errDraftUnsupported = errors.New("vk: live draft preview unsupported; use message edits")
+
+// Delete removes messageID for everyone; failures are non-fatal to the caller.
+func (c *botChat) Delete(ctx context.Context, chatID chat.ChatID, messageID chat.MessageID) error {
+	return c.api.MessagesDelete(ctx, parsePeerID(chatID), parseMessageID(messageID))
+}
+
+// SendDocument uploads a local file to chatID as a VK document attachment via the
+// three-step docs.* dance, then sends a message carrying it. The data is streamed
+// (no token-bearing URL constructed). Used by the outbox.
+func (c *botChat) SendDocument(ctx context.Context, chatID chat.ChatID, name string, data io.Reader) error {
+	peerID := parsePeerID(chatID)
+	attachment, err := c.api.UploadDocument(ctx, peerID, name, data)
+	if err != nil {
+		return err
+	}
+	_, err = c.api.MessagesSend(ctx, peerID, "", c.nextRandomID(), "", attachment)
+	return err
+}
+
+// SendStarNudge posts the post-task star-nudge message with the inline confirm
+// button (a callback keyboard whose payload triggers the star action), mirroring
+// the Telegram nudge's separate-seam shape. It returns the new global message id.
+func (c *botChat) SendStarNudge(ctx context.Context, chatID chat.ChatID, text string) (chat.MessageID, error) {
+	msgID, err := c.api.MessagesSend(ctx, parsePeerID(chatID), text, c.nextRandomID(), starKeyboard(), "")
+	if err != nil {
+		return "", err
+	}
+	return strconv.FormatInt(msgID, 10), nil
+}
+
+// RetryAfter reports a fixed back-off when err is a VK flood/rate error (code 6
+// "too many requests" or code 9 "flood control"). VK sends no Retry-After header,
+// so a small fixed delay is used. It is wired into core/chat.Config.RetryAfter so
+// the neutral run loop throttles its edit fallback and backs off terminal
+// delivery without importing VK's error types.
+func RetryAfter(err error) (time.Duration, bool) {
+	var ae *apiError
+	if errors.As(err, &ae) && (ae.Code == errCodeTooManyRequests || ae.Code == errCodeFloodControl) {
+		return floodBackoff, true
+	}
+	return 0, false
+}
+
+// stopKeyboard returns the JSON for a VK inline keyboard carrying a single
+// callback Stop button bound to runID, or "" when runID is empty (final messages
+// carry no keyboard). The payload is {"stop":"<runID>"}, parsed back by the
+// message_event handler into a Service Stop.
+func stopKeyboard(runID string) string {
+	if runID == "" {
+		return ""
+	}
+	return keyboardJSON("⏹ Stop", stopPayload(runID), "negative")
+}
+
+// starKeyboard returns the JSON for the star-nudge confirm keyboard: a single
+// callback button whose payload triggers the star action.
+func starKeyboard() string {
+	return keyboardJSON(starButtonText, starPayloadJSON(), "positive")
+}
+
+// vkKeyboard / vkButton / vkAction model VK's inline keyboard JSON so it is built
+// with encoding/json (correct escaping) rather than fragile string concatenation.
+type vkKeyboard struct {
+	Inline  bool         `json:"inline"`
+	Buttons [][]vkButton `json:"buttons"`
+}
+
+type vkButton struct {
+	Action vkAction `json:"action"`
+	Color  string   `json:"color"`
+}
+
+type vkAction struct {
+	Type    string `json:"type"`
+	Label   string `json:"label"`
+	Payload string `json:"payload"`
+}
+
+// keyboardJSON builds a one-button inline callback keyboard. The payload is a
+// JSON string (VK requires the payload be valid JSON; we pass a JSON object
+// encoded as a string).
+func keyboardJSON(label, payload, color string) string {
+	kb := vkKeyboard{
+		Inline: true,
+		Buttons: [][]vkButton{{
+			{Action: vkAction{Type: "callback", Label: label, Payload: payload}, Color: color},
+		}},
+	}
+	b, err := json.Marshal(kb)
+	if err != nil {
+		// The struct is fixed-shape and always marshalable; on the impossible error
+		// path return "" so the message still sends without a keyboard.
+		return ""
+	}
+	return string(b)
+}

--- a/adapters/vk/bot_test.go
+++ b/adapters/vk/bot_test.go
@@ -1,0 +1,162 @@
+//nolint:testpackage // intentionally whitebox to test unexported VK transport internals
+package vk
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/duckbugio/flock/core/chat"
+)
+
+func TestCapabilities(t *testing.T) {
+	c := NewBotChat(NewClient("tok"), 100, 1)
+	caps := c.Capabilities()
+	if !caps.CanEditMessages || !caps.CanInlineStop || !caps.CanSendDocument {
+		t.Errorf("capabilities = %+v, want all-true feature flags", caps)
+	}
+	if caps.MaxMessageRunes != vkMaxMessageRunes {
+		t.Errorf("MaxMessageRunes = %d, want %d", caps.MaxMessageRunes, vkMaxMessageRunes)
+	}
+}
+
+func TestSendRendersStopKeyboardAndUniqueRandomID(t *testing.T) {
+	rs := newRecordingServer(t, map[string]string{
+		"messages.send": `{"response": 7}`,
+	})
+	api := rs.client("tok")
+	c := NewBotChat(api, 100, 1000) // fixed seed → deterministic random_ids
+
+	// With a stopRunID, a callback Stop keyboard must be rendered.
+	if _, err := c.Send(context.Background(), "200", "working", "run-42", true); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	first := rs.last("messages.send")
+	kb := first.Get("keyboard")
+	if kb == "" {
+		t.Fatal("Send with stopRunID rendered no keyboard")
+	}
+	var parsed vkKeyboard
+	mustUnmarshal(t, kb, &parsed)
+	if !parsed.Inline || len(parsed.Buttons) != 1 || len(parsed.Buttons[0]) != 1 {
+		t.Fatalf("keyboard shape = %+v, want one inline callback button", parsed)
+	}
+	btn := parsed.Buttons[0][0]
+	if btn.Action.Type != "callback" || btn.Color != "negative" {
+		t.Errorf("button = %+v, want callback/negative", btn)
+	}
+	var pl callbackPayload
+	mustUnmarshal(t, btn.Action.Payload, &pl)
+	if pl.Stop != "run-42" {
+		t.Errorf("payload.stop = %q, want run-42", pl.Stop)
+	}
+	firstRandom := first.Get("random_id")
+
+	// A second send (empty stopRunID → no keyboard) must use a DIFFERENT random_id.
+	if _, err := c.Send(context.Background(), "200", "final", "", true); err != nil {
+		t.Fatalf("second Send: %v", err)
+	}
+	second := rs.last("messages.send")
+	if second.Get("keyboard") != "" {
+		t.Errorf("Send with empty stopRunID rendered a keyboard %q, want none", second.Get("keyboard"))
+	}
+	if second.Get("random_id") == firstRandom {
+		t.Errorf("two sends reused random_id %q; must be unique", firstRandom)
+	}
+}
+
+func TestEditClearsKeyboardOnFinal(t *testing.T) {
+	rs := newRecordingServer(t, map[string]string{"messages.edit": `{"response": 1}`})
+	c := NewBotChat(rs.client("tok"), 100, 1)
+
+	if err := c.Edit(context.Background(), "200", "55", "final answer", "", true); err != nil {
+		t.Fatalf("Edit: %v", err)
+	}
+	got := rs.last("messages.edit")
+	if got.Get("message_id") != "55" || got.Get("message") != "final answer" {
+		t.Errorf("edit params = %v", got)
+	}
+	if got.Get("keyboard") != "" {
+		t.Errorf("final edit keyboard = %q, want empty (markup cleared)", got.Get("keyboard"))
+	}
+}
+
+func TestSendDocumentUploadsThenSends(t *testing.T) {
+	// Reuse the three-step dance asserted in api_test, but through the Transport.
+	rs := newRecordingServer(t, nil)
+	uploadSrv := newUploadServer(t)
+	rs.replies = map[string]string{
+		"docs.getMessagesUploadServer": `{"response": {"upload_url": "` + uploadSrv + `"}}`,
+		"docs.save":                    `{"response": {"type": "doc", "doc": {"id": 5, "owner_id": -100}}}`,
+		"messages.send":                `{"response": 1}`,
+	}
+	c := NewBotChat(rs.client("tok"), 100, 1)
+
+	if err := c.SendDocument(context.Background(), "200", "out.txt", strings.NewReader("DATA")); err != nil {
+		t.Fatalf("SendDocument: %v", err)
+	}
+	send := rs.last("messages.send")
+	if send.Get("attachment") != "doc-100_5" {
+		t.Errorf("send attachment = %q, want doc-100_5", send.Get("attachment"))
+	}
+}
+
+func TestStreamDraftUnsupported(t *testing.T) {
+	c := NewBotChat(NewClient("tok"), 100, 1)
+	err := c.StreamDraft(context.Background(), "200", "draft", "frame", true)
+	if !errors.Is(err, errDraftUnsupported) {
+		t.Errorf("StreamDraft error = %v, want errDraftUnsupported (Service falls back to Edit)", err)
+	}
+}
+
+func TestRetryAfterClassifiesFloodErrors(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		err    error
+		wantOK bool
+	}{
+		{"flood control 9", &apiError{Code: 9, Msg: "Flood control"}, true},
+		{"too many requests 6", &apiError{Code: 6, Msg: "Too many requests"}, true},
+		{"other api error", &apiError{Code: 100, Msg: "param error"}, false},
+		{"non-api error", errors.New("boom"), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d, ok := RetryAfter(tc.err)
+			if ok != tc.wantOK {
+				t.Fatalf("RetryAfter ok = %v, want %v", ok, tc.wantOK)
+			}
+			if ok && d != floodBackoff {
+				t.Errorf("RetryAfter delay = %v, want %v", d, floodBackoff)
+			}
+		})
+	}
+}
+
+// Compile-time assertion that botChat satisfies the Transport contract.
+var _ chat.Transport = (*botChat)(nil)
+
+// newUploadServer returns the URL of a fake VK doc upload endpoint that accepts a
+// multipart "file" field and returns a fixed file token.
+func newUploadServer(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, testBodyLimit)
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		f, _, err := r.FormFile("file")
+		if err != nil {
+			http.Error(w, "no file field", http.StatusBadRequest)
+			return
+		}
+		defer func() { _ = f.Close() }()
+		_, _ = io.WriteString(w, `{"file": "uploaded-file-token"}`)
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}

--- a/adapters/vk/bot_test.go
+++ b/adapters/vk/bot_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -133,6 +134,109 @@ func TestRetryAfterClassifiesFloodErrors(t *testing.T) {
 				t.Errorf("RetryAfter delay = %v, want %v", d, floodBackoff)
 			}
 		})
+	}
+}
+
+// keyboardGatedServer is a fake api.vk.com that rejects any call carrying a
+// non-empty "keyboard" form field with VK error 912 ("Bot abilities" toggle OFF)
+// and succeeds otherwise — modelling the live finding that a keyboard'd send/edit
+// fails while the same call without a keyboard goes through. It records every
+// call so a test can assert the retry happened and dropped the keyboard.
+func keyboardGatedServer(t *testing.T, successReply string) *recordingServer {
+	t.Helper()
+	rs := &recordingServer{
+		calls: map[string][]url.Values{},
+		mu:    make(chan struct{}, 1),
+	}
+	rs.mu <- struct{}{}
+	rs.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		method := strings.TrimPrefix(r.URL.Path, "/")
+		r.Body = http.MaxBytesReader(w, r.Body, testBodyLimit)
+		_ = r.ParseForm()
+		<-rs.mu
+		rs.calls[method] = append(rs.calls[method], r.Form)
+		rs.mu <- struct{}{}
+		if r.Form.Get("keyboard") != "" {
+			_, _ = io.WriteString(w, `{"error": {"error_code": 912, "error_msg": "This is a chat bot feature"}}`)
+			return
+		}
+		_, _ = io.WriteString(w, successReply)
+	}))
+	t.Cleanup(rs.srv.Close)
+	return rs
+}
+
+func TestSendRetriesWithoutKeyboardOn912(t *testing.T) {
+	rs := keyboardGatedServer(t, `{"response": 77}`)
+	c := NewBotChat(rs.client("tok"), 100, 1)
+
+	id, err := c.Send(context.Background(), "200", "working", "run-1", true)
+	if err != nil {
+		t.Fatalf("Send after 912 fallback = %v, want nil", err)
+	}
+	if id != "77" {
+		t.Errorf("delivered message id = %q, want 77 (the keyboard-less resend)", id)
+	}
+	if got := rs.count("messages.send"); got != 2 {
+		t.Fatalf("messages.send call count = %d, want 2 (keyboard'd attempt + keyboard-less retry)", got)
+	}
+	first := rs.calls["messages.send"][0]
+	if first.Get("keyboard") == "" {
+		t.Error("first send carried no keyboard; the 912 path requires a keyboard'd attempt")
+	}
+	second := rs.calls["messages.send"][1]
+	if second.Get("keyboard") != "" {
+		t.Errorf("retry send keyboard = %q, want empty (Stop button dropped)", second.Get("keyboard"))
+	}
+	if second.Get("message") != "working" {
+		t.Errorf("retry send message = %q, want the original text", second.Get("message"))
+	}
+}
+
+func TestEditRetriesWithoutKeyboardOn912(t *testing.T) {
+	rs := keyboardGatedServer(t, `{"response": 1}`)
+	c := NewBotChat(rs.client("tok"), 100, 1)
+
+	if err := c.Edit(context.Background(), "200", "55", "progress", "run-1", true); err != nil {
+		t.Fatalf("Edit after 912 fallback = %v, want nil", err)
+	}
+	if got := rs.count("messages.edit"); got != 2 {
+		t.Fatalf("messages.edit call count = %d, want 2 (keyboard'd attempt + keyboard-less retry)", got)
+	}
+	if got := rs.calls["messages.edit"][1].Get("keyboard"); got != "" {
+		t.Errorf("retry edit keyboard = %q, want empty (Stop button dropped)", got)
+	}
+}
+
+func TestSendDoesNotRetryNon912(t *testing.T) {
+	// A non-912 error from a keyboard'd send must propagate unchanged, with no
+	// second attempt.
+	rs := newRecordingServer(t, map[string]string{
+		"messages.send": `{"error": {"error_code": 100, "error_msg": "param error"}}`,
+	})
+	c := NewBotChat(rs.client("tok"), 100, 1)
+
+	if _, err := c.Send(context.Background(), "200", "working", "run-1", true); err == nil {
+		t.Fatal("Send on non-912 error = nil, want the error propagated")
+	}
+	if got := rs.count("messages.send"); got != 1 {
+		t.Errorf("messages.send call count = %d, want 1 (no retry for non-912)", got)
+	}
+}
+
+func TestSendDoesNotRetryWhenNoKeyboard(t *testing.T) {
+	// A keyboard-less send that somehow returns 912 must NOT trigger a pointless
+	// double-send (there is no keyboard to drop).
+	rs := newRecordingServer(t, map[string]string{
+		"messages.send": `{"error": {"error_code": 912, "error_msg": "This is a chat bot feature"}}`,
+	})
+	c := NewBotChat(rs.client("tok"), 100, 1)
+
+	if _, err := c.Send(context.Background(), "200", "final", "", true); err == nil {
+		t.Fatal("keyboard-less Send on 912 = nil, want the error propagated")
+	}
+	if got := rs.count("messages.send"); got != 1 {
+		t.Errorf("messages.send call count = %d, want 1 (no retry without a keyboard)", got)
 	}
 }
 

--- a/adapters/vk/commands.go
+++ b/adapters/vk/commands.go
@@ -1,0 +1,9 @@
+package vk
+
+// HelpText is the static usage message for the VK adapter. It mirrors the
+// Telegram adapter's HelpText but reflects VK's command surface: VK has no native
+// slash-command UI, so /stop is the universal text fallback for cancelling a run.
+// It is an engineering artifact (professional English, no duck flavor).
+const HelpText = "DuckFlock VK assistant — usage:\n\n" +
+	"/stop — stop the run currently in progress\n\n" +
+	"Send any other message to run it through the assistant."

--- a/adapters/vk/longpoll.go
+++ b/adapters/vk/longpoll.go
@@ -1,0 +1,170 @@
+package vk
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+// longPollWait is the Bots Long Poll wait window (seconds) — how long the server
+// holds an a_check request open before returning an empty update set.
+const longPollWait = 25
+
+// pollBackoff is the delay before retrying after a transient HTTP/transport error
+// in the receive loop, so a flapping network doesn't spin the loop hot.
+const pollBackoff = 3 * time.Second
+
+// maxLongPollBytes caps a single Long Poll response read.
+const maxLongPollBytes = 16 << 20 // 16 MiB
+
+// VK Long Poll "failed" codes (returned instead of updates):
+//
+//	1 → ts is outdated: continue with the returned ts, reuse key.
+//	2 → key expired: re-fetch the server (new key), keep ts.
+//	3 → information lost: re-fetch the server (new key AND ts).
+const (
+	failedOutdatedTS = 1
+	failedKeyExpired = 2
+	failedInfoLost   = 3
+)
+
+// longPollServer is the groups.getLongPollServer response.
+type longPollServer struct {
+	Key    string `json:"key"`
+	Server string `json:"server"`
+	TS     string `json:"ts"`
+}
+
+// longPollResponse is one a_check result: either updates (+ a new ts) or a failed
+// code (with, for code 1, a new ts to resume from).
+type longPollResponse struct {
+	TS      json.Number `json:"ts"`
+	Updates []update    `json:"updates"`
+	Failed  int         `json:"failed"`
+}
+
+// update is one Long Poll update envelope. Only message_new and message_event are
+// handled; other types are ignored.
+type update struct {
+	Type    string          `json:"type"`
+	Object  json.RawMessage `json:"object"`
+	GroupID int64           `json:"group_id"` //nolint:tagliatelle // VK API uses snake_case.
+}
+
+// messageNewObject is the object of a message_new update.
+type messageNewObject struct {
+	Message messageObject `json:"message"`
+}
+
+// messageObject is a VK message. peer_id is the conversation key; from_id is the
+// sender (negative = a community, ignored); conversation_message_id is the
+// per-conversation id preferred for edits but the run loop keys on it as the
+// neutral MessageID for supersede ordering.
+type messageObject struct {
+	FromID                int64        `json:"from_id"` //nolint:tagliatelle // VK API uses snake_case.
+	PeerID                int64        `json:"peer_id"` //nolint:tagliatelle // VK API uses snake_case.
+	Text                  string       `json:"text"`
+	ID                    int64        `json:"id"`
+	ConversationMessageID int64        `json:"conversation_message_id"` //nolint:tagliatelle // VK API uses snake_case.
+	Date                  int64        `json:"date"`
+	Attachments           []attachment `json:"attachments"`
+}
+
+// messageEventObject is the object of a message_event update (a callback button
+// press): the pressed run's payload plus the ids needed to ack it.
+type messageEventObject struct {
+	UserID                int64           `json:"user_id"`  //nolint:tagliatelle // VK API uses snake_case.
+	PeerID                int64           `json:"peer_id"`  //nolint:tagliatelle // VK API uses snake_case.
+	EventID               string          `json:"event_id"` //nolint:tagliatelle // VK API uses snake_case.
+	Payload               json.RawMessage `json:"payload"`
+	ConversationMessageID int64           `json:"conversation_message_id"` //nolint:tagliatelle // VK API uses snake_case.
+}
+
+// attachment is one message attachment. Only the kinds the download seam handles
+// are modeled (doc, photo, audio_message); other types are ignored.
+type attachment struct {
+	Type         string           `json:"type"`
+	Doc          *docAttachment   `json:"doc"`
+	Photo        *photoAttachment `json:"photo"`
+	AudioMessage *audioMsgAttach  `json:"audio_message"` //nolint:tagliatelle // VK API uses snake_case.
+}
+
+type docAttachment struct {
+	URL   string `json:"url"`
+	Ext   string `json:"ext"`
+	Title string `json:"title"`
+}
+
+type photoAttachment struct {
+	Sizes []photoSize `json:"sizes"`
+}
+
+type photoSize struct {
+	URL    string `json:"url"`
+	Width  int    `json:"width"`
+	Height int    `json:"height"`
+}
+
+type audioMsgAttach struct {
+	LinkOGG  string `json:"link_ogg"` //nolint:tagliatelle // VK API uses snake_case.
+	LinkMP3  string `json:"link_mp3"` //nolint:tagliatelle // VK API uses snake_case.
+	Duration int    `json:"duration"`
+}
+
+// longPoller fetches the Long Poll server descriptor (groups.getLongPollServer)
+// and runs a_check polls. *Client satisfies it; tests use a fake to script the
+// poll responses (so the receive loop is driven deterministically without a real
+// server).
+type longPoller interface {
+	getLongPollServer(ctx context.Context, groupID int64) (longPollServer, error)
+	poll(ctx context.Context, server longPollServer) (longPollResponse, error)
+}
+
+// getLongPollServer fetches a fresh Long Poll server descriptor for groupID.
+func (c *Client) getLongPollServer(ctx context.Context, groupID int64) (longPollServer, error) {
+	params := url.Values{}
+	params.Set("group_id", strconv.FormatInt(groupID, 10))
+	var server longPollServer
+	if err := c.call(ctx, "groups.getLongPollServer", params, &server); err != nil {
+		return longPollServer{}, err
+	}
+	return server, nil
+}
+
+// poll performs one a_check request against the Long Poll server, decoding the
+// response. It is the poll the Receiver's Run loop calls via the longPoller
+// interface (separated out so the failed-code handling and the unit tests stay
+// readable). The client and wait window are the Client's.
+func (c *Client) poll(ctx context.Context, server longPollServer) (longPollResponse, error) {
+	params := url.Values{}
+	params.Set("act", "a_check")
+	params.Set("key", server.Key)
+	params.Set("ts", server.TS)
+	params.Set("wait", strconv.Itoa(longPollWait))
+	endpoint := server.Server + "?" + params.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return longPollResponse{}, fmt.Errorf("build poll request: %w", redactURLError(err))
+	}
+	resp, err := c.httpClient().Do(req)
+	if err != nil {
+		return longPollResponse{}, fmt.Errorf("poll: %w", redactURLError(err))
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxLongPollBytes))
+	if err != nil {
+		return longPollResponse{}, fmt.Errorf("read poll response: %w", err)
+	}
+	var out longPollResponse
+	if err := json.Unmarshal(body, &out); err != nil {
+		return longPollResponse{}, fmt.Errorf("decode poll response: %w", err)
+	}
+	return out, nil
+}

--- a/adapters/vk/mention.go
+++ b/adapters/vk/mention.go
@@ -45,22 +45,18 @@ func parseMention(text string, groupID int64) (mentioned bool, stripped string) 
 //
 // Rules (identical to the neutral gate): DMs and groups with requireMention=false
 // are always handled; a group with requireMention=true is handled only when the
-// message mentions this community (or, supplied by the caller, replies to the
-// bot — VK reply detection is handled upstream). The returned cleaned text always
-// has this community's mention stripped, even when handle is false.
-func shouldHandle(isGroup bool, text string, groupID int64, requireMention, replyToBot bool) (handle bool, cleaned string) {
+// message mentions this community. The returned cleaned text always has this
+// community's mention stripped, even when handle is false.
+func shouldHandle(isGroup bool, text string, groupID int64, requireMention bool) (handle bool, cleaned string) {
 	mentioned, cleaned := parseMention(text, groupID)
 
 	// The decision mirrors core/chat.ShouldHandle exactly (DMs and non-require
-	// groups always handled; a require-mention group needs a mention or a reply),
-	// but the addressed/stripped inputs are pre-resolved here because VK mentions
-	// are textual [club<id>|...] tokens, not the entity spans the neutral gate
-	// parses for Telegram — so this is the VK half of the §4 mention-gate split.
+	// groups always handled; a require-mention group needs a mention), but the
+	// addressed/stripped inputs are pre-resolved here because VK mentions are
+	// textual [club<id>|...] tokens, not the entity spans the neutral gate parses
+	// for Telegram — so this is the VK half of the §4 mention-gate split.
 	if !isGroup || !requireMention {
 		return true, cleaned
 	}
-	if replyToBot || mentioned {
-		return true, cleaned
-	}
-	return false, cleaned
+	return mentioned, cleaned
 }

--- a/adapters/vk/mention.go
+++ b/adapters/vk/mention.go
@@ -1,0 +1,66 @@
+package vk
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// mentionPattern matches a VK community mention token: [club<id>|display] or
+// [public<id>|display]. VK renders a mention of a community in message text this
+// way (the leading char is "*" or "@" in some clients, but the canonical bot-API
+// form is the bracketed token). The id group is captured so we only treat a
+// mention of THIS community as addressing the bot.
+var mentionPattern = regexp.MustCompile(`\[(?:club|public)(\d+)\|[^\]]*\]`)
+
+// parseMention reports whether text mentions the community groupID and returns
+// the text with that mention token stripped (and surrounding whitespace
+// trimmed). A mention of a DIFFERENT community is left intact and does not count
+// as addressing the bot. When groupID's mention appears, every occurrence of it
+// is removed and the result is space-collapsed at the edges so Claude sees the
+// user's words without the "[club123|Bot]" noise — mirroring how the Telegram
+// adapter strips a leading @mention before handing text to the gate.
+func parseMention(text string, groupID int64) (mentioned bool, stripped string) {
+	want := strconv.FormatInt(groupID, 10)
+	stripped = mentionPattern.ReplaceAllStringFunc(text, func(tok string) string {
+		m := mentionPattern.FindStringSubmatch(tok)
+		if len(m) == 2 && m[1] == want {
+			mentioned = true
+			return ""
+		}
+		return tok // a different community's mention stays in place
+	})
+	if mentioned {
+		stripped = strings.TrimSpace(stripped)
+	}
+	return mentioned, stripped
+}
+
+// shouldHandle applies the transport-agnostic mention-gate decision to a VK group
+// message, after parsing VK's own [club<id>|...] mention. It mirrors the Telegram
+// adapter's handleMessage shape: the adapter parses the platform mention, then
+// the neutral chat.ShouldHandle makes the decision. Because VK mentions are
+// textual (not entity-spanned like Telegram's), the parse + strip happens here
+// and the result is fed to the gate as a pre-resolved "addressed + cleaned text".
+//
+// Rules (identical to the neutral gate): DMs and groups with requireMention=false
+// are always handled; a group with requireMention=true is handled only when the
+// message mentions this community (or, supplied by the caller, replies to the
+// bot — VK reply detection is handled upstream). The returned cleaned text always
+// has this community's mention stripped, even when handle is false.
+func shouldHandle(isGroup bool, text string, groupID int64, requireMention, replyToBot bool) (handle bool, cleaned string) {
+	mentioned, cleaned := parseMention(text, groupID)
+
+	// The decision mirrors core/chat.ShouldHandle exactly (DMs and non-require
+	// groups always handled; a require-mention group needs a mention or a reply),
+	// but the addressed/stripped inputs are pre-resolved here because VK mentions
+	// are textual [club<id>|...] tokens, not the entity spans the neutral gate
+	// parses for Telegram — so this is the VK half of the §4 mention-gate split.
+	if !isGroup || !requireMention {
+		return true, cleaned
+	}
+	if replyToBot || mentioned {
+		return true, cleaned
+	}
+	return false, cleaned
+}

--- a/adapters/vk/mention_test.go
+++ b/adapters/vk/mention_test.go
@@ -1,0 +1,59 @@
+//nolint:testpackage // intentionally whitebox to test unexported VK mention/gate internals
+package vk
+
+import "testing"
+
+func TestParseMentionStripsThisCommunity(t *testing.T) {
+	const groupID = 123
+	for _, tc := range []struct {
+		name          string
+		text          string
+		wantMentioned bool
+		wantStripped  string
+	}{
+		{"club mention leading", "[club123|Duck Bot] please help", true, "please help"},
+		{"public mention", "[public123|Duck] do X", true, "do X"},
+		{"mention in middle", "hey [club123|Duck] now", true, "hey  now"},
+		{"other community", "[club999|Other] hi", false, "[club999|Other] hi"},
+		{"no mention", "just a message", false, "just a message"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mentioned, stripped := parseMention(tc.text, groupID)
+			if mentioned != tc.wantMentioned {
+				t.Errorf("mentioned = %v, want %v", mentioned, tc.wantMentioned)
+			}
+			if stripped != tc.wantStripped {
+				t.Errorf("stripped = %q, want %q", stripped, tc.wantStripped)
+			}
+		})
+	}
+}
+
+func TestShouldHandleGate(t *testing.T) {
+	const groupID = 123
+	for _, tc := range []struct {
+		name           string
+		isGroup        bool
+		text           string
+		requireMention bool
+		replyToBot     bool
+		wantHandle     bool
+		wantCleaned    string
+	}{
+		{"dm always handled", false, "hello", true, false, true, "hello"},
+		{"group no-require always handled", true, "hello", false, false, true, "hello"},
+		{"group require + mention", true, "[club123|Duck] hi", true, false, true, "hi"},
+		{"group require + no mention ignored", true, "hello", true, false, false, "hello"},
+		{"group require + reply handled", true, "hello", true, true, true, "hello"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			handle, cleaned := shouldHandle(tc.isGroup, tc.text, groupID, tc.requireMention, tc.replyToBot)
+			if handle != tc.wantHandle {
+				t.Errorf("handle = %v, want %v", handle, tc.wantHandle)
+			}
+			if cleaned != tc.wantCleaned {
+				t.Errorf("cleaned = %q, want %q", cleaned, tc.wantCleaned)
+			}
+		})
+	}
+}

--- a/adapters/vk/mention_test.go
+++ b/adapters/vk/mention_test.go
@@ -36,18 +36,16 @@ func TestShouldHandleGate(t *testing.T) {
 		isGroup        bool
 		text           string
 		requireMention bool
-		replyToBot     bool
 		wantHandle     bool
 		wantCleaned    string
 	}{
-		{"dm always handled", false, "hello", true, false, true, "hello"},
-		{"group no-require always handled", true, "hello", false, false, true, "hello"},
-		{"group require + mention", true, "[club123|Duck] hi", true, false, true, "hi"},
-		{"group require + no mention ignored", true, "hello", true, false, false, "hello"},
-		{"group require + reply handled", true, "hello", true, true, true, "hello"},
+		{"dm always handled", false, "hello", true, true, "hello"},
+		{"group no-require always handled", true, "hello", false, true, "hello"},
+		{"group require + mention", true, "[club123|Duck] hi", true, true, "hi"},
+		{"group require + no mention ignored", true, "hello", true, false, "hello"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			handle, cleaned := shouldHandle(tc.isGroup, tc.text, groupID, tc.requireMention, tc.replyToBot)
+			handle, cleaned := shouldHandle(tc.isGroup, tc.text, groupID, tc.requireMention)
 			if handle != tc.wantHandle {
 				t.Errorf("handle = %v, want %v", handle, tc.wantHandle)
 			}

--- a/adapters/vk/payload.go
+++ b/adapters/vk/payload.go
@@ -1,0 +1,59 @@
+package vk
+
+import "encoding/json"
+
+// callbackPayload is the JSON object carried by an inline callback button. Stop
+// buttons set Stop to the run id; the star-nudge button sets Star to true. A
+// message_event update relays this payload back verbatim, so the handler decodes
+// it to route the press.
+type callbackPayload struct {
+	// Stop, when non-empty, is the run id a Stop button cancels.
+	Stop string `json:"stop,omitempty"`
+	// Star, when true, marks the star-nudge confirm button.
+	Star bool `json:"star,omitempty"`
+}
+
+// starButtonText labels the star-nudge confirm button. Pressing it triggers the
+// server-side star (a callback button). It mirrors the Telegram nudge's copy.
+const starButtonText = "⭐ Поставить звезду"
+
+// stopPayload encodes the callback payload for a Stop button bound to runID.
+func stopPayload(runID string) string {
+	return marshalPayload(callbackPayload{Stop: runID})
+}
+
+// starPayloadJSON encodes the callback payload for the star-nudge confirm button.
+func starPayloadJSON() string {
+	return marshalPayload(callbackPayload{Star: true})
+}
+
+// marshalPayload JSON-encodes p. The shape is fixed and always marshalable, so on
+// the impossible error path it returns an empty JSON object.
+func marshalPayload(p callbackPayload) string {
+	b, err := json.Marshal(p)
+	if err != nil {
+		return "{}"
+	}
+	return string(b)
+}
+
+// parsePayload decodes a callback button payload (the raw JSON VK relays in a
+// message_event). A malformed payload yields a zero-value callbackPayload, which
+// routes to no action (a safe no-op).
+func parsePayload(raw json.RawMessage) callbackPayload {
+	var p callbackPayload
+	if len(raw) == 0 {
+		return p
+	}
+	// VK may relay the payload either as a JSON object or, when the button payload
+	// was stored as a JSON-encoded string, as a quoted string. Try the object form
+	// first, then the string-wrapped form.
+	if err := json.Unmarshal(raw, &p); err == nil {
+		return p
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil && s != "" {
+		_ = json.Unmarshal([]byte(s), &p)
+	}
+	return p
+}

--- a/adapters/vk/payload_test.go
+++ b/adapters/vk/payload_test.go
@@ -1,0 +1,51 @@
+//nolint:testpackage // intentionally whitebox to test unexported VK payload internals
+package vk
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestStopPayloadRoundTrip(t *testing.T) {
+	raw := stopPayload("run-7")
+	p := parsePayload(json.RawMessage(raw))
+	if p.Stop != "run-7" {
+		t.Errorf("parsed stop = %q, want run-7", p.Stop)
+	}
+	if p.Star {
+		t.Error("stop payload should not set star")
+	}
+}
+
+func TestStarPayloadRoundTrip(t *testing.T) {
+	raw := starPayloadJSON()
+	p := parsePayload(json.RawMessage(raw))
+	if !p.Star {
+		t.Error("parsed star = false, want true")
+	}
+	if p.Stop != "" {
+		t.Errorf("star payload should not set stop, got %q", p.Stop)
+	}
+}
+
+func TestParsePayloadStringWrapped(t *testing.T) {
+	// VK may relay the payload as a JSON-encoded STRING; parsePayload must unwrap it.
+	wrapped, err := json.Marshal(`{"stop":"run-9"}`)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	p := parsePayload(wrapped)
+	if p.Stop != "run-9" {
+		t.Errorf("string-wrapped parsed stop = %q, want run-9", p.Stop)
+	}
+}
+
+func TestParsePayloadMalformedIsNoop(t *testing.T) {
+	p := parsePayload(json.RawMessage(`not json`))
+	if p.Stop != "" || p.Star {
+		t.Errorf("malformed payload = %+v, want zero value (no action)", p)
+	}
+	if p := parsePayload(nil); p.Stop != "" || p.Star {
+		t.Errorf("nil payload = %+v, want zero value", p)
+	}
+}

--- a/adapters/vk/receiver.go
+++ b/adapters/vk/receiver.go
@@ -297,7 +297,7 @@ func (r *Receiver) onMessageNew(ctx context.Context, msg messageObject) {
 		return
 	}
 
-	handle, cleaned := shouldHandle(isGroup, msg.Text, r.groupID, r.requireMention, false)
+	handle, cleaned := shouldHandle(isGroup, msg.Text, r.groupID, r.requireMention)
 	if !handle {
 		r.logger.Debug("vk: group message not addressed to bot — ignoring", "peer_id", peerID)
 		return

--- a/adapters/vk/receiver.go
+++ b/adapters/vk/receiver.go
@@ -1,0 +1,519 @@
+package vk
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/duckbugio/flock/core/chat"
+	"github.com/duckbugio/flock/core/claude"
+)
+
+// stopCommand is the universal text fallback for cancelling the in-flight run,
+// mapped in the receive loop alongside the inline Stop button (CanInlineStop).
+const stopCommand = "/stop"
+
+// Service is the subset of *core/chat.Service the receiver drives. The real
+// Service satisfies it; tests use a fake to assert the mapped calls.
+type Service interface {
+	Handle(ctx context.Context, chatID chat.ChatID, userID int64, msgID chat.MessageID, prompt string)
+	HandleMedia(
+		ctx context.Context, chatID chat.ChatID, userID int64, msgID chat.MessageID, prompt string, images []claude.ImageInput,
+	)
+	Stop(runID string) bool
+	StopChat(chatID chat.ChatID) bool
+	StarPress() (toast string, ok bool)
+}
+
+// guardChecker decides whether an allowed user's accepted message may run (rate
+// limit + cost cap), mirroring the Telegram adapter's CheckGuards call. It
+// returns a reason to send back on denial. A nil checker means "always allow"
+// (the cmd always wires one).
+type guardChecker func(userID int64) (allow bool, reason string)
+
+// transcriber transcribes a VK voice attachment from its (self-keyed) URL.
+// *VoiceTranscriber satisfies it; nil disables voice.
+type transcriber interface {
+	Transcribe(ctx context.Context, url string) (string, error)
+}
+
+// uploader saves an inbound attachment from its URL to the per-chat uploads dir.
+// *Uploader satisfies it; nil disables uploads.
+type uploader interface {
+	Save(ctx context.Context, chatID int64, url, fileName string) (string, error)
+	MaxBytes() int64
+}
+
+// NoticeSender posts a short user-facing notice (a guard denial, a failed
+// transcription, an oversize/undownloadable upload) to a VK conversation. The
+// cmd wires a client-backed implementation (NewNoticeSender); tests use a fake.
+type NoticeSender interface {
+	Notify(ctx context.Context, peerID int64, text string)
+}
+
+// clientNotice is the production NoticeSender: it sends a plain message via the
+// VK client, generating a unique random_id per notice (VK dedupes a repeated
+// random_id within ~1h). Delivery failures are non-fatal and only logged at debug.
+type clientNotice struct {
+	api    *Client
+	seed   int64
+	seq    atomic.Uint64
+	logger *slog.Logger
+}
+
+// NewNoticeSender builds a client-backed NoticeSender. seed seeds the per-sender
+// random_id generator (the cmd passes a monotonic seed); a nil logger defaults to
+// slog.Default().
+func NewNoticeSender(api *Client, seed int64, logger *slog.Logger) NoticeSender {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &clientNotice{api: api, seed: seed, logger: logger}
+}
+
+// Notify sends text to peerID as a plain message. Best-effort: a failure is logged
+// at debug and swallowed (a notice must never crash the receive loop).
+func (n *clientNotice) Notify(ctx context.Context, peerID int64, text string) {
+	//nolint:gosec // G115: deliberate wrap into the signed random_id space; uniqueness, not range, matters.
+	randomID := n.seed + int64(n.seq.Add(1))
+	if _, err := n.api.MessagesSend(ctx, peerID, text, randomID, "", ""); err != nil {
+		n.logger.Debug("vk: send notice", "peer_id", peerID, "error", err)
+	}
+}
+
+// Receiver maps VK Long Poll updates onto the neutral Service. It owns the gate
+// (allow-list + community mention), the guard check, and the inbound media/voice
+// download seams, mirroring cmd/flock-telegram's handler shape but for VK.
+type Receiver struct {
+	svc            Service
+	groupID        int64
+	requireMention bool
+	isAllowed      func(userID int64) bool
+	guards         guardChecker
+	voice          transcriber
+	uploads        uploader
+	notices        NoticeSender
+	eventAck       eventAckFunc
+	logger         *slog.Logger
+}
+
+// ReceiverConfig bundles the Receiver's dependencies.
+type ReceiverConfig struct {
+	Service        Service
+	GroupID        int64
+	RequireMention bool
+	IsAllowed      func(userID int64) bool
+	Guards         func(userID int64) (allow bool, reason string)
+	Voice          transcriber
+	Uploads        uploader
+	Notices        NoticeSender
+	// EventAck acks a callback button press (messages.sendMessageEventAnswer) so VK
+	// clears the button spinner. May be nil (the ack is then skipped).
+	EventAck eventAckFunc
+	Logger   *slog.Logger
+}
+
+// NewReceiver builds a Receiver from cfg. A nil logger defaults to slog.Default();
+// a nil IsAllowed denies everyone (fail-safe); a nil Guards allows every accepted
+// message.
+func NewReceiver(cfg ReceiverConfig) *Receiver {
+	log := cfg.Logger
+	if log == nil {
+		log = slog.Default()
+	}
+	isAllowed := cfg.IsAllowed
+	if isAllowed == nil {
+		isAllowed = func(int64) bool { return false }
+	}
+	return &Receiver{
+		svc:            cfg.Service,
+		groupID:        cfg.GroupID,
+		requireMention: cfg.RequireMention,
+		isAllowed:      isAllowed,
+		guards:         cfg.Guards,
+		voice:          cfg.Voice,
+		uploads:        cfg.Uploads,
+		notices:        cfg.Notices,
+		eventAck:       cfg.EventAck,
+		logger:         log,
+	}
+}
+
+// Run drives the Bots Long Poll receive loop until ctx is cancelled: it fetches a
+// server descriptor, polls a_check, dispatches updates, and handles the failed
+// codes (1 → resume with the returned ts; 2 → re-fetch the key; 3 → re-fetch key
+// + ts). Transient HTTP/transport errors back off and retry rather than crash the
+// loop. It blocks until ctx is done and returns ctx.Err().
+func (r *Receiver) Run(ctx context.Context, lp longPoller) error {
+	server, err := r.refreshServer(ctx, lp)
+	if err != nil {
+		// Couldn't get the initial server; back off and let the loop retry below.
+		r.logger.Warn("vk long poll: initial getLongPollServer failed", "error", err)
+	}
+
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if server.Server == "" || server.Key == "" {
+			if !r.sleep(ctx, pollBackoff) {
+				return ctx.Err()
+			}
+			if s, sErr := r.refreshServer(ctx, lp); sErr != nil {
+				r.logger.Warn("vk long poll: getLongPollServer failed", "error", sErr)
+			} else {
+				server = s
+			}
+			continue
+		}
+
+		resp, err := lp.poll(ctx, server)
+		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			r.logger.Warn("vk long poll: poll failed; backing off", "error", err)
+			if !r.sleep(ctx, pollBackoff) {
+				return ctx.Err()
+			}
+			continue
+		}
+
+		if resp.Failed != 0 {
+			server = r.handleFailed(ctx, lp, server, resp)
+			continue
+		}
+
+		if ts := resp.TS.String(); ts != "" {
+			server.TS = ts
+		}
+		for i := range resp.Updates {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			r.dispatch(ctx, resp.Updates[i])
+		}
+	}
+}
+
+// handleFailed advances the server descriptor per the Long Poll failed code and
+// returns the descriptor to poll next.
+func (r *Receiver) handleFailed(
+	ctx context.Context, lp longPoller, server longPollServer, resp longPollResponse,
+) longPollServer {
+	switch resp.Failed {
+	case failedOutdatedTS:
+		// History outdated: continue from the returned ts, reuse the key.
+		if ts := resp.TS.String(); ts != "" {
+			server.TS = ts
+		}
+		return server
+	case failedKeyExpired, failedInfoLost:
+		// Key expired (2) or information lost (3): re-fetch a fresh server (new key,
+		// and for 3 a fresh ts too — getLongPollServer returns both).
+		s, err := r.refreshServer(ctx, lp)
+		if err != nil {
+			r.logger.Warn("vk long poll: refresh after failed code", "failed", resp.Failed, "error", err)
+			server.Server = "" // force a backoff+retry on the next iteration
+			return server
+		}
+		if resp.Failed == failedKeyExpired {
+			// Keep our current ts (only the key expired); the fresh server's ts would
+			// skip queued updates.
+			s.TS = server.TS
+		}
+		return s
+	default:
+		r.logger.Warn("vk long poll: unknown failed code", "failed", resp.Failed)
+		server.Server = ""
+		return server
+	}
+}
+
+// refreshServer fetches a fresh Long Poll server descriptor.
+func (r *Receiver) refreshServer(ctx context.Context, lp longPoller) (longPollServer, error) {
+	return lp.getLongPollServer(ctx, r.groupID)
+}
+
+// sleep waits d or until ctx is cancelled; it reports false when cancelled.
+func (r *Receiver) sleep(ctx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-t.C:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+// dispatch routes a single update to its handler. Unhandled types are ignored.
+func (r *Receiver) dispatch(ctx context.Context, u update) {
+	switch u.Type {
+	case "message_new":
+		var obj messageNewObject
+		if err := unmarshalObject(u.Object, &obj); err != nil {
+			r.logger.Debug("vk: decode message_new", "error", err)
+			return
+		}
+		r.onMessageNew(ctx, obj.Message)
+	case "message_event":
+		var ev messageEventObject
+		if err := unmarshalObject(u.Object, &ev); err != nil {
+			r.logger.Debug("vk: decode message_event", "error", err)
+			return
+		}
+		r.onMessageEvent(ctx, ev)
+	default:
+		// message_edit and other update types are intentionally not wired: the
+		// Service exposes no VK-specific edit entry point that maps cleanly, so an
+		// edited VK message is left unhandled (documented in the P1 report).
+	}
+}
+
+// onMessageNew maps a message_new update onto the Service: allow-list, the /stop
+// text fallback, the community mention-gate, the guard check, then a text or
+// media run.
+func (r *Receiver) onMessageNew(ctx context.Context, msg messageObject) {
+	// Ignore messages from communities (negative from_id) and our own echoes.
+	if msg.FromID <= 0 {
+		return
+	}
+	if !r.isAllowed(msg.FromID) {
+		r.logger.Debug("vk: ignoring message from disallowed user", "user_id", msg.FromID)
+		return
+	}
+
+	peerID := msg.PeerID
+	isGroup := isGroupPeer(peerID)
+
+	// Universal Stop fallback: a bare "/stop" cancels the chat's in-flight run.
+	if strings.TrimSpace(msg.Text) == stopCommand {
+		r.svc.StopChat(chatIDStr(peerID))
+		return
+	}
+
+	handle, cleaned := shouldHandle(isGroup, msg.Text, r.groupID, r.requireMention, false)
+	if !handle {
+		r.logger.Debug("vk: group message not addressed to bot — ignoring", "peer_id", peerID)
+		return
+	}
+
+	if r.guards != nil {
+		if allow, reason := r.guards(msg.FromID); !allow {
+			r.logger.Debug("vk: guardrail denied message", "peer_id", peerID, "user_id", msg.FromID, "reason", reason)
+			r.notify(ctx, peerID, reason)
+			return
+		}
+	}
+
+	text := strings.TrimSpace(cleaned)
+
+	// Voice: transcribe the first audio_message attachment (gate already passed, so
+	// we only pay for transcription on an accepted message).
+	if att := firstAudioMessage(msg.Attachments); att != nil && r.voice != nil && text == "" {
+		r.handleVoice(ctx, msg, att)
+		return
+	}
+
+	// Inbound document / photo: save to the per-chat uploads dir (outside every git
+	// tree) and submit a run referencing the saved path (a photo also attaches a
+	// vision content block).
+	if r.uploads != nil {
+		if doc := firstDoc(msg.Attachments); doc != nil {
+			r.handleDocument(ctx, msg, doc, text)
+			return
+		}
+		if ph := firstPhoto(msg.Attachments); ph != nil {
+			r.handlePhoto(ctx, msg, ph, text)
+			return
+		}
+	}
+
+	if text == "" {
+		return
+	}
+	r.svc.Handle(ctx, chatIDStr(peerID), msg.FromID, msgIDStr(msg.ConversationMessageID), text)
+}
+
+// handleVoice downloads + transcribes a voice attachment and submits the
+// transcript as a text run. An empty/failed transcript gets one notice.
+func (r *Receiver) handleVoice(ctx context.Context, msg messageObject, att *audioMsgAttach) {
+	url := att.LinkOGG
+	if url == "" {
+		url = att.LinkMP3
+	}
+	transcript, err := r.voice.Transcribe(ctx, url)
+	if err != nil {
+		r.logger.Warn("vk: voice transcription failed", "peer_id", msg.PeerID, "error", err)
+		r.notify(ctx, msg.PeerID, "Sorry, I couldn't transcribe that voice message.")
+		return
+	}
+	text := strings.TrimSpace(transcript)
+	if text == "" {
+		r.notify(ctx, msg.PeerID, "Sorry, I couldn't make out that voice message.")
+		return
+	}
+	r.svc.Handle(ctx, chatIDStr(msg.PeerID), msg.FromID, msgIDStr(msg.ConversationMessageID), text)
+}
+
+// handleDocument downloads + saves a document attachment and submits a run
+// referencing the saved path plus the message text.
+func (r *Receiver) handleDocument(ctx context.Context, msg messageObject, doc *docAttachment, caption string) {
+	savedPath, err := r.uploads.Save(ctx, msg.PeerID, doc.URL, docFileName(doc))
+	if err != nil {
+		r.logger.Warn("vk: save document failed", "peer_id", msg.PeerID, "error", err)
+		r.notify(ctx, msg.PeerID, "Sorry, I couldn't save that file.")
+		return
+	}
+	prompt := chat.DocumentPrompt(savedPath, caption)
+	r.svc.HandleMedia(ctx, chatIDStr(msg.PeerID), msg.FromID, msgIDStr(msg.ConversationMessageID), prompt, nil)
+}
+
+// handlePhoto downloads + saves the largest photo size and submits a vision run
+// (the saved path + an attached image content block). A vision-load failure falls
+// back to a path-only run.
+func (r *Receiver) handlePhoto(ctx context.Context, msg messageObject, ph *photoAttachment, caption string) {
+	size := largestPhoto(ph.Sizes)
+	if size == nil {
+		return
+	}
+	savedPath, err := r.uploads.Save(ctx, msg.PeerID, size.URL, "photo.jpg")
+	if err != nil {
+		r.logger.Warn("vk: save photo failed", "peer_id", msg.PeerID, "error", err)
+		r.notify(ctx, msg.PeerID, "Sorry, I couldn't save that image.")
+		return
+	}
+	prompt := chat.PhotoPrompt(savedPath, caption)
+	images, err := chat.LoadPhotoImage(savedPath)
+	if err != nil {
+		r.logger.Warn("vk: load photo image failed; path-only", "peer_id", msg.PeerID, "error", err)
+		images = nil
+	}
+	r.svc.HandleMedia(ctx, chatIDStr(msg.PeerID), msg.FromID, msgIDStr(msg.ConversationMessageID), prompt, images)
+}
+
+// onMessageEvent maps a callback button press onto the Service: a Stop payload
+// cancels the run, a star payload triggers the star, and either way the event is
+// acked (sendMessageEventAnswer) by the caller-provided ack func.
+func (r *Receiver) onMessageEvent(ctx context.Context, ev messageEventObject) {
+	if !r.isAllowed(ev.UserID) {
+		r.logger.Debug("vk: ignoring callback from disallowed user", "user_id", ev.UserID)
+		r.ack(ctx, ev)
+		return
+	}
+	payload := parsePayload(ev.Payload)
+	switch {
+	case payload.Stop != "":
+		r.svc.Stop(payload.Stop)
+	case payload.Star:
+		r.svc.StarPress()
+	}
+	r.ack(ctx, ev)
+}
+
+// ack acknowledges a message_event so VK clears the button's loading spinner.
+// Best-effort: a failed ack only leaves the spinner, it never affects the run.
+func (r *Receiver) ack(ctx context.Context, ev messageEventObject) {
+	if r.eventAck == nil {
+		return
+	}
+	if err := r.eventAck(ctx, ev.EventID, ev.UserID, ev.PeerID); err != nil {
+		r.logger.Debug("vk: sendMessageEventAnswer", "error", err)
+	}
+}
+
+// eventAckFunc acks a callback press (messages.sendMessageEventAnswer). Wired by
+// the cmd to the VK client's SendMessageEventAnswer; tests inject a fake to
+// assert the ack.
+type eventAckFunc func(ctx context.Context, eventID string, userID, peerID int64) error
+
+// unmarshalObject decodes a Long Poll update object into out.
+func unmarshalObject(raw json.RawMessage, out any) error {
+	return json.Unmarshal(raw, out)
+}
+
+// notify posts a short user-facing notice when a notice sender is configured.
+func (r *Receiver) notify(ctx context.Context, peerID int64, text string) {
+	if r.notices == nil {
+		return
+	}
+	r.notices.Notify(ctx, peerID, text)
+}
+
+// isGroupPeer reports whether a VK peer id is a group/chat conversation. VK
+// multi-user chats use peer ids >= 2000000000 (2_000_000_000 + chat_id); a peer
+// id below that is a 1:1 user DM (never gated as a group).
+func isGroupPeer(peerID int64) bool {
+	return peerID >= chatPeerBase
+}
+
+// chatPeerBase is the offset VK adds to a multi-user chat id to form its peer id.
+const chatPeerBase = 2_000_000_000
+
+// chatIDStr renders a VK int64 peer id as the transport-neutral string chat id.
+func chatIDStr(id int64) string { return strconv.FormatInt(id, 10) }
+
+// msgIDStr renders a VK int64 conversation_message_id as the neutral string id.
+func msgIDStr(id int64) string { return strconv.FormatInt(id, 10) }
+
+// docFileName derives a filename for a document attachment: its title, or a
+// synthesized name from the extension.
+func docFileName(doc *docAttachment) string {
+	if strings.TrimSpace(doc.Title) != "" {
+		return doc.Title
+	}
+	if doc.Ext != "" {
+		return "document." + doc.Ext
+	}
+	return "document"
+}
+
+// firstDoc returns the first doc attachment, or nil.
+func firstDoc(atts []attachment) *docAttachment {
+	for i := range atts {
+		if atts[i].Type == "doc" && atts[i].Doc != nil {
+			return atts[i].Doc
+		}
+	}
+	return nil
+}
+
+// firstPhoto returns the first photo attachment, or nil.
+func firstPhoto(atts []attachment) *photoAttachment {
+	for i := range atts {
+		if atts[i].Type == "photo" && atts[i].Photo != nil {
+			return atts[i].Photo
+		}
+	}
+	return nil
+}
+
+// firstAudioMessage returns the first audio_message (voice) attachment, or nil.
+func firstAudioMessage(atts []attachment) *audioMsgAttach {
+	for i := range atts {
+		if atts[i].Type == "audio_message" && atts[i].AudioMessage != nil {
+			return atts[i].AudioMessage
+		}
+	}
+	return nil
+}
+
+// largestPhoto returns the highest-resolution size from a VK photo set
+// (Width*Height), or nil for an empty set.
+func largestPhoto(sizes []photoSize) *photoSize {
+	var best *photoSize
+	var bestScore int
+	for i := range sizes {
+		score := sizes[i].Width * sizes[i].Height
+		if best == nil || score > bestScore {
+			best = &sizes[i]
+			bestScore = score
+		}
+	}
+	return best
+}

--- a/adapters/vk/receiver_test.go
+++ b/adapters/vk/receiver_test.go
@@ -1,0 +1,277 @@
+//nolint:testpackage // intentionally whitebox to test unexported VK receiver internals
+package vk
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/duckbugio/flock/core/chat"
+	"github.com/duckbugio/flock/core/claude"
+)
+
+// fakeService records the Service calls the receiver makes.
+type fakeService struct {
+	mu          sync.Mutex
+	handleCalls []handleCall
+	mediaCalls  []handleCall
+	stopRunIDs  []string
+	stopChats   []string
+	starPresses int
+}
+
+type handleCall struct {
+	chatID, msgID, prompt string
+	userID                int64
+	images                []claude.ImageInput
+}
+
+func (f *fakeService) Handle(_ context.Context, chatID chat.ChatID, userID int64, msgID chat.MessageID, prompt string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.handleCalls = append(f.handleCalls, handleCall{chatID: chatID, userID: userID, msgID: msgID, prompt: prompt})
+}
+
+func (f *fakeService) HandleMedia(
+	_ context.Context, chatID chat.ChatID, userID int64, msgID chat.MessageID, prompt string, images []claude.ImageInput,
+) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.mediaCalls = append(f.mediaCalls, handleCall{chatID: chatID, userID: userID, msgID: msgID, prompt: prompt, images: images})
+}
+
+func (f *fakeService) Stop(runID string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.stopRunIDs = append(f.stopRunIDs, runID)
+	return true
+}
+
+func (f *fakeService) StopChat(chatID chat.ChatID) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.stopChats = append(f.stopChats, chatID)
+	return true
+}
+
+func (f *fakeService) StarPress() (string, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.starPresses++
+	return "ok", true
+}
+
+// fakeNotice records notice calls.
+type fakeNotice struct {
+	mu    sync.Mutex
+	texts []string
+}
+
+func (n *fakeNotice) Notify(_ context.Context, _ int64, text string) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.texts = append(n.texts, text)
+}
+
+// newTestReceiver builds a Receiver wired to the fakes, allowing user 42, group
+// 123, with the given requireMention.
+func newTestReceiver(svc Service, notices NoticeSender, requireMention bool, acked *[]string) *Receiver {
+	return NewReceiver(ReceiverConfig{
+		Service:        svc,
+		GroupID:        123,
+		RequireMention: requireMention,
+		IsAllowed:      func(uid int64) bool { return uid == 42 },
+		Notices:        notices,
+		EventAck: func(_ context.Context, eventID string, _, _ int64) error {
+			if acked != nil {
+				*acked = append(*acked, eventID)
+			}
+			return nil
+		},
+	})
+}
+
+// msgNewUpdate builds a message_new update from a messageObject.
+func msgNewUpdate(t *testing.T, msg messageObject) update {
+	t.Helper()
+	obj, err := json.Marshal(messageNewObject{Message: msg})
+	if err != nil {
+		t.Fatalf("marshal message_new: %v", err)
+	}
+	return update{Type: "message_new", Object: obj}
+}
+
+func TestReceiverMessageNewFromAllowedUser(t *testing.T) {
+	svc := &fakeService{}
+	r := newTestReceiver(svc, &fakeNotice{}, false, nil)
+
+	r.dispatch(context.Background(), msgNewUpdate(t, messageObject{
+		FromID: 42, PeerID: 200, Text: "hello duck", ConversationMessageID: 9,
+	}))
+
+	if len(svc.handleCalls) != 1 {
+		t.Fatalf("Handle calls = %d, want 1", len(svc.handleCalls))
+	}
+	got := svc.handleCalls[0]
+	if got.chatID != "200" || got.userID != 42 || got.msgID != "9" || got.prompt != "hello duck" {
+		t.Errorf("Handle call = %+v, want chat=200 user=42 msg=9 prompt='hello duck'", got)
+	}
+}
+
+func TestReceiverIgnoresDisallowedAndCommunityMessages(t *testing.T) {
+	svc := &fakeService{}
+	r := newTestReceiver(svc, &fakeNotice{}, false, nil)
+
+	// Disallowed user.
+	r.dispatch(context.Background(), msgNewUpdate(t, messageObject{FromID: 99, PeerID: 200, Text: "hi"}))
+	// Community (negative from_id) — ignored.
+	r.dispatch(context.Background(), msgNewUpdate(t, messageObject{FromID: -100, PeerID: 200, Text: "echo"}))
+
+	if len(svc.handleCalls) != 0 {
+		t.Errorf("Handle calls = %d, want 0 (disallowed + community ignored)", len(svc.handleCalls))
+	}
+}
+
+func TestReceiverMentionGateInGroup(t *testing.T) {
+	svc := &fakeService{}
+	// peer_id >= 2000000000 is a group conversation; requireMention=true.
+	r := newTestReceiver(svc, &fakeNotice{}, true, nil)
+	const groupPeer = 2_000_000_001
+
+	// Non-mention group message: ignored.
+	r.dispatch(context.Background(), msgNewUpdate(t, messageObject{
+		FromID: 42, PeerID: groupPeer, Text: "just chatting", ConversationMessageID: 1,
+	}))
+	if len(svc.handleCalls) != 0 {
+		t.Fatalf("non-mention group message handled (%d calls), want ignored", len(svc.handleCalls))
+	}
+
+	// Mention of THIS community: handled, with the mention stripped.
+	r.dispatch(context.Background(), msgNewUpdate(t, messageObject{
+		FromID: 42, PeerID: groupPeer, Text: "[club123|Duck] build it", ConversationMessageID: 2,
+	}))
+	if len(svc.handleCalls) != 1 {
+		t.Fatalf("mention group message handled %d times, want 1", len(svc.handleCalls))
+	}
+	if svc.handleCalls[0].prompt != "build it" {
+		t.Errorf("mention prompt = %q, want 'build it' (mention stripped)", svc.handleCalls[0].prompt)
+	}
+}
+
+func TestReceiverStopTextCommand(t *testing.T) {
+	svc := &fakeService{}
+	r := newTestReceiver(svc, &fakeNotice{}, false, nil)
+
+	r.dispatch(context.Background(), msgNewUpdate(t, messageObject{FromID: 42, PeerID: 200, Text: "/stop"}))
+	if len(svc.stopChats) != 1 || svc.stopChats[0] != "200" {
+		t.Errorf("StopChat calls = %v, want ['200']", svc.stopChats)
+	}
+	if len(svc.handleCalls) != 0 {
+		t.Errorf("/stop should not start a run, got %d Handle calls", len(svc.handleCalls))
+	}
+}
+
+func TestReceiverMessageEventStopAndAck(t *testing.T) {
+	svc := &fakeService{}
+	var acked []string
+	r := newTestReceiver(svc, &fakeNotice{}, false, &acked)
+
+	ev := messageEventObject{
+		UserID:  42,
+		PeerID:  200,
+		EventID: "evt-1",
+		Payload: json.RawMessage(stopPayload("run-77")),
+	}
+	obj, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+	r.dispatch(context.Background(), update{Type: "message_event", Object: obj})
+
+	if len(svc.stopRunIDs) != 1 || svc.stopRunIDs[0] != "run-77" {
+		t.Errorf("Stop calls = %v, want ['run-77']", svc.stopRunIDs)
+	}
+	if len(acked) != 1 || acked[0] != "evt-1" {
+		t.Errorf("acked events = %v, want ['evt-1'] (sendMessageEventAnswer)", acked)
+	}
+}
+
+func TestReceiverMessageEventStarPress(t *testing.T) {
+	svc := &fakeService{}
+	var acked []string
+	r := newTestReceiver(svc, &fakeNotice{}, false, &acked)
+
+	obj, err := json.Marshal(messageEventObject{
+		UserID: 42, PeerID: 200, EventID: "evt-2", Payload: json.RawMessage(starPayloadJSON()),
+	})
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+	r.dispatch(context.Background(), update{Type: "message_event", Object: obj})
+
+	if svc.starPresses != 1 {
+		t.Errorf("StarPress calls = %d, want 1", svc.starPresses)
+	}
+	if len(acked) != 1 {
+		t.Errorf("star press not acked: %v", acked)
+	}
+}
+
+// TestRunLoopProcessesUpdatesAndHandlesFailed drives the full Run loop with a
+// scripted poll func: first an outdated-ts failed code (1), then a real update,
+// then it cancels the context to stop the loop.
+func TestRunLoopProcessesUpdatesAndHandlesFailed(t *testing.T) {
+	svc := &fakeService{}
+	r := newTestReceiver(svc, &fakeNotice{}, false, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	msg := msgNewUpdate(t, messageObject{FromID: 42, PeerID: 200, Text: "go", ConversationMessageID: 3})
+	lp := &fakeLongPoller{
+		server: longPollServer{Key: "k", Server: "srv", TS: "1"},
+		responses: []longPollResponse{
+			{Failed: failedOutdatedTS, TS: json.Number("5")},
+			{TS: json.Number("6"), Updates: []update{msg}},
+		},
+		onExhausted: cancel, // stop the loop once the scripted responses are delivered
+	}
+
+	err := r.Run(ctx, lp)
+	if !isContextErr(err) {
+		t.Fatalf("Run returned %v, want context cancellation", err)
+	}
+	if len(svc.handleCalls) != 1 || svc.handleCalls[0].prompt != "go" {
+		t.Errorf("Run did not deliver the scripted update: %+v", svc.handleCalls)
+	}
+}
+
+// fakeLongPoller returns a fixed server descriptor and replays scripted poll
+// responses; once exhausted it calls onExhausted (to cancel the loop) and returns
+// an empty response.
+type fakeLongPoller struct {
+	server      longPollServer
+	responses   []longPollResponse
+	onExhausted func()
+	step        int
+}
+
+func (f *fakeLongPoller) getLongPollServer(_ context.Context, _ int64) (longPollServer, error) {
+	return f.server, nil
+}
+
+func (f *fakeLongPoller) poll(_ context.Context, _ longPollServer) (longPollResponse, error) {
+	if f.step < len(f.responses) {
+		resp := f.responses[f.step]
+		f.step++
+		return resp, nil
+	}
+	if f.onExhausted != nil {
+		f.onExhausted()
+	}
+	return longPollResponse{}, nil
+}
+
+func isContextErr(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}

--- a/adapters/vk/upload.go
+++ b/adapters/vk/upload.go
@@ -1,0 +1,171 @@
+package vk
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+// defaultMaxUploadBytes caps an inbound attachment download. 20 MiB matches the
+// Telegram adapter's cap; an oversize file is rejected with a single friendly
+// notice rather than downloaded.
+const defaultMaxUploadBytes int64 = 20 << 20 // 20 MiB
+
+// filePerm is the owner-only permission for bot-created upload files.
+const filePerm os.FileMode = 0o600
+
+// ErrUploadTooLarge is returned when the stream exceeds the configured size cap,
+// so the caller can turn it into one friendly notice.
+var ErrUploadTooLarge = errors.New("uploaded file exceeds the size limit")
+
+// uploadsDirResolver resolves (and creates) a chat's uploads directory. The
+// *workspace.Renderer satisfies it via UploadsDir; tests use a fake. The chat id
+// is the transport-neutral string id (VK peer id rendered as a string).
+type uploadsDirResolver interface {
+	UploadsDir(chatID string) (string, error)
+}
+
+// Uploader downloads a VK inbound attachment by its (self-keyed) URL and saves it
+// under a per-chat uploads directory OUTSIDE every repo working tree (a sibling
+// of the cloned repos), so user files can never enter a git commit. VK attachment
+// URLs carry their own access keys (NOT the community token), so the download is
+// a direct GET; the URL is still redacted from any error/log, mirroring the
+// Telegram adapter's discipline.
+type Uploader struct {
+	client   *http.Client
+	uploads  uploadsDirResolver
+	maxBytes int64
+	logger   *slog.Logger
+	seq      atomic.Uint64 // collision-safe filename prefix counter
+}
+
+// NewUploader builds an Uploader. A nil client defaults to http.DefaultClient, a
+// non-positive maxBytes to defaultMaxUploadBytes, and a nil logger to
+// slog.Default().
+func NewUploader(client *http.Client, uploads uploadsDirResolver, maxBytes int64, logger *slog.Logger) *Uploader {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	if maxBytes <= 0 {
+		maxBytes = defaultMaxUploadBytes
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Uploader{client: client, uploads: uploads, maxBytes: maxBytes, logger: logger}
+}
+
+// MaxBytes is the configured download cap.
+func (u *Uploader) MaxBytes() int64 { return u.maxBytes }
+
+// Save downloads url's bytes (capped at maxBytes) and writes them to a sanitized,
+// collision-safe path under chatID's uploads directory, returning the saved
+// ABSOLUTE path. fileName is the client-supplied name and is treated as hostile:
+// only its sanitized base is used so the saved file can never escape the uploads
+// dir. An oversize or undownloadable file returns an error (ErrUploadTooLarge for
+// the size case) the caller turns into one friendly notice; the error never
+// carries the attachment URL.
+func (u *Uploader) Save(ctx context.Context, chatID int64, url, fileName string) (string, error) {
+	uploadsDir, err := u.uploads.UploadsDir(strconv.FormatInt(chatID, 10))
+	if err != nil {
+		return "", fmt.Errorf("resolve uploads dir: %w", err)
+	}
+
+	dest, err := u.destPath(uploadsDir, fileName)
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		// The url carries the attachment's access key — never include it in the error.
+		return "", fmt.Errorf("build download request: %w", redactURLError(err))
+	}
+
+	resp, err := u.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("download attachment: %w", redactURLError(err))
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		return "", fmt.Errorf("download attachment: status %d", resp.StatusCode)
+	}
+
+	saved, err := u.writeCapped(dest, resp.Body)
+	if err != nil {
+		_ = os.Remove(dest) // best-effort cleanup of a partial file
+		return "", err
+	}
+	u.logger.Debug("saved upload", "chat_id", chatID, "path", saved)
+	return saved, nil
+}
+
+// destPath builds the sanitized, collision-safe absolute destination path inside
+// uploadsDir and asserts the result is contained within it.
+func (u *Uploader) destPath(uploadsDir, fileName string) (string, error) {
+	name := sanitizeUploadName(fileName)
+	prefix := u.uniquePrefix()
+	dest := filepath.Join(uploadsDir, prefix+name)
+
+	rel, err := filepath.Rel(uploadsDir, dest)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return "", fmt.Errorf("refusing upload path outside uploads dir: %q", fileName)
+	}
+	return dest, nil
+}
+
+// uniquePrefix returns a short collision-safe prefix (timestamp + monotonic
+// counter + random hex) so two uploads with the same sanitized name never clash.
+func (u *Uploader) uniquePrefix() string {
+	var rnd [4]byte
+	_, _ = rand.Read(rnd[:])
+	return fmt.Sprintf("%d-%d-%s-", time.Now().UnixNano(), u.seq.Add(1), hex.EncodeToString(rnd[:]))
+}
+
+// writeCapped streams src into dest under a maxBytes cap (LimitReader). If the
+// source is longer than the cap the file is rejected as oversize rather than
+// silently truncated: we read one extra byte and fail when it is present.
+func (u *Uploader) writeCapped(dest string, src io.Reader) (string, error) {
+	//nolint:gosec // G304: dest is a workspace upload path we construct, not raw user input.
+	f, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_EXCL, filePerm)
+	if err != nil {
+		return "", fmt.Errorf("create upload file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	limited := io.LimitReader(src, u.maxBytes+1)
+	n, err := io.Copy(f, limited)
+	if err != nil {
+		return "", fmt.Errorf("write upload file: %w", err)
+	}
+	if n > u.maxBytes {
+		return "", ErrUploadTooLarge
+	}
+	return dest, nil
+}
+
+// sanitizeUploadName reduces a client-supplied file name to a safe basename that
+// can never escape the uploads dir. Mirrors the Telegram adapter's sanitizer.
+func sanitizeUploadName(name string) string {
+	name = strings.ReplaceAll(name, "\\", "/")
+	name = path.Base(name)
+	name = strings.TrimLeft(name, ".")
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "upload"
+	}
+	return name
+}

--- a/adapters/vk/upload_test.go
+++ b/adapters/vk/upload_test.go
@@ -1,0 +1,97 @@
+//nolint:testpackage // intentionally whitebox to test unexported VK upload internals
+package vk
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fakeUploadsResolver returns a fixed uploads dir.
+type fakeUploadsResolver struct{ dir string }
+
+func (f *fakeUploadsResolver) UploadsDir(string) (string, error) { return f.dir, nil }
+
+func newTestUploader(t *testing.T, body string, maxBytes int64) (u *Uploader, dir, url string) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(srv.Close)
+	dir = t.TempDir()
+	u = NewUploader(srv.Client(), &fakeUploadsResolver{dir: dir}, maxBytes, nil)
+	return u, dir, srv.URL
+}
+
+func TestVKUploaderSavesFile(t *testing.T) {
+	const content = "VK-DOC-CONTENT"
+	u, dir, url := newTestUploader(t, content, 0)
+
+	path, err := u.Save(context.Background(), 200, url, "report.pdf")
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if !filepath.IsAbs(path) || filepath.Dir(path) != dir {
+		t.Errorf("saved path %q not in uploads dir %q", path, dir)
+	}
+	if !strings.HasSuffix(path, "report.pdf") {
+		t.Errorf("saved path %q does not preserve the sanitized name", path)
+	}
+	got, err := os.ReadFile(path) //nolint:gosec // G304: test reads a controlled temp path
+	if err != nil {
+		t.Fatalf("read saved file: %v", err)
+	}
+	if string(got) != content {
+		t.Errorf("saved bytes = %q, want %q", got, content)
+	}
+}
+
+func TestVKUploaderHostileNameContained(t *testing.T) {
+	u, dir, url := newTestUploader(t, "x", 0)
+	for _, name := range []string{"../../etc/passwd", `..\..\x`, "/abs/secret", "..."} {
+		p, err := u.Save(context.Background(), 1, url, name)
+		if err != nil {
+			t.Fatalf("Save(%q): %v", name, err)
+		}
+		if filepath.Dir(p) != dir {
+			t.Errorf("hostile name %q escaped uploads dir: %q", name, p)
+		}
+	}
+}
+
+func TestVKUploaderOversizeRejected(t *testing.T) {
+	const maxBytes = 8
+	u, dir, url := newTestUploader(t, strings.Repeat("A", 100), maxBytes)
+	_, err := u.Save(context.Background(), 1, url, "big.bin")
+	if err == nil {
+		t.Fatal("Save of oversize file = nil, want ErrUploadTooLarge")
+	}
+	if !strings.Contains(err.Error(), ErrUploadTooLarge.Error()) {
+		t.Errorf("error = %v, want ErrUploadTooLarge", err)
+	}
+	if entries, _ := os.ReadDir(dir); len(entries) != 0 {
+		t.Errorf("oversize upload left %d file(s) behind", len(entries))
+	}
+}
+
+func TestVKUploaderDownloadErrorRedactsURL(t *testing.T) {
+	const marker = "ACCESS-MARKER-12345"
+	closed := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	addr := closed.URL
+	closed.Close()
+	url := addr + "/doc?key=" + marker
+
+	u := NewUploader(http.DefaultClient, &fakeUploadsResolver{dir: t.TempDir()}, 0, nil)
+	_, err := u.Save(context.Background(), 1, url, "doc.bin")
+	if err == nil {
+		t.Fatal("Save on transport error = nil, want error")
+	}
+	if strings.Contains(err.Error(), marker) {
+		t.Errorf("download error leaks the attachment access key: %q", err.Error())
+	}
+}

--- a/adapters/vk/voice.go
+++ b/adapters/vk/voice.go
@@ -1,11 +1,13 @@
 package vk
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"path"
 
 	"github.com/duckbugio/flock/core/voice"
@@ -62,6 +64,25 @@ func (vt *VoiceTranscriber) Transcribe(ctx context.Context, url string) (string,
 		return "", fmt.Errorf("download voice file: status %d", resp.StatusCode)
 	}
 
-	limited := io.LimitReader(resp.Body, vt.maxBytes)
-	return vt.transcriber.Transcribe(ctx, limited, path.Base(url))
+	// Read one byte past the cap so an oversized file is rejected, not silently
+	// truncated to a misleading transcript (mirrors upload.go's writeCapped).
+	limited := io.LimitReader(resp.Body, vt.maxBytes+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return "", fmt.Errorf("download voice file: %w", redactURLError(err))
+	}
+	if int64(len(data)) > vt.maxBytes {
+		return "", ErrUploadTooLarge
+	}
+	return vt.transcriber.Transcribe(ctx, bytes.NewReader(data), voiceFilename(url))
+}
+
+// voiceFilename derives a clean filename hint from a VK audio URL, dropping any
+// query string (the self-keyed link carries one) so the transcriber sees a bare
+// basename.
+func voiceFilename(rawURL string) string {
+	if u, err := url.Parse(rawURL); err == nil && u.Path != "" {
+		return path.Base(u.Path)
+	}
+	return path.Base(rawURL)
 }

--- a/adapters/vk/voice.go
+++ b/adapters/vk/voice.go
@@ -1,0 +1,67 @@
+package vk
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"path"
+
+	"github.com/duckbugio/flock/core/voice"
+)
+
+// defaultMaxVoiceBytes caps a voice download to guard against oversized files.
+const defaultMaxVoiceBytes int64 = 25 << 20 // 25 MiB
+
+// VoiceTranscriber downloads a VK audio_message file (its self-keyed link_ogg /
+// link_mp3 URL) and transcribes it via the provider-neutral core/voice
+// Transcriber — the same plumbing the Telegram adapter reuses. The download is
+// capped at maxBytes; the (self-keyed) URL is redacted from any error.
+type VoiceTranscriber struct {
+	client      *http.Client
+	transcriber voice.Transcriber
+	maxBytes    int64
+	logger      *slog.Logger
+}
+
+// NewVoiceTranscriber builds a VoiceTranscriber. A nil client defaults to
+// http.DefaultClient, a non-positive maxBytes to defaultMaxVoiceBytes, and a nil
+// logger to slog.Default().
+func NewVoiceTranscriber(
+	client *http.Client, transcriber voice.Transcriber, maxBytes int64, logger *slog.Logger,
+) *VoiceTranscriber {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	if maxBytes <= 0 {
+		maxBytes = defaultMaxVoiceBytes
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &VoiceTranscriber{client: client, transcriber: transcriber, maxBytes: maxBytes, logger: logger}
+}
+
+// Transcribe fetches the audio at url (a VK audio_message link, preferring the
+// OGG link) capped at maxBytes and returns the transcript. The URL carries its
+// own access key (not the community token) and is redacted from any error.
+func (vt *VoiceTranscriber) Transcribe(ctx context.Context, url string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("build download request: %w", redactURLError(err))
+	}
+
+	resp, err := vt.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("download voice file: %w", redactURLError(err))
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		return "", fmt.Errorf("download voice file: status %d", resp.StatusCode)
+	}
+
+	limited := io.LimitReader(resp.Body, vt.maxBytes)
+	return vt.transcriber.Transcribe(ctx, limited, path.Base(url))
+}

--- a/cmd/duck-vk/main.go
+++ b/cmd/duck-vk/main.go
@@ -1,0 +1,315 @@
+// Command duck-vk is the Go VKontakte (VK) community-bot adapter for flock. Each
+// allowed VK user's DM/mention is dispatched to that chat's isolated workspace
+// and run through the core/claude Runner; the event stream renders to one live
+// "Working… (Ns)" progress message with a Stop button (edited in place, as VK has
+// no ephemeral draft), replaced by the final answer on completion. Runs are
+// parallel across chats (capped) and serial within a chat (core/dispatch); each
+// chat gets its own /workspace/chat_<peer_id> with a rendered CLAUDE.md + agents
+// (core/workspace). It wires the SAME shared core/chat.Service the Telegram
+// binary uses — only the adapter construction and the Long Poll receive loop
+// differ.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/duckbugio/flock/adapters/vk"
+	"github.com/duckbugio/flock/core/chat"
+	"github.com/duckbugio/flock/core/claude"
+	"github.com/duckbugio/flock/core/cost"
+	"github.com/duckbugio/flock/core/dispatch"
+	"github.com/duckbugio/flock/core/ghstar"
+	"github.com/duckbugio/flock/core/gitsetup"
+	"github.com/duckbugio/flock/core/nudge"
+	"github.com/duckbugio/flock/core/poller"
+	"github.com/duckbugio/flock/core/ratelimit"
+	"github.com/duckbugio/flock/core/session"
+	"github.com/duckbugio/flock/core/voice"
+	"github.com/duckbugio/flock/core/workspace"
+	"github.com/duckbugio/flock/internal/config"
+)
+
+// shutdownDrainTimeout bounds how long Shutdown waits for in-flight runs to
+// deliver their final message during graceful drain.
+const shutdownDrainTimeout = 5 * time.Second
+
+// voiceClientTimeout is the shared budget for the voice file download plus the
+// transcription provider call.
+const voiceClientTimeout = 60 * time.Second
+
+// uploadClientTimeout is the budget for a (potentially large) inbound file
+// download.
+const uploadClientTimeout = 120 * time.Second
+
+func main() {
+	os.Exit(run())
+}
+
+// run holds the adapter's startup and serve logic, returning a process exit code.
+// Splitting it out of main lets deferred cleanups (signal context, dispatcher
+// drain) run before the process exits.
+func run() int {
+	cfg, err := config.Load()
+	if err != nil {
+		slog.Error("load config", "error", err)
+		return 1
+	}
+	if err := cfg.ValidateVK(); err != nil {
+		slog.Error("invalid vk config", "error", err)
+		return 1
+	}
+
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: cfg.SlogLevel(),
+	}))
+	slog.SetDefault(logger)
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	// Best-effort git startup wiring (identity, default branch, inline credential
+	// helper). Non-fatal: a git setup failure must not crash-loop the bot.
+	if err := gitsetup.Apply(ctx, gitsetup.Config{
+		Host:        cfg.GitHost,
+		Scheme:      cfg.GitScheme,
+		AuthorName:  cfg.GitAuthorName,
+		AuthorEmail: cfg.GitAuthorEmail,
+		HasToken:    cfg.GitToken != "",
+	}); err != nil {
+		logger.Warn("git setup", "error", err)
+	}
+
+	runner := claude.New(cfg.ClaudeBin)
+	opts := claude.Options{
+		Model:    cfg.ClaudeModel,
+		MaxTurns: cfg.ClaudeMaxTurns,
+		Env:      claudeEnv(cfg),
+	}
+
+	ws := &workspace.Renderer{
+		BaseDir:        cfg.ApprovedDirectory,
+		TemplatePath:   cfg.TeamTemplatePath,
+		AgentsDir:      cfg.TeamAgentsDir,
+		PrePRCycles:    cfg.PrePRCycles,
+		PrReviewCycles: cfg.PrReviewCycles,
+		EnablePRReview: cfg.EnablePRReview,
+		GitHost:        cfg.GitHost,
+	}
+	sessions, err := session.Open(cfg.SessionStoreFile())
+	if err != nil {
+		logger.Error("open session store", "path", cfg.SessionStoreFile(), "error", err)
+		return 1
+	}
+
+	limiter := ratelimit.New(cfg.RateLimitRequests, cfg.RateLimitWindow())
+	costs, err := cost.Open(cfg.CostStoreFile())
+	if err != nil {
+		logger.Error("open cost store; cost cap disabled", "path", cfg.CostStoreFile(), "error", err)
+		costs = nil
+	}
+	logger.Info("guardrails configured",
+		"rate_limit_enabled", cfg.RateLimitEnabled(),
+		"rate_limit_requests", cfg.RateLimitRequests,
+		"rate_limit_window", cfg.RateLimitWindow(),
+		"cost_cap_enabled", cfg.CostCapEnabled() && costs != nil,
+		"cost_cap_usd", cfg.ClaudeMaxCostPerUser,
+	)
+
+	disp := dispatch.New(cfg.MaxConcurrentChatRuns)
+	defer func() {
+		drainCtx, cancelDrain := context.WithTimeout(context.Background(), shutdownDrainTimeout)
+		defer cancelDrain()
+		if err := disp.Shutdown(drainCtx); err != nil {
+			logger.Warn("dispatcher drain timed out", "error", err)
+		}
+	}()
+
+	// The VK API client (injectable base/client; defaults to the real endpoint).
+	api := vk.NewClient(cfg.VKBotToken)
+	// Seed the random_id generator from a monotonic source so two process runs don't
+	// reuse ids (VK dedupes a repeated random_id within ~1h). Not time-derived in
+	// tests (those inject a fixed seed); here a process-start nanosecond seed is fine.
+	transport := vk.NewBotChat(api, cfg.VKGroupID, time.Now().UnixNano())
+
+	// Voice transcription (optional, OFF by default). A provider misconfiguration is
+	// non-fatal: log and run with voice disabled.
+	var vt *vk.VoiceTranscriber
+	if cfg.EnableVoiceMessages {
+		voiceClient := &http.Client{Timeout: voiceClientTimeout}
+		tr, terr := voice.New(voice.Config{
+			Provider:      cfg.VoiceProvider,
+			MistralAPIKey: cfg.MistralAPIKey,
+			OpenAIAPIKey:  cfg.OpenAIAPIKey,
+			MistralModel:  cfg.VoiceMistralModel,
+			OpenAIModel:   cfg.VoiceOpenAIModel,
+			LocalCommand:  cfg.VoiceLocalCommand,
+			HTTPClient:    voiceClient,
+			Logger:        logger,
+		})
+		if terr != nil {
+			logger.Warn("voice disabled", "error", terr)
+		} else {
+			vt = vk.NewVoiceTranscriber(voiceClient, tr, 0, logger)
+			logger.Info("voice transcription enabled", "provider", cfg.VoiceProvider)
+		}
+	}
+
+	// Inbound document/photo uploads. Always enabled: files are saved to the per-chat
+	// uploads dir (outside every git tree), the URL redacted from any error.
+	uploadClient := &http.Client{Timeout: uploadClientTimeout}
+	up := vk.NewUploader(uploadClient, ws, cfg.MaxUploadBytes, logger)
+
+	// Outbound file delivery ("outbox"): after each run, sweep the per-chat outbox
+	// dir and send each produced file as a VK document.
+	outbox := chat.NewSweeper(ws, cfg.MaxOutboxBytes, cfg.MaxOutboxFiles, logger)
+
+	// Post-task GitHub star nudge (GitHub-only; the gate is the off switch).
+	starNudge := buildStarNudge(cfg, logger)
+
+	svc := chat.New(chat.Config{
+		Runner:     runner,
+		Transport:  transport,
+		Dispatcher: disp,
+		Workspace:  ws,
+		Sessions:   sessions,
+		Costs:      costs,
+		Outbox:     outbox,
+		StarNudge:  starNudge,
+		Opts:       opts,
+		Timeout:    cfg.ClaudeTimeout(),
+		RetryAfter: vk.RetryAfter,
+		Logger:     logger,
+	})
+
+	guards := chat.GuardConfig{CostCapUSD: cfg.ClaudeMaxCostPerUser}
+	receiver := vk.NewReceiver(vk.ReceiverConfig{
+		Service:        svc,
+		GroupID:        cfg.VKGroupID,
+		RequireMention: cfg.RequireGroupMention,
+		IsAllowed:      cfg.IsVKAllowed,
+		Guards: func(userID int64) (bool, string) {
+			return chat.CheckGuards(limiter, costs, guards, userID)
+		},
+		Voice:    voiceTranscriber(vt),
+		Uploads:  up,
+		Notices:  vk.NewNoticeSender(api, time.Now().UnixNano(), logger),
+		EventAck: api.SendMessageEventAnswer,
+		Logger:   logger,
+	})
+
+	// PR poller (same as Telegram): relay PR review comments on a duck/<chatid>/… PR
+	// into the owning chat. Transport-neutral (keyed on the string chat id).
+	if cfg.PollerEnabled() {
+		out := make(chan poller.PRComment)
+		go func() {
+			if err := poller.Run(ctx, poller.Config{
+				BaseURL:   cfg.GiteaAPIURL,
+				Token:     cfg.GitToken,
+				SelfLogin: strings.ToLower(cfg.GitUser),
+				Interval:  cfg.GiteaPollDuration(),
+				Logger:    logger,
+			}, out); err != nil && ctx.Err() == nil {
+				logger.Error("poller stopped", "error", err)
+			}
+		}()
+		go func() {
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case c := <-out:
+					if _, err := strconv.ParseInt(c.ChatID, 10, 64); err != nil {
+						logger.Warn("poller: bad chat id in branch", "chat_id", c.ChatID)
+						continue
+					}
+					svc.Inject(c.ChatID, formatPRComment(c))
+				}
+			}
+		}()
+	}
+
+	logger.Info("starting vk adapter", "group_id", cfg.VKGroupID)
+	err = receiver.Run(ctx, api)
+	if err != nil && ctx.Err() == nil {
+		logger.Error("vk adapter stopped", "error", err)
+		return 1
+	}
+	logger.Info("vk adapter stopped")
+	return 0
+}
+
+// voiceTranscriber adapts a possibly-nil *vk.VoiceTranscriber to the receiver's
+// transcriber interface: a nil concrete pointer must be passed as a nil interface
+// so the receiver's nil-check disables voice (passing a typed-nil pointer would
+// make the interface non-nil and panic on call).
+func voiceTranscriber(vt *vk.VoiceTranscriber) vkTranscriber {
+	if vt == nil {
+		return nil
+	}
+	return vt
+}
+
+// vkTranscriber mirrors the receiver's transcriber seam so the cmd can hand a nil
+// interface when voice is disabled.
+type vkTranscriber interface {
+	Transcribe(ctx context.Context, url string) (string, error)
+}
+
+// buildStarNudge assembles the post-task star-nudge config (GitHub-only; disabled
+// otherwise). Mirrors cmd/flock-telegram.
+func buildStarNudge(cfg config.Config, logger *slog.Logger) chat.StarNudgeConfig {
+	if !cfg.StarNudgeEnabled() {
+		return chat.StarNudgeConfig{}
+	}
+	owner, repo, ok := cfg.StarNudgeRepoParts()
+	if !ok {
+		return chat.StarNudgeConfig{}
+	}
+	store, err := nudge.Open(cfg.StarNudgeStoreFile())
+	if err != nil {
+		logger.Error("open star-nudge store; nudge disabled", "path", cfg.StarNudgeStoreFile(), "error", err)
+		return chat.StarNudgeConfig{}
+	}
+	logger.Info("star nudge enabled", "repo", cfg.StarNudgeRepo)
+	return chat.StarNudgeConfig{
+		Enabled: true,
+		Owner:   owner,
+		Repo:    repo,
+		Client:  ghstar.New(ghstar.Config{Token: cfg.GitToken, Logger: logger}),
+		Store:   store,
+	}
+}
+
+// claudeEnv derives the child process environment for the claude CLI. Mirrors
+// cmd/flock-telegram.
+func claudeEnv(cfg config.Config) []string {
+	env := os.Environ()
+	if cfg.ClaudeCodeOAuthToken != "" {
+		env = append(env, "CLAUDE_CODE_OAUTH_TOKEN="+cfg.ClaudeCodeOAuthToken)
+	}
+	if cfg.AnthropicAPIKey != "" {
+		env = append(env, "ANTHROPIC_API_KEY="+cfg.AnthropicAPIKey)
+	}
+	return env
+}
+
+// formatPRComment builds a neutral English prompt relaying a polled PR review
+// comment into a chat. Mirrors cmd/flock-telegram (an engineering artifact, no
+// duck flavor, no token).
+func formatPRComment(c poller.PRComment) string {
+	return fmt.Sprintf(
+		"A reviewer left a comment on pull request #%d in %s (branch duck/%s/…).\n\n"+
+			"Comment by @%s:\n%s\n\n"+
+			"Please address this PR review comment following the Phase 2 review workflow.",
+		c.PRIndex, c.Repo, c.ChatID, c.Author, c.Body,
+	)
+}

--- a/cmd/flock-telegram/main.go
+++ b/cmd/flock-telegram/main.go
@@ -63,6 +63,10 @@ func run() int {
 		slog.Error("load config", "error", err)
 		return 1
 	}
+	if err := cfg.ValidateTelegram(); err != nil {
+		slog.Error("invalid telegram config", "error", err)
+		return 1
+	}
 
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 		Level: cfg.SlogLevel(),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"path/filepath"
@@ -13,15 +14,41 @@ import (
 	env "github.com/caarlos0/env/v11"
 )
 
+// ErrMissingTelegramToken is returned by ValidateTelegram when TELEGRAM_BOT_TOKEN
+// is unset, mirroring the previous env "required" behavior but deferred so a
+// non-Telegram binary (e.g. cmd/duck-vk) can share the same Config without
+// demanding the Telegram token.
+var ErrMissingTelegramToken = errors.New("TELEGRAM_BOT_TOKEN is required")
+
+// ErrMissingVKToken is returned by ValidateVK when VK_BOT_TOKEN is unset.
+var ErrMissingVKToken = errors.New("VK_BOT_TOKEN is required")
+
+// ErrMissingVKGroupID is returned by ValidateVK when VK_GROUP_ID is unset/zero;
+// the community id is needed for groups.getLongPollServer and the mention parse.
+var ErrMissingVKGroupID = errors.New("VK_GROUP_ID is required")
+
 // Config holds all runtime configuration sourced from the environment. Field
 // names and env keys mirror adapters/telegram/.env.example for deploy parity.
+// The per-transport tokens are parsed but NOT marked env-required: each binary
+// validates only its own transport (ValidateTelegram / ValidateVK) so a VK
+// deployment need not set TELEGRAM_BOT_TOKEN and vice versa, while the shared
+// core config is parsed once and reused.
 type Config struct {
-	// Required.
-	TelegramBotToken    string `env:"TELEGRAM_BOT_TOKEN,required"`
+	// Telegram (cmd/flock-telegram). Validated by ValidateTelegram, not env-required.
+	TelegramBotToken    string `env:"TELEGRAM_BOT_TOKEN"`
 	TelegramBotUsername string `env:"TELEGRAM_BOT_USERNAME"`
 
 	// Telegram user IDs allowed to use the bot (comma-separated).
 	AllowedUsers []int64 `env:"ALLOWED_USERS" envSeparator:","`
+
+	// VK (cmd/duck-vk). VKBotToken is the community access token; VKGroupID is the
+	// community id (used for groups.getLongPollServer and the [club<id>|...] mention
+	// parse); VKAllowedUsers is the comma-separated allow-list of VK user ids. These
+	// are validated by ValidateVK, not env-required, so the Telegram binary need not
+	// set them. REQUIRE_GROUP_MENTION is shared (reused, not duplicated).
+	VKBotToken     string  `env:"VK_BOT_TOKEN"`
+	VKGroupID      int64   `env:"VK_GROUP_ID"`
+	VKAllowedUsers []int64 `env:"VK_ALLOWED_USERS" envSeparator:","`
 
 	// Claude auth — not hard-required at Stage 0.
 	ClaudeCodeOAuthToken string `env:"CLAUDE_CODE_OAUTH_TOKEN"`
@@ -306,10 +333,46 @@ func (c Config) StarNudgeEnabled() bool {
 
 // IsAllowed reports whether the given Telegram user ID is in the allow-list.
 func (c Config) IsAllowed(userID int64) bool {
-	for _, id := range c.AllowedUsers {
+	return containsID(c.AllowedUsers, userID)
+}
+
+// IsVKAllowed reports whether the given VK user ID is in the VK allow-list.
+// VK_ALLOWED_USERS is a separate list from the Telegram ALLOWED_USERS so the two
+// transports' deploys stay independent (a VK user id is unrelated to a Telegram
+// one).
+func (c Config) IsVKAllowed(userID int64) bool {
+	return containsID(c.VKAllowedUsers, userID)
+}
+
+// containsID reports whether ids contains userID.
+func containsID(ids []int64, userID int64) bool {
+	for _, id := range ids {
 		if id == userID {
 			return true
 		}
 	}
 	return false
+}
+
+// ValidateTelegram checks the fields the Telegram binary requires at startup. It
+// is called by cmd/flock-telegram after Load, replacing the previous env
+// "required" tag on TELEGRAM_BOT_TOKEN so the shared Config can be parsed by a
+// non-Telegram binary too.
+func (c Config) ValidateTelegram() error {
+	if strings.TrimSpace(c.TelegramBotToken) == "" {
+		return ErrMissingTelegramToken
+	}
+	return nil
+}
+
+// ValidateVK checks the fields the VK binary requires at startup (the community
+// access token and the community id). It is called by cmd/duck-vk after Load.
+func (c Config) ValidateVK() error {
+	if strings.TrimSpace(c.VKBotToken) == "" {
+		return ErrMissingVKToken
+	}
+	if c.VKGroupID == 0 {
+		return ErrMissingVKGroupID
+	}
+	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,7 @@
 package config
 
 import (
+	"errors"
 	"log/slog"
 	"testing"
 	"time"
@@ -35,11 +36,11 @@ func TestLoad(t *testing.T) {
 			wantUsers: nil,
 		},
 		{
-			name: "missing token errors",
+			name: "missing telegram token still loads (validated per-binary)",
 			env: map[string]string{
 				"TELEGRAM_BOT_USERNAME": "duckbot",
 			},
-			wantErr: true,
+			wantUsers: nil,
 		},
 		{
 			name: "log level mapping",
@@ -338,6 +339,84 @@ func TestIsAllowed(t *testing.T) {
 	}
 	if c.IsAllowed(99) {
 		t.Errorf("IsAllowed(99) = true, want false")
+	}
+}
+
+func TestValidateTelegram(t *testing.T) {
+	if err := (Config{TelegramBotToken: "token"}).ValidateTelegram(); err != nil {
+		t.Errorf("ValidateTelegram() with token = %v, want nil", err)
+	}
+	if err := (Config{TelegramBotToken: "  "}).ValidateTelegram(); err == nil {
+		t.Error("ValidateTelegram() with blank token = nil, want error")
+	}
+	if err := (Config{}).ValidateTelegram(); err == nil {
+		t.Error("ValidateTelegram() with no token = nil, want error")
+	}
+}
+
+func TestVKConfigParses(t *testing.T) {
+	t.Setenv("VK_BOT_TOKEN", "vk-community-token")
+	t.Setenv("VK_GROUP_ID", "123456")
+	t.Setenv("VK_ALLOWED_USERS", "10,20,30")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.VKBotToken != "vk-community-token" {
+		t.Errorf("VKBotToken = %q, want vk-community-token", cfg.VKBotToken)
+	}
+	if cfg.VKGroupID != 123456 {
+		t.Errorf("VKGroupID = %d, want 123456", cfg.VKGroupID)
+	}
+	want := []int64{10, 20, 30}
+	if len(cfg.VKAllowedUsers) != len(want) {
+		t.Fatalf("VKAllowedUsers = %v, want %v", cfg.VKAllowedUsers, want)
+	}
+	for i := range want {
+		if cfg.VKAllowedUsers[i] != want[i] {
+			t.Fatalf("VKAllowedUsers = %v, want %v", cfg.VKAllowedUsers, want)
+		}
+	}
+}
+
+func TestValidateVK(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		cfg     Config
+		wantErr error
+	}{
+		{"ok", Config{VKBotToken: "t", VKGroupID: 1}, nil},
+		{"missing token", Config{VKGroupID: 1}, ErrMissingVKToken},
+		{"blank token", Config{VKBotToken: "  ", VKGroupID: 1}, ErrMissingVKToken},
+		{"missing group", Config{VKBotToken: "t"}, ErrMissingVKGroupID},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.ValidateVK()
+			if tt.wantErr == nil {
+				if err != nil {
+					t.Fatalf("ValidateVK() = %v, want nil", err)
+				}
+				return
+			}
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("ValidateVK() = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestIsVKAllowed(t *testing.T) {
+	c := Config{VKAllowedUsers: []int64{10, 20}}
+	if !c.IsVKAllowed(10) {
+		t.Errorf("IsVKAllowed(10) = false, want true")
+	}
+	if c.IsVKAllowed(99) {
+		t.Errorf("IsVKAllowed(99) = true, want false")
+	}
+	// The VK list is independent of the Telegram one.
+	c = Config{AllowedUsers: []int64{5}}
+	if c.IsVKAllowed(5) {
+		t.Errorf("IsVKAllowed(5) = true on a Telegram-only allow-list, want false")
 	}
 }
 


### PR DESCRIPTION
## Summary

Phase **P1** of `docs/multi-transport-plan.md`: a **VK (VKontakte) community-bot adapter**, functionally analogous to the Telegram bot, built on the transport-neutral `core/chat` seam that P0 introduced. A VK user's DM/mention runs through the **unchanged** `core/chat.Service` and gets live progress, the final answer, Stop, inbound files/voice, and the outbox.

No change to the Telegram bot's behavior; `core/chat.Service` and `adapters/telegram` are untouched.

## What's new

- **`adapters/vk/`** — implements `core/chat.Transport` for VK, hand-rolled over `net/http` (no SDK, no new deps):
  - `api.go` — VK API client (`api.vk.com/method/*`, `v=5.199`), token sent as a POST form field (never in a URL). `messages.send/edit/delete`, `messages.sendMessageEventAnswer`, and the `docs.getMessagesUploadServer`→multipart upload→`docs.save`→`doc{owner}_{id}` dance (streamed). Base URL + `*http.Client` are injectable for `httptest`-based tests.
  - `longpoll.go` + `receiver.go` — Bots Long Poll receive loop: `groups.getLongPollServer` + `a_check`, `failed` 1/2/3 recovery, ctx-cancellable with transient-error backoff. Maps `message_new` → the Service, `message_event` (callback button) → Stop + ack, plus a universal `/stop` text fallback. Allowed-user gating and group mention-gating happen before dispatch.
  - `bot.go` — the `Transport` methods + `Capabilities`. `StreamDraft` returns an error so the Service falls back to editing the anchor (VK has no ephemeral draft); `asMarkdown` is ignored (VK has no parse mode — plain text); inline Stop keyboard rendered only when a Stop run id is present.
  - `mention.go` — `[club<id>|...]` / `[public<id>|...]` parse + strip, scoped to this community's id.
  - `upload.go` / `voice.go` — inbound attachment + voice download seam mirroring `adapters/telegram/upload.go`: size cap (reject, not truncate), path-traversal containment, self-keyed URL redaction. Voice reuses the provider-neutral `core/voice`.
- **`cmd/duck-vk/main.go`** — mirrors `cmd/flock-telegram`'s wiring DAG 1:1 (runner, workspace renderer, session, rate-limit/cost, dispatch, voice, uploader, outbox sweeper, star-nudge, receive loop). Constructs the adapter and runs the loop — no run-loop logic forked.
- **`internal/config`** — VK sub-struct (`VK_BOT_TOKEN`, `VK_GROUP_ID`, `VK_ALLOWED_USERS`) reusing all shared core vars and `REQUIRE_GROUP_MENTION`. `TELEGRAM_BOT_TOKEN` moved off the `required` struct tag onto a per-binary `ValidateTelegram()` (called right after `Load()` in flock-telegram) so both binaries share one `Config` — Telegram's missing-token startup-fail behavior is preserved (and slightly hardened to reject whitespace-only).
- **CI / deploy** — `adapters/vk/Dockerfile` (+ `.env.example`) mirroring telegram and **copying `adapters/`** into the build context; a PR-only "Build vk image (no push)" CI job; `publish-vk.yml` (`ghcr.io/duckbugio/flock-vk`); dependabot Docker dir.

## Capabilities (documented defaults — see live gate below)

`{CanEditMessages: true, CanInlineStop: true, CanSendDocument: true, MaxMessageRunes: 4096}`. The full Telegram-equivalent path is exercised (edit-based live progress, callback-button Stop, `docs.*` outbox uploads, 4096-rune chunking).

## How it was verified

Run via the repo's CI image (`dev-tools`):
- `gofmt -l .` empty · `go build ./...` clean · `go vet ./...` clean
- `golangci-lint run --timeout=5m ./...` → **0 issues**
- `go test -race ./...` → **all green**; Telegram suite intact, VK package covered by fake-VK-API unit tests (canned Long-Poll JSON → asserted Service calls / outbound payloads: send/edit/delete params, keyboard JSON, `random_id` uniqueness, the docs upload dance, mention strip, allowed-user gating, `message_event`→Stop+ack).
- `go mod tidy` → `go.mod`/`go.sum` unchanged (net/http only, **no new deps**)
- VK Dockerfile build context validated: `./cmd/duck-vk` builds against only the Dockerfile's COPY set.

## ⚠️ Remaining Human-only gate — live VK confirmation

The §6 facts are encoded from VK's documented API, **not yet verified against a live community** (needs a throwaway VK community token). Before/at deploy, confirm against the test community and adjust `Capabilities` if reality differs:

1. Long Poll shape (`{key,server,ts}`; `a_check`→`{ts,updates}`/`{failed:1|2|3}`) and the 1/2/3 recovery semantics.
2. `messages.edit` window/rate — that the real edit cadence is comfortable with the Service's `minEditInterval` (flood codes 6/9 → 1s backoff; VK sends no Retry-After).
3. Callback keyboard + `message_event` payload shape and `sendMessageEventAnswer` ack.
4. Message length cap (assumed 4096 runes).
5. `[club<id>|...]` / `[public<id>|...]` mention rendering in bot-API message text.
6. `docs.*` upload (`type=doc`, multipart `file`, attachment `doc{owner}_{id}`).
7. `peer_id >= 2_000_000_000` ⇒ multi-user chat (group-gate assumption).

If a fact differs, the fix is localized to the adapter + its `Capabilities` — the core and Telegram are unaffected.

## Notes

- `message_edit` inbound updates are intentionally not wired (an edited VK message is ignored — degrades safely, documented in `receiver.go`).
- **Merge order:** this builds on P0 (already merged to `main`); merge after confirming CI green.
