### PR TITLE
refactor: drop dead code, share atomic-write & download primitives

### DIFF
--- a/adapters/telegram/bot.go
+++ b/adapters/telegram/bot.go
@@ -40,13 +40,11 @@ func NewBotChat(b *bot.Bot) chat.Transport {
 	return &botChat{b: b}
 }
 
-// Capabilities reports Telegram's full feature set: it can edit messages, render
-// an inline Stop button, send documents, and its message cap is 4096 runes. With
-// every flag true the neutral Service behaves exactly as before.
+// Capabilities reports Telegram's full feature set: it can send documents and
+// its message cap is 4096 runes. With these flags the neutral Service behaves
+// exactly as before.
 func (c *botChat) Capabilities() chat.Capabilities {
 	return chat.Capabilities{
-		CanEditMessages: true,
-		CanInlineStop:   true,
 		CanSendDocument: true,
 		MaxMessageRunes: telegramMaxMessageRunes,
 	}

--- a/adapters/telegram/nudge.go
+++ b/adapters/telegram/nudge.go
@@ -1,8 +1,6 @@
 package telegram
 
 import (
-	"strings"
-
 	"github.com/go-telegram/bot/models"
 )
 
@@ -28,13 +26,6 @@ func starMarkup() models.ReplyMarkup {
 			{Text: starButtonText, CallbackData: starCallbackData},
 		}},
 	}
-}
-
-// IsStarCallback reports whether callback data is a star-confirm callback the
-// Service should handle. Used as the prefix for the bot's callback handler, the
-// same way CallbackMatch drives the Stop handler.
-func IsStarCallback(data string) bool {
-	return strings.HasPrefix(data, starCallbackPrefix)
 }
 
 // StarCallbackPrefix is the callback_data prefix the cmd registers the star

--- a/adapters/telegram/upload.go
+++ b/adapters/telegram/upload.go
@@ -2,20 +2,14 @@ package telegram
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/hex"
-	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"os"
-	"path"
-	"path/filepath"
 	"strconv"
-	"strings"
 	"sync/atomic"
-	"time"
+
+	"github.com/duckbugio/flock/internal/fsutil"
 )
 
 // defaultMaxUploadBytes caps a document/photo download. 20 MiB matches the
@@ -28,7 +22,7 @@ const filePerm os.FileMode = 0o600
 
 // ErrUploadTooLarge is returned when the source reports (or the stream exceeds)
 // the configured size cap, so the caller can turn it into one friendly notice.
-var ErrUploadTooLarge = errors.New("uploaded file exceeds the size limit")
+var ErrUploadTooLarge = fsutil.ErrUploadTooLarge
 
 // Uploader downloads a Telegram document/photo by file_id and saves it under a
 // per-chat uploads directory that lives OUTSIDE every repo working tree (a
@@ -93,7 +87,7 @@ func (u *Uploader) Save(ctx context.Context, chatID int64, fileID, fileName stri
 		return "", fmt.Errorf("resolve uploads dir: %w", err)
 	}
 
-	dest, err := u.destPath(uploadsDir, fileName)
+	dest, err := fsutil.DestPath(uploadsDir, fileName, &u.seq)
 	if err != nil {
 		return "", err
 	}
@@ -115,7 +109,7 @@ func (u *Uploader) Save(ctx context.Context, chatID int64, fileID, fileName stri
 		// A transport error from client.Do is a *url.Error whose message embeds the
 		// request URL (and thus the bot token); strip it so nothing leaks to a log
 		// or a user-facing error.
-		return "", fmt.Errorf("download file: %w", redactURLError(err))
+		return "", fmt.Errorf("download file: %w", fsutil.RedactURLError(err))
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -123,7 +117,7 @@ func (u *Uploader) Save(ctx context.Context, chatID int64, fileID, fileName stri
 		return "", fmt.Errorf("download file: status %d", resp.StatusCode)
 	}
 
-	saved, err := u.writeCapped(dest, resp.Body)
+	saved, err := fsutil.WriteCapped(dest, resp.Body, u.maxBytes, filePerm)
 	if err != nil {
 		// Best-effort cleanup of a partial file; ignore its error.
 		_ = os.Remove(dest)
@@ -133,75 +127,4 @@ func (u *Uploader) Save(ctx context.Context, chatID int64, fileID, fileName stri
 	// saved sibling-of-repos path (safe to surface).
 	u.logger.Debug("saved upload", "chat_id", chatID, "path", saved)
 	return saved, nil
-}
-
-// destPath builds the sanitized, collision-safe absolute destination path inside
-// uploadsDir and asserts the result is contained within it.
-func (u *Uploader) destPath(uploadsDir, fileName string) (string, error) {
-	name := sanitizeUploadName(fileName)
-	prefix := u.uniquePrefix()
-	dest := filepath.Join(uploadsDir, prefix+name)
-
-	// Defense in depth: assert containment. filepath.Join already cleans the path
-	// and the sanitizer strips separators, but verify the result still sits under
-	// uploadsDir so a hostile name can never escape (AC3).
-	rel, err := filepath.Rel(uploadsDir, dest)
-	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
-		return "", fmt.Errorf("refusing upload path outside uploads dir: %q", fileName)
-	}
-	return dest, nil
-}
-
-// uniquePrefix returns a short collision-safe prefix (timestamp + monotonic
-// counter + random hex) so two uploads with the same sanitized name never clash.
-func (u *Uploader) uniquePrefix() string {
-	var rnd [4]byte
-	// crypto/rand never returns a short read; on the impossible error path the
-	// zero bytes plus the counter still keep the prefix unique.
-	_, _ = rand.Read(rnd[:])
-	return fmt.Sprintf("%d-%d-%s-", time.Now().UnixNano(), u.seq.Add(1), hex.EncodeToString(rnd[:]))
-}
-
-// writeCapped streams src into dest under a maxBytes cap (LimitReader). If the
-// source is longer than the cap the file is rejected as oversize rather than
-// silently truncated: we read one extra byte and fail when it is present.
-func (u *Uploader) writeCapped(dest string, src io.Reader) (string, error) {
-	//nolint:gosec // G304: dest is a workspace upload path we construct, not raw user input.
-	f, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_EXCL, filePerm)
-	if err != nil {
-		return "", fmt.Errorf("create upload file: %w", err)
-	}
-	defer func() { _ = f.Close() }()
-
-	// Read up to maxBytes+1: any byte beyond the cap means the file is oversize.
-	limited := io.LimitReader(src, u.maxBytes+1)
-	n, err := io.Copy(f, limited)
-	if err != nil {
-		return "", fmt.Errorf("write upload file: %w", err)
-	}
-	if n > u.maxBytes {
-		return "", ErrUploadTooLarge
-	}
-	return dest, nil
-}
-
-// sanitizeUploadName reduces a client-supplied file name to a safe basename that
-// can never escape the uploads dir: it takes filepath.Base, then also strips any
-// Windows-style "\" segments (filepath.Base only handles the OS separator),
-// drops leading dots so "..", "..." and dotfiles can't traverse or hide, and
-// falls back to a default when nothing safe remains.
-func sanitizeUploadName(name string) string {
-	// Normalize Windows separators so "..\..\x" collapses too, then take the base.
-	// path.Base operates on slash-separated paths regardless of host OS, so it
-	// reduces the normalized name to its last element ("." for an empty/all-slash
-	// input). filepath.Base alone would miss "\" segments on Linux.
-	name = strings.ReplaceAll(name, "\\", "/")
-	name = path.Base(name)
-	// Strip every leading dot so ".", "..", "...", ".env" cannot traverse or hide.
-	name = strings.TrimLeft(name, ".")
-	name = strings.TrimSpace(name)
-	if name == "" {
-		return "upload"
-	}
-	return name
 }

--- a/adapters/telegram/voice.go
+++ b/adapters/telegram/voice.go
@@ -2,18 +2,17 @@ package telegram
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
-	"net/url"
 	"path"
 
 	"github.com/go-telegram/bot"
 	"github.com/go-telegram/bot/models"
 
 	"github.com/duckbugio/flock/core/voice"
+	"github.com/duckbugio/flock/internal/fsutil"
 )
 
 // defaultMaxVoiceBytes caps a voice download to guard against oversized files.
@@ -108,7 +107,7 @@ func (vt *VoiceTranscriber) Transcribe(ctx context.Context, fileID string) (stri
 		// A transport error from client.Do is a *url.Error whose message embeds
 		// the request URL — which carries the bot token. Strip the URL so the
 		// token never reaches a log or a user-facing error.
-		return "", fmt.Errorf("download voice file: %w", redactURLError(err))
+		return "", fmt.Errorf("download voice file: %w", fsutil.RedactURLError(err))
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -118,15 +117,4 @@ func (vt *VoiceTranscriber) Transcribe(ctx context.Context, fileID string) (stri
 
 	limited := io.LimitReader(resp.Body, vt.maxBytes)
 	return vt.transcriber.Transcribe(ctx, limited, path.Base(filePath))
-}
-
-// redactURLError replaces a *url.Error (whose Error() includes the request URL,
-// and thus the bot token in a Telegram file-download URL) with its underlying
-// cause, which carries no URL. Other errors pass through unchanged.
-func redactURLError(err error) error {
-	var ue *url.Error
-	if errors.As(err, &ue) && ue.Err != nil {
-		return ue.Err
-	}
-	return err
 }

--- a/adapters/vk/api.go
+++ b/adapters/vk/api.go
@@ -23,6 +23,8 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+
+	"github.com/duckbugio/flock/internal/fsutil"
 )
 
 // apiBase is the default VK API method endpoint. It is a struct field on Client
@@ -343,11 +345,8 @@ func (c *Client) docsSave(ctx context.Context, uploaded uploadFileResult) (docSa
 
 // redactURLError replaces a *url.Error (whose Error() includes the request URL)
 // with its underlying cause so a URL never reaches a log or a user-facing error.
-// Mirrors adapters/telegram/voice.go's discipline.
+// It delegates to the shared primitive; the package keeps this name because the
+// general VK API plumbing (call/longpoll) redacts the same way.
 func redactURLError(err error) error {
-	var ue *url.Error
-	if errors.As(err, &ue) && ue.Err != nil {
-		return ue.Err
-	}
-	return err
+	return fsutil.RedactURLError(err)
 }

--- a/adapters/vk/bot.go
+++ b/adapters/vk/bot.go
@@ -49,15 +49,11 @@ func NewBotChat(api *Client, groupID, randSeed int64) chat.Transport {
 	return &botChat{api: api, groupID: groupID, randSeed: randSeed}
 }
 
-// Capabilities reports VK's feature set: it can edit messages (messages.edit),
-// render an inline Stop button (callback keyboard + message_event), send
-// documents (the docs.* dance), and its message cap is 4096 runes. With every
-// flag true the neutral Service drives the full live-progress + Stop-button +
-// outbox path, exactly as on Telegram.
+// Capabilities reports VK's feature set: it can send documents (the docs.*
+// dance), and its message cap is 4096 runes. With these flags the neutral
+// Service drives the full outbox path, exactly as on Telegram.
 func (c *botChat) Capabilities() chat.Capabilities {
 	return chat.Capabilities{
-		CanEditMessages: true,
-		CanInlineStop:   true,
 		CanSendDocument: true,
 		MaxMessageRunes: vkMaxMessageRunes,
 	}

--- a/adapters/vk/bot_test.go
+++ b/adapters/vk/bot_test.go
@@ -17,8 +17,8 @@ import (
 func TestCapabilities(t *testing.T) {
 	c := NewBotChat(NewClient("tok"), 100, 1)
 	caps := c.Capabilities()
-	if !caps.CanEditMessages || !caps.CanInlineStop || !caps.CanSendDocument {
-		t.Errorf("capabilities = %+v, want all-true feature flags", caps)
+	if !caps.CanSendDocument {
+		t.Errorf("capabilities = %+v, want CanSendDocument true", caps)
 	}
 	if caps.MaxMessageRunes != vkMaxMessageRunes {
 		t.Errorf("MaxMessageRunes = %d, want %d", caps.MaxMessageRunes, vkMaxMessageRunes)

--- a/adapters/vk/receiver.go
+++ b/adapters/vk/receiver.go
@@ -14,7 +14,7 @@ import (
 )
 
 // stopCommand is the universal text fallback for cancelling the in-flight run,
-// mapped in the receive loop alongside the inline Stop button (CanInlineStop).
+// mapped in the receive loop alongside the inline Stop button.
 const stopCommand = "/stop"
 
 // Service is the subset of *core/chat.Service the receiver drives. The real

--- a/adapters/vk/upload.go
+++ b/adapters/vk/upload.go
@@ -2,20 +2,14 @@ package vk
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/hex"
-	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"os"
-	"path"
-	"path/filepath"
 	"strconv"
-	"strings"
 	"sync/atomic"
-	"time"
+
+	"github.com/duckbugio/flock/internal/fsutil"
 )
 
 // defaultMaxUploadBytes caps an inbound attachment download. 20 MiB matches the
@@ -28,7 +22,7 @@ const filePerm os.FileMode = 0o600
 
 // ErrUploadTooLarge is returned when the stream exceeds the configured size cap,
 // so the caller can turn it into one friendly notice.
-var ErrUploadTooLarge = errors.New("uploaded file exceeds the size limit")
+var ErrUploadTooLarge = fsutil.ErrUploadTooLarge
 
 // uploadsDirResolver resolves (and creates) a chat's uploads directory. The
 // *workspace.Renderer satisfies it via UploadsDir; tests use a fake. The chat id
@@ -83,7 +77,7 @@ func (u *Uploader) Save(ctx context.Context, chatID int64, url, fileName string)
 		return "", fmt.Errorf("resolve uploads dir: %w", err)
 	}
 
-	dest, err := u.destPath(uploadsDir, fileName)
+	dest, err := fsutil.DestPath(uploadsDir, fileName, &u.seq)
 	if err != nil {
 		return "", err
 	}
@@ -104,68 +98,11 @@ func (u *Uploader) Save(ctx context.Context, chatID int64, url, fileName string)
 		return "", fmt.Errorf("download attachment: status %d", resp.StatusCode)
 	}
 
-	saved, err := u.writeCapped(dest, resp.Body)
+	saved, err := fsutil.WriteCapped(dest, resp.Body, u.maxBytes, filePerm)
 	if err != nil {
 		_ = os.Remove(dest) // best-effort cleanup of a partial file
 		return "", err
 	}
 	u.logger.Debug("saved upload", "chat_id", chatID, "path", saved)
 	return saved, nil
-}
-
-// destPath builds the sanitized, collision-safe absolute destination path inside
-// uploadsDir and asserts the result is contained within it.
-func (u *Uploader) destPath(uploadsDir, fileName string) (string, error) {
-	name := sanitizeUploadName(fileName)
-	prefix := u.uniquePrefix()
-	dest := filepath.Join(uploadsDir, prefix+name)
-
-	rel, err := filepath.Rel(uploadsDir, dest)
-	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
-		return "", fmt.Errorf("refusing upload path outside uploads dir: %q", fileName)
-	}
-	return dest, nil
-}
-
-// uniquePrefix returns a short collision-safe prefix (timestamp + monotonic
-// counter + random hex) so two uploads with the same sanitized name never clash.
-func (u *Uploader) uniquePrefix() string {
-	var rnd [4]byte
-	_, _ = rand.Read(rnd[:])
-	return fmt.Sprintf("%d-%d-%s-", time.Now().UnixNano(), u.seq.Add(1), hex.EncodeToString(rnd[:]))
-}
-
-// writeCapped streams src into dest under a maxBytes cap (LimitReader). If the
-// source is longer than the cap the file is rejected as oversize rather than
-// silently truncated: we read one extra byte and fail when it is present.
-func (u *Uploader) writeCapped(dest string, src io.Reader) (string, error) {
-	//nolint:gosec // G304: dest is a workspace upload path we construct, not raw user input.
-	f, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_EXCL, filePerm)
-	if err != nil {
-		return "", fmt.Errorf("create upload file: %w", err)
-	}
-	defer func() { _ = f.Close() }()
-
-	limited := io.LimitReader(src, u.maxBytes+1)
-	n, err := io.Copy(f, limited)
-	if err != nil {
-		return "", fmt.Errorf("write upload file: %w", err)
-	}
-	if n > u.maxBytes {
-		return "", ErrUploadTooLarge
-	}
-	return dest, nil
-}
-
-// sanitizeUploadName reduces a client-supplied file name to a safe basename that
-// can never escape the uploads dir. Mirrors the Telegram adapter's sanitizer.
-func sanitizeUploadName(name string) string {
-	name = strings.ReplaceAll(name, "\\", "/")
-	name = path.Base(name)
-	name = strings.TrimLeft(name, ".")
-	name = strings.TrimSpace(name)
-	if name == "" {
-		return "upload"
-	}
-	return name
 }

--- a/core/chat/service_test.go
+++ b/core/chat/service_test.go
@@ -65,9 +65,9 @@ func newFakeChat() *fakeChat {
 }
 
 // Capabilities reports a full-capability transport so the fake drives the same
-// run-loop path Telegram does (live edits, inline Stop, documents, 4096 cap).
+// run-loop path Telegram does (documents, 4096 cap).
 func (f *fakeChat) Capabilities() Capabilities {
-	return Capabilities{CanEditMessages: true, CanInlineStop: true, CanSendDocument: true, MaxMessageRunes: TelegramMaxMessage}
+	return Capabilities{CanSendDocument: true, MaxMessageRunes: TelegramMaxMessage}
 }
 
 func (f *fakeChat) Send(_ context.Context, _ ChatID, text, stopRunID string, _ bool) (MessageID, error) {

--- a/core/chat/transport.go
+++ b/core/chat/transport.go
@@ -61,14 +61,6 @@ type Transport interface {
 // returns every flag true and MaxMessageRunes 4096, so its behavior is
 // unchanged.
 type Capabilities struct {
-	// CanEditMessages: platform supports editing a sent message. false → the
-	// Service does NOT post a live-updating progress message; it sends the final
-	// answer as a new message (the wall-clock tick edit loop is skipped).
-	CanEditMessages bool
-	// CanInlineStop: platform supports an inline button / callback bound to a
-	// message. false → no Stop button is rendered; Stop is still reachable via a
-	// text command the adapter maps to Service.Stop.
-	CanInlineStop bool
 	// CanSendDocument: platform supports file attachments. false → the outbox
 	// sweep is skipped. (Telegram/VK: true.)
 	CanSendDocument bool

--- a/core/chat/transport.go
+++ b/core/chat/transport.go
@@ -56,10 +56,9 @@ type Transport interface {
 	Capabilities() Capabilities
 }
 
-// Capabilities lets the Service adapt to platforms weaker than Telegram. Each
-// flag has a defined fallback so a "false" never breaks delivery. Telegram
-// returns every flag true and MaxMessageRunes 4096, so its behavior is
-// unchanged.
+// Capabilities lets the Service adapt to platforms weaker than Telegram, with a
+// defined fallback so a missing primitive never breaks delivery. Telegram and VK
+// set CanSendDocument true and MaxMessageRunes 4096.
 type Capabilities struct {
 	// CanSendDocument: platform supports file attachments. false → the outbox
 	// sweep is skipped. (Telegram/VK: true.)

--- a/core/cost/cost.go
+++ b/core/cost/cost.go
@@ -20,6 +20,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"sync"
+
+	"github.com/duckbugio/flock/internal/atomicfile"
 )
 
 // dirPerm is the owner-only permission for bot-created directories.
@@ -125,30 +127,8 @@ func (s *Store) persistLocked() error {
 	if err != nil {
 		return fmt.Errorf("cost: encode store: %w", err)
 	}
-
-	dir := filepath.Dir(s.path)
-	tmp, err := os.CreateTemp(dir, ".costs-*.tmp")
-	if err != nil {
-		return fmt.Errorf("cost: create temp store: %w", err)
-	}
-	tmpName := tmp.Name()
-	// Best-effort cleanup if we bail before the rename; after a successful rename
-	// the temp name no longer exists so the Remove is a harmless no-op.
-	defer func() { _ = os.Remove(tmpName) }()
-
-	if _, err := tmp.Write(data); err != nil {
-		_ = tmp.Close()
-		return fmt.Errorf("cost: write temp store: %w", err)
-	}
-	if err := tmp.Sync(); err != nil {
-		_ = tmp.Close()
-		return fmt.Errorf("cost: sync temp store: %w", err)
-	}
-	if err := tmp.Close(); err != nil {
-		return fmt.Errorf("cost: close temp store: %w", err)
-	}
-	if err := os.Rename(tmpName, s.path); err != nil {
-		return fmt.Errorf("cost: rename store into place: %w", err)
+	if err := atomicfile.Write(s.path, data, ".costs-*.tmp"); err != nil {
+		return fmt.Errorf("cost: %w", err)
 	}
 	return nil
 }

--- a/core/nudge/nudge.go
+++ b/core/nudge/nudge.go
@@ -14,6 +14,8 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+
+	"github.com/duckbugio/flock/internal/atomicfile"
 )
 
 // dirPerm is the owner-only permission for bot-created directories.
@@ -107,30 +109,8 @@ func (s *Store) persistLocked() error {
 	if err != nil {
 		return fmt.Errorf("nudge: encode store: %w", err)
 	}
-
-	dir := filepath.Dir(s.path)
-	tmp, err := os.CreateTemp(dir, ".nudge-*.tmp")
-	if err != nil {
-		return fmt.Errorf("nudge: create temp store: %w", err)
-	}
-	tmpName := tmp.Name()
-	// Best-effort cleanup if we bail before the rename; after a successful rename
-	// the temp name no longer exists so the Remove is a harmless no-op.
-	defer func() { _ = os.Remove(tmpName) }()
-
-	if _, err := tmp.Write(data); err != nil {
-		_ = tmp.Close()
-		return fmt.Errorf("nudge: write temp store: %w", err)
-	}
-	if err := tmp.Sync(); err != nil {
-		_ = tmp.Close()
-		return fmt.Errorf("nudge: sync temp store: %w", err)
-	}
-	if err := tmp.Close(); err != nil {
-		return fmt.Errorf("nudge: close temp store: %w", err)
-	}
-	if err := os.Rename(tmpName, s.path); err != nil {
-		return fmt.Errorf("nudge: rename store into place: %w", err)
+	if err := atomicfile.Write(s.path, data, ".nudge-*.tmp"); err != nil {
+		return fmt.Errorf("nudge: %w", err)
 	}
 	return nil
 }

--- a/core/session/session.go
+++ b/core/session/session.go
@@ -17,6 +17,8 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+
+	"github.com/duckbugio/flock/internal/atomicfile"
 )
 
 // Store persists chatID -> sessionID durably. The chat id is the transport's
@@ -136,30 +138,8 @@ func (s *FileStore) persistLocked() error {
 	if err != nil {
 		return fmt.Errorf("session: encode store: %w", err)
 	}
-
-	dir := filepath.Dir(s.path)
-	tmp, err := os.CreateTemp(dir, ".sessions-*.tmp")
-	if err != nil {
-		return fmt.Errorf("session: create temp store: %w", err)
-	}
-	tmpName := tmp.Name()
-	// Best-effort cleanup if we bail before the rename; after a successful rename
-	// the temp name no longer exists so the Remove is a harmless no-op.
-	defer func() { _ = os.Remove(tmpName) }()
-
-	if _, err := tmp.Write(data); err != nil {
-		_ = tmp.Close()
-		return fmt.Errorf("session: write temp store: %w", err)
-	}
-	if err := tmp.Sync(); err != nil {
-		_ = tmp.Close()
-		return fmt.Errorf("session: sync temp store: %w", err)
-	}
-	if err := tmp.Close(); err != nil {
-		return fmt.Errorf("session: close temp store: %w", err)
-	}
-	if err := os.Rename(tmpName, s.path); err != nil {
-		return fmt.Errorf("session: rename store into place: %w", err)
+	if err := atomicfile.Write(s.path, data, ".sessions-*.tmp"); err != nil {
+		return fmt.Errorf("session: %w", err)
 	}
 	return nil
 }

--- a/internal/atomicfile/atomicfile.go
+++ b/internal/atomicfile/atomicfile.go
@@ -1,0 +1,43 @@
+// Package atomicfile writes a file in place atomically: it stages the data in a
+// temp file in the same directory, fsyncs it, then renames it over the target.
+// A crash mid-write therefore never leaves a half-written or corrupt file
+// (rename is atomic on the same filesystem).
+package atomicfile
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Write atomically replaces the file at path with data. The temp file is created
+// in path's directory using tmpPattern (an os.CreateTemp pattern, e.g.
+// ".store-*.tmp") so the final rename stays on the same filesystem. The resulting
+// file carries os.CreateTemp's default 0600 permission. On any failure before the
+// rename the temp file is removed; after a successful rename the temp name no
+// longer exists, so the cleanup is a harmless no-op.
+func Write(path string, data []byte, tmpPattern string) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, tmpPattern)
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp file: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp file: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("rename temp file into place: %w", err)
+	}
+	return nil
+}

--- a/internal/atomicfile/atomicfile_test.go
+++ b/internal/atomicfile/atomicfile_test.go
@@ -1,0 +1,80 @@
+package atomicfile_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/duckbugio/flock/internal/atomicfile"
+)
+
+func TestWriteCreatesFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "store.json")
+
+	if err := atomicfile.Write(path, []byte(`{"a":1}`), ".store-*.tmp"); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	got, err := os.ReadFile(path) //nolint:gosec // G304: test reads a controlled temp path
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != `{"a":1}` {
+		t.Errorf("content = %q, want %q", got, `{"a":1}`)
+	}
+}
+
+func TestWriteAtomicallyReplacesExisting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "store.json")
+
+	if err := atomicfile.Write(path, []byte("first"), ".store-*.tmp"); err != nil {
+		t.Fatalf("first Write: %v", err)
+	}
+	if err := atomicfile.Write(path, []byte("second"), ".store-*.tmp"); err != nil {
+		t.Fatalf("second Write: %v", err)
+	}
+
+	got, err := os.ReadFile(path) //nolint:gosec // G304: test reads a controlled temp path
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != "second" {
+		t.Errorf("content = %q, want %q", got, "second")
+	}
+
+	// No temp files should linger after a successful write.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("dir has %d entries, want 1 (only the target file)", len(entries))
+	}
+}
+
+func TestWriteResultPerm(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "store.json")
+
+	if err := atomicfile.Write(path, []byte("data"), ".store-*.tmp"); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	// os.CreateTemp creates files with mode 0600; the rename preserves it.
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("perm = %o, want 0600", perm)
+	}
+}
+
+func TestWriteFailsOnMissingDir(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nope", "store.json")
+	if err := atomicfile.Write(path, []byte("data"), ".store-*.tmp"); err == nil {
+		t.Fatal("Write into a nonexistent directory: want error, got nil")
+	}
+}

--- a/internal/fsutil/upload.go
+++ b/internal/fsutil/upload.go
@@ -1,0 +1,112 @@
+// Package fsutil holds the transport-neutral file-download primitives shared by
+// the chat adapters' Uploader/VoiceTranscriber: hostile-name sanitizing, a
+// collision-safe destination path, a size-capped copy that rejects (rather than
+// truncates) oversize streams, and URL-error redaction. The per-adapter URL
+// acquisition and download strategy stay in each adapter; only these leaf
+// primitives are shared.
+package fsutil
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+// ErrUploadTooLarge is returned when a stream exceeds the configured size cap, so
+// the caller can turn it into one friendly notice.
+var ErrUploadTooLarge = errors.New("uploaded file exceeds the size limit")
+
+// SanitizeUploadName reduces a client-supplied file name to a safe basename that
+// can never escape the uploads dir: it normalizes Windows-style "\" separators
+// (filepath.Base only handles the OS separator), takes path.Base, drops leading
+// dots so "..", "..." and dotfiles can't traverse or hide, trims whitespace, and
+// falls back to a default when nothing safe remains.
+func SanitizeUploadName(name string) string {
+	// Normalize Windows separators so "..\..\x" collapses too, then take the base.
+	// path.Base operates on slash-separated paths regardless of host OS, so it
+	// reduces the normalized name to its last element ("." for an empty/all-slash
+	// input). filepath.Base alone would miss "\" segments on Linux.
+	name = strings.ReplaceAll(name, "\\", "/")
+	name = path.Base(name)
+	// Strip every leading dot so ".", "..", "...", ".env" cannot traverse or hide.
+	name = strings.TrimLeft(name, ".")
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "upload"
+	}
+	return name
+}
+
+// UniquePrefix returns a short collision-safe filename prefix (timestamp +
+// monotonic counter + random hex) so two uploads with the same sanitized name
+// never clash. seq is the caller's per-Uploader counter.
+func UniquePrefix(seq *atomic.Uint64) string {
+	var rnd [4]byte
+	// crypto/rand never returns a short read; on the impossible error path the
+	// zero bytes plus the counter still keep the prefix unique.
+	_, _ = rand.Read(rnd[:])
+	return fmt.Sprintf("%d-%d-%s-", time.Now().UnixNano(), seq.Add(1), hex.EncodeToString(rnd[:]))
+}
+
+// DestPath builds the sanitized, collision-safe absolute destination path inside
+// uploadsDir and asserts the result is contained within it, so a hostile fileName
+// can never escape the uploads dir.
+func DestPath(uploadsDir, fileName string, seq *atomic.Uint64) (string, error) {
+	name := SanitizeUploadName(fileName)
+	prefix := UniquePrefix(seq)
+	dest := filepath.Join(uploadsDir, prefix+name)
+
+	// Defense in depth: assert containment. filepath.Join already cleans the path
+	// and the sanitizer strips separators, but verify the result still sits under
+	// uploadsDir so a hostile name can never escape.
+	rel, err := filepath.Rel(uploadsDir, dest)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return "", fmt.Errorf("refusing upload path outside uploads dir: %q", fileName)
+	}
+	return dest, nil
+}
+
+// WriteCapped streams src into dest under a maxBytes cap (LimitReader). If the
+// source is longer than the cap the file is rejected as oversize (ErrUploadTooLarge)
+// rather than silently truncated: it reads one extra byte and fails when present.
+// dest is created O_EXCL with perm.
+func WriteCapped(dest string, src io.Reader, maxBytes int64, perm fs.FileMode) (string, error) {
+	//nolint:gosec // G304: dest is a workspace upload path the caller constructs, not raw user input.
+	f, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_EXCL, perm)
+	if err != nil {
+		return "", fmt.Errorf("create upload file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	// Read up to maxBytes+1: any byte beyond the cap means the file is oversize.
+	limited := io.LimitReader(src, maxBytes+1)
+	n, err := io.Copy(f, limited)
+	if err != nil {
+		return "", fmt.Errorf("write upload file: %w", err)
+	}
+	if n > maxBytes {
+		return "", ErrUploadTooLarge
+	}
+	return dest, nil
+}
+
+// RedactURLError replaces a *url.Error (whose Error() includes the request URL —
+// which may carry a bot token or a self-keyed access key) with its underlying
+// cause, which carries no URL. Other errors pass through unchanged.
+func RedactURLError(err error) error {
+	var ue *url.Error
+	if errors.As(err, &ue) && ue.Err != nil {
+		return ue.Err
+	}
+	return err
+}

--- a/internal/fsutil/upload_test.go
+++ b/internal/fsutil/upload_test.go
@@ -1,0 +1,115 @@
+package fsutil_test
+
+import (
+	"errors"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/duckbugio/flock/internal/fsutil"
+)
+
+func TestSanitizeUploadName(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain", "report.pdf", "report.pdf"},
+		{"unix traversal", "../../etc/passwd", "passwd"},
+		{"windows traversal", `..\..\secret.txt`, "secret.txt"},
+		{"leading dots dotfile", ".env", "env"},
+		{"dot dot only", "..", "upload"},
+		{"empty", "", "upload"},
+		{"whitespace", "  spaced.txt  ", "spaced.txt"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := fsutil.SanitizeUploadName(tc.in); got != tc.want {
+				t.Errorf("SanitizeUploadName(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestUniquePrefixDistinctAndContainsCounter(t *testing.T) {
+	var seq atomic.Uint64
+	a := fsutil.UniquePrefix(&seq)
+	b := fsutil.UniquePrefix(&seq)
+	if a == b {
+		t.Fatalf("UniquePrefix returned identical prefixes: %q", a)
+	}
+	if !strings.HasSuffix(a, "-") || !strings.HasSuffix(b, "-") {
+		t.Errorf("prefixes should end with '-': %q, %q", a, b)
+	}
+}
+
+func TestDestPathContainsAndSanitizes(t *testing.T) {
+	dir := t.TempDir()
+	var seq atomic.Uint64
+
+	dest, err := fsutil.DestPath(dir, "../../etc/passwd", &seq)
+	if err != nil {
+		t.Fatalf("DestPath: %v", err)
+	}
+	if filepath.Dir(dest) != dir {
+		t.Errorf("dest %q not contained in %q", dest, dir)
+	}
+	if !strings.HasSuffix(dest, "passwd") {
+		t.Errorf("dest %q should preserve the sanitized base name", dest)
+	}
+}
+
+func TestWriteCappedWritesUnderCap(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "out.bin")
+
+	got, err := fsutil.WriteCapped(dest, strings.NewReader("hello"), 1024, 0o600)
+	if err != nil {
+		t.Fatalf("WriteCapped: %v", err)
+	}
+	if got != dest {
+		t.Errorf("returned path = %q, want %q", got, dest)
+	}
+	data, err := os.ReadFile(dest) //nolint:gosec // G304: test reads a controlled temp path
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data) != "hello" {
+		t.Errorf("content = %q, want %q", data, "hello")
+	}
+	if info, _ := os.Stat(dest); info.Mode().Perm() != 0o600 {
+		t.Errorf("perm = %o, want 0600", info.Mode().Perm())
+	}
+}
+
+func TestWriteCappedRejectsOversize(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "out.bin")
+
+	_, err := fsutil.WriteCapped(dest, strings.NewReader("0123456789"), 4, 0o600)
+	if !errors.Is(err, fsutil.ErrUploadTooLarge) {
+		t.Fatalf("WriteCapped oversize = %v, want ErrUploadTooLarge", err)
+	}
+}
+
+func TestRedactURLError(t *testing.T) {
+	cause := errors.New("connection refused")
+	ue := &url.Error{Op: "Get", URL: "https://api.example/method?token=SECRET", Err: cause}
+
+	got := fsutil.RedactURLError(ue)
+	if !errors.Is(got, cause) {
+		t.Errorf("RedactURLError unwrap = %v, want %v", got, cause)
+	}
+	if strings.Contains(got.Error(), "SECRET") {
+		t.Errorf("redacted error still leaks URL: %v", got)
+	}
+
+	plain := errors.New("plain")
+	if !errors.Is(fsutil.RedactURLError(plain), plain) {
+		t.Error("RedactURLError should pass non-url errors through unchanged")
+	}
+}


### PR DESCRIPTION
## Summary

Post-merge **quality-only refactor** (no behavior change) from a three-angle review of the project. Removes dead code and consolidates two verbatim-duplicated, safety-sensitive primitives now that a second transport (VK) exists. The green test suite is the oracle — it stays green with only mechanical updates.

## Changes (4 findings)

- **Drop unread `Capabilities` flags** — `CanEditMessages` / `CanInlineStop` were set by both adapters but **read by nobody**; the documented "false → degrade" behavior was never implemented (the run loop discovers edit/draft support dynamically). Deleted both fields + their doc blocks + adapter assignments. `CanSendDocument` (outbox gate) and `MaxMessageRunes` (chunker) are kept — they're genuinely consulted.
- **Extract the atomic JSON-write primitive** — `core/session`, `core/cost`, `core/nudge` each carried a byte-identical `persistLocked` (temp-in-dir → write → `Sync` → `Close` → `Rename` → defer-`Remove`). Lifted into new `internal/atomicfile.Write`; the three stores keep their types, mutexes, `Open`/`load`, domain methods, and per-store error-wrap prefix. Safety-critical I/O now lives (and is unit-tested) in one place instead of drifting across three.
- **Share download leaf-primitives** — `SanitizeUploadName`, `WriteCapped`, `UniquePrefix`/`DestPath`, `RedactURLError`, `ErrUploadTooLarge` were duplicated verbatim across the Telegram and VK adapters (path-traversal containment + URL redaction — exactly where drift is dangerous). Lifted into new `internal/fsutil`. The `Uploader`/`VoiceTranscriber` structs and the per-adapter URL-acquisition/download strategy **stay per-adapter** (Telegram's token-bearing getFile indirection vs VK's self-keyed direct GET) — only the pure leaves moved. Each adapter keeps an `ErrUploadTooLarge` alias so existing `errors.Is` sites resolve to the same sentinel.
- **Delete dead export** — `IsStarCallback` (no callers); `StarCallbackPrefix` kept.

## Scope / safety

- **No behavior change.** The two extracted primitives are byte-for-byte reproductions (same ordering, perms 0600, error path, durability). Verified behavior-preserving by a fresh-context review.
- **No new dependencies** — all stdlib; `go.mod`/`go.sum` unchanged.
- **`core/claude/**` deliberately untouched** — the AI-backend layer (runner/decode/`RunResult`) is reserved for the upcoming multi-backend work (adding Codex alongside Claude); this refactor stays in the chat-transport / file-I/O layers.

## Verification

Via the CI image (`dev-tools`): `gofmt -l .` empty · `go build ./...` · `go vet ./...` · `golangci-lint run` **0 issues** · `go test -race ./...` **all green** (incl. new `internal/atomicfile` + `internal/fsutil` tests) · `go mod tidy` no change.

Net: production code shrinks; duplication removed; new shared packages covered by focused tests.
