### PR TITLE
fix: handle /start and self-heal a stale resume session

### DIFF
--- a/adapters/telegram/commands.go
+++ b/adapters/telegram/commands.go
@@ -45,3 +45,10 @@ const HelpText = "DuckFlock Telegram assistant — available commands:\n\n" +
 	"/new — start a fresh session (forget the current conversation)\n" +
 	"/stop — stop the run currently in progress\n\n" +
 	"Send any other message to run it through the assistant."
+
+// WelcomeText is the static usage message replied to an allowed user who sends
+// /start. It is a short greeting prepended to the command help so a brand-new
+// user immediately sees what the bot does and how to use it. Like HelpText it is
+// an engineering artifact (plain English, no duck flavor) and never reaches the
+// Claude Runner — the duck greeting comes from the model on a real message.
+const WelcomeText = "Hi! I'm the DuckFlock assistant.\n\n" + HelpText

--- a/adapters/vk/receiver.go
+++ b/adapters/vk/receiver.go
@@ -17,6 +17,18 @@ import (
 // mapped in the receive loop alongside the inline Stop button.
 const stopCommand = "/stop"
 
+// startCommand is the text command a new user sends first; it is answered with a
+// short welcome + usage notice and never starts a run (parity with Telegram's
+// /start handler).
+const startCommand = "/start"
+
+// welcomeText is the static reply to /start: a short greeting + usage, mirroring
+// the Telegram adapter's WelcomeText. It is an engineering artifact (plain
+// English, no duck flavor) and never reaches the Claude Runner.
+const welcomeText = "Hi! I'm the DuckFlock assistant.\n\n" +
+	"Send any message to run it through the assistant.\n" +
+	"/stop — stop the run currently in progress."
+
 // Service is the subset of *core/chat.Service the receiver drives. The real
 // Service satisfies it; tests use a fake to assert the mapped calls.
 type Service interface {
@@ -292,8 +304,13 @@ func (r *Receiver) onMessageNew(ctx context.Context, msg messageObject) {
 	isGroup := isGroupPeer(peerID)
 
 	// Universal Stop fallback: a bare "/stop" cancels the chat's in-flight run.
-	if strings.TrimSpace(msg.Text) == stopCommand {
+	switch strings.TrimSpace(msg.Text) {
+	case stopCommand:
 		r.svc.StopChat(chatIDStr(peerID))
+		return
+	case startCommand:
+		// /start is answered with the welcome/usage notice and never starts a run.
+		r.notify(ctx, peerID, welcomeText)
 		return
 	}
 

--- a/adapters/vk/receiver_test.go
+++ b/adapters/vk/receiver_test.go
@@ -173,6 +173,23 @@ func TestReceiverStopTextCommand(t *testing.T) {
 	}
 }
 
+// TestReceiverStartTextCommand is the VK /start guard: a bare "/start" replies
+// with the welcome notice and does NOT start a run (no Service dispatch).
+func TestReceiverStartTextCommand(t *testing.T) {
+	svc := &fakeService{}
+	notices := &fakeNotice{}
+	r := newTestReceiver(svc, notices, false, nil)
+
+	r.dispatch(context.Background(), msgNewUpdate(t, messageObject{FromID: 42, PeerID: 200, Text: "/start"}))
+
+	if len(svc.handleCalls) != 0 {
+		t.Errorf("/start should not start a run, got %d Handle calls", len(svc.handleCalls))
+	}
+	if len(notices.texts) != 1 || notices.texts[0] != welcomeText {
+		t.Errorf("notice texts = %v, want one welcome notice", notices.texts)
+	}
+}
+
 func TestReceiverMessageEventStopAndAck(t *testing.T) {
 	svc := &fakeService{}
 	var acked []string

--- a/cmd/flock-telegram/commands_test.go
+++ b/cmd/flock-telegram/commands_test.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/go-telegram/bot/models"
 
+	"github.com/duckbugio/flock/adapters/telegram"
 	"github.com/duckbugio/flock/internal/config"
 )
 
@@ -63,6 +65,44 @@ func botCommandUpdate(text string, cmdLen int) *models.Update {
 		Text:     text,
 		Entities: []models.MessageEntity{{Type: models.MessageEntityTypeBotCommand, Offset: 0, Length: cmdLen}},
 	}}
+}
+
+// TestStartCommandRouted is the /start routing guard: /start must be matched as a command
+// (so it is handled by the start handler and never reaches the text/model path),
+// tolerating the group @botname suffix exactly like the other slash commands.
+// Without a /start handler the message falls through to the default text handler
+// and is forwarded to the model, which improvises a confusing reply.
+func TestStartCommandRouted(t *testing.T) {
+	match := commandMatch("start")
+	tests := []struct {
+		name string
+		u    *models.Update
+		want bool
+	}{
+		{"bare /start", botCommandUpdate("/start", 6), true},
+		{"group form /start@duck_bot", botCommandUpdate("/start@duck_bot", 15), true},
+		{"/start with args", botCommandUpdate("/start now", 6), true},
+		{"different command /stop", botCommandUpdate("/stop", 5), false},
+		{"nil update", nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := match(tt.u); got != tt.want {
+				t.Fatalf("commandMatch(start)(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestStartWelcomeText asserts the static /start reply is the welcome text: a
+// short greeting prepended to the usage help, plain English with no duck flavor.
+func TestStartWelcomeText(t *testing.T) {
+	if !strings.HasPrefix(telegram.WelcomeText, "Hi!") {
+		t.Fatalf("WelcomeText should open with a greeting, got %q", telegram.WelcomeText)
+	}
+	if !strings.Contains(telegram.WelcomeText, telegram.HelpText) {
+		t.Fatalf("WelcomeText should include the usage help (HelpText)")
+	}
 }
 
 // TestCommandMatchToleratesBotnameSuffix is the routing guard: a command handler

--- a/cmd/flock-telegram/main.go
+++ b/cmd/flock-telegram/main.go
@@ -257,6 +257,7 @@ func run() int {
 	// does NOT match (different command name). Each command is gated by the same
 	// allow-list as text messages and is NOT mention-gated (a slash command is an
 	// explicit address).
+	b.RegisterHandlerMatchFunc(commandMatch("start"), startHandler(cfg))
 	b.RegisterHandlerMatchFunc(commandMatch("help"), helpHandler(cfg))
 	b.RegisterHandlerMatchFunc(commandMatch("new"), newHandler(cfg, svc))
 	b.RegisterHandlerMatchFunc(commandMatch("stop"), stopCommandHandler(cfg, svc))
@@ -762,6 +763,21 @@ func commandSender(cfg config.Config, msg *models.Message) (int64, bool) {
 		return 0, false
 	}
 	return msg.Chat.ID, true
+}
+
+// startHandler replies to /start from an allowed user with the static welcome
+// text (a short greeting + the usage help). Like helpHandler it is gated by the
+// allow-list, is not mention-gated, and never touches the dispatcher or session
+// store (no Claude run) — without it /start would fall through to the text
+// handler and be forwarded to the model as a prompt.
+func startHandler(cfg config.Config) bot.HandlerFunc {
+	return func(ctx context.Context, b *bot.Bot, update *models.Update) {
+		chatID, ok := commandSender(cfg, update.Message)
+		if !ok {
+			return
+		}
+		sendCommandReply(ctx, b, chatID, telegram.WelcomeText)
+	}
 }
 
 // helpHandler replies to /help from an allowed user with the static usage text.

--- a/core/chat/progress.go
+++ b/core/chat/progress.go
@@ -271,7 +271,13 @@ func Final(res *claude.RunResult) string {
 	text := strings.TrimSpace(res.Text)
 	if res.IsError {
 		if text == "" {
-			text = "the run ended with an error"
+			// Surface the result subtype (e.g. "error_max_turns") when present so the
+			// cause isn't fully opaque; fall back to the plain message otherwise.
+			if res.Subtype != "" {
+				text = "the run ended with an error (" + res.Subtype + ")"
+			} else {
+				text = "the run ended with an error"
+			}
 		}
 		return "⚠️ " + text
 	}

--- a/core/chat/progress_test.go
+++ b/core/chat/progress_test.go
@@ -362,6 +362,17 @@ func TestFinalErrorResult(t *testing.T) {
 		t.Fatalf("empty error result not flagged: %q", empty)
 	}
 
+	// Diagnostic: an empty-bodied error Result surfaces the subtype so the cause
+	// isn't fully opaque.
+	withSub := Final(&claude.RunResult{Text: "", IsError: true, Subtype: "error_max_turns"})
+	if !strings.Contains(withSub, "error_max_turns") {
+		t.Fatalf("empty error result should include the subtype: %q", withSub)
+	}
+	// With no subtype the plain fallback is kept (no empty parentheses).
+	if empty != "⚠️ the run ended with an error" {
+		t.Fatalf("empty error result without subtype should use the plain fallback: %q", empty)
+	}
+
 	if got := Final(&claude.RunResult{Text: "", IsError: false}); got != "(empty response)" {
 		t.Fatalf("empty success placeholder: %q", got)
 	}

--- a/core/chat/service.go
+++ b/core/chat/service.go
@@ -56,15 +56,16 @@ type dispatcher interface {
 
 // sessionStore persists each chat's Claude session_id so the next message can
 // resume context via --resume. *session.FileStore satisfies it. A timeout/cancel
-// must NOT discard the stored id (plan §7.3), so the run path only ever Get/Set;
-// the sole Delete caller is the explicit /new reset (NewSession), never the run
-// or timeout path.
+// must NOT discard the stored id (plan §7.3), so the run path only ever Get/Set
+// on those paths. Delete has exactly two callers: the explicit /new reset
+// (NewSession) and the run path's self-heal when a RESUMED run ends in an
+// is_error result (a likely-stale id) — never a timeout, cancel, or RunError.
 type sessionStore interface {
 	Get(chatID ChatID) (sessionID string, ok bool)
 	Set(chatID ChatID, sessionID string) error
 	// Delete drops chatID's stored session id so the next message starts fresh
-	// (no --resume). Deleting an absent chat is a harmless no-op. Only the
-	// explicit /new reset calls this.
+	// (no --resume). Deleting an absent chat is a harmless no-op. Called by the
+	// explicit /new reset and by the run path's is_error-while-resuming self-heal.
 	Delete(chatID ChatID) error
 }
 

--- a/core/chat/service.go
+++ b/core/chat/service.go
@@ -313,10 +313,14 @@ func (s *Service) run(ctx context.Context, chatID ChatID, userID int64, prompt s
 
 	// Resume this chat's stored Claude session so the run continues its context
 	// (empty = a fresh session). Continuity survives restarts because the store is
-	// durable and reloaded on startup.
+	// durable and reloaded on startup. resuming records whether THIS run carried a
+	// non-empty resume id, so a terminal is_error Result can self-heal a stale/
+	// poisoned session id (see the clear after the event loop).
+	resuming := false
 	if s.sessions != nil {
-		if sid, ok := s.sessions.Get(chatID); ok {
+		if sid, ok := s.sessions.Get(chatID); ok && sid != "" {
 			opts.SessionID = sid
+			resuming = true
 		}
 	}
 
@@ -470,6 +474,20 @@ loop:
 	s.recordCost(userID, finalResult)
 
 	s.finish(ctx, chatID, progressMsgID, runID, finalResult, finalErr, ctx.Err())
+
+	// Self-heal a stale/poisoned resume id: when a run that USED a resume session
+	// id terminates with an is_error Result, drop the stored session for this chat
+	// so the NEXT message starts fresh (no --resume) instead of re-failing forever.
+	// This fires ONLY on an is_error Result while resuming — never on a clean
+	// Result, a RunError (a process/transport crash, likely transient — keep the
+	// context for a retry), or a Stop/timeout (finalResult nil). storeSession may
+	// have just re-persisted the id from this Result, so clear it here regardless.
+	if resuming && finalErr == nil && ctx.Err() == nil && finalResult != nil && finalResult.IsError {
+		s.log.Info("clearing session after error during resume; next message starts fresh", "chat_id", chatID)
+		if err := s.sessions.Delete(chatID); err != nil {
+			s.log.Error("clear session after error", "chat_id", chatID, "error", err)
+		}
+	}
 
 	// Post-task GitHub star nudge. Fire ONLY on a cleanly successful run (a
 	// terminal Result with no error and no cancel/timeout) so a failed, stopped,

--- a/core/chat/service_test.go
+++ b/core/chat/service_test.go
@@ -921,6 +921,161 @@ func TestSessionPreservedOnShutdown(t *testing.T) {
 	}
 }
 
+// errorResultRunner emits a SystemInit (so the session id is captured) followed
+// by a terminal Result whose IsError flag is configurable. It lets the
+// stale-session self-heal tests drive an is_error vs a clean Result. When init is
+// empty no SystemInit is emitted (a fresh run with no captured session id).
+type errorResultRunner struct {
+	init    string
+	isError bool
+}
+
+func (r *errorResultRunner) Run(ctx context.Context, _ string, _ claude.Options) (<-chan claude.Event, error) {
+	out := make(chan claude.Event)
+	go func() {
+		defer close(out)
+		if r.init != "" {
+			if !emit(ctx, out, claude.Event{Type: claude.SystemInit, SessionID: r.init}) {
+				return
+			}
+		}
+		emit(ctx, out, claude.Event{Type: claude.Result, Result: &claude.RunResult{
+			Text:      "done",
+			SessionID: r.init,
+			IsError:   r.isError,
+		}})
+	}()
+	return out, nil
+}
+
+// runErrorRunner emits a SystemInit (capturing the session id) then a RunError —
+// a process/transport crash, distinct from an is_error Result.
+type runErrorRunner struct{ init string }
+
+func (r *runErrorRunner) Run(ctx context.Context, _ string, _ claude.Options) (<-chan claude.Event, error) {
+	out := make(chan claude.Event)
+	go func() {
+		defer close(out)
+		if !emit(ctx, out, claude.Event{Type: claude.SystemInit, SessionID: r.init}) {
+			return
+		}
+		emit(ctx, out, claude.Event{Type: claude.RunError, Err: errors.New("transport crash")})
+	}()
+	return out, nil
+}
+
+// TestSessionClearedOnErrorResultWhileResuming is the stale-session self-heal: when a run
+// that USED a resume session id terminates with an is_error Result, the stored
+// session is cleared so the NEXT message starts fresh (no --resume) and recovers
+// from a stale/poisoned session id.
+func TestSessionClearedOnErrorResultWhileResuming(t *testing.T) {
+	fc := newFakeChat()
+	sess := newFakeSessions()
+	// Pre-seed a stored session id so this run resumes (opts.SessionID non-empty).
+	if err := sess.Set(testChatID, "stale-id"); err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+	fr := &errorResultRunner{init: "stale-id", isError: true}
+	svc, d := newTestServiceWithSessions(t, fr, fc, sess, 0)
+	defer d.Close()
+
+	svc.Handle(context.Background(), testChatID, 100, "1", "hello")
+
+	// The poisoned session must be cleared so the next message self-heals.
+	waitUntil(t, func() bool {
+		_, ok := sess.get()
+		return !ok
+	})
+	if dels := sess.deletes(); len(dels) != 1 || dels[0] != testChatID {
+		t.Fatalf("Delete calls = %v, want [%q]", dels, testChatID)
+	}
+}
+
+// TestSessionNotClearedOnCleanResultWhileResuming asserts a CLEAN Result while
+// resuming leaves the stored session intact (normal continuity).
+func TestSessionNotClearedOnCleanResultWhileResuming(t *testing.T) {
+	fc := newFakeChat()
+	sess := newFakeSessions()
+	if err := sess.Set(testChatID, "good-id"); err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+	fr := &errorResultRunner{init: "good-id", isError: false}
+	svc, d := newTestServiceWithSessions(t, fr, fc, sess, 0)
+	defer d.Close()
+
+	svc.Handle(context.Background(), testChatID, 100, "1", "hello")
+
+	// The terminal answer lands.
+	waitUntil(t, func() bool {
+		text, _ := fc.snapshot()
+		return strings.Contains(text, "done")
+	})
+	// The session is preserved (and never deleted).
+	if id, ok := sess.get(); !ok || id != "good-id" {
+		t.Fatalf("session Get = (%q, %v), want (good-id, true)", id, ok)
+	}
+	if dels := sess.deletes(); len(dels) != 0 {
+		t.Fatalf("Delete calls = %v, want none on a clean result", dels)
+	}
+}
+
+// TestSessionNotClearedOnErrorResultFreshRun asserts an is_error Result on a FRESH
+// run (no prior session id, so no resume) is a no-op: nothing to clear, no panic.
+func TestSessionNotClearedOnErrorResultFreshRun(t *testing.T) {
+	fc := newFakeChat()
+	sess := newFakeSessions()
+	// No pre-seeded session: the run starts fresh (opts.SessionID empty). The
+	// runner still emits a captured init id, which the run persists.
+	fr := &errorResultRunner{init: "new-id", isError: true}
+	svc, d := newTestServiceWithSessions(t, fr, fc, sess, 0)
+	defer d.Close()
+
+	svc.Handle(context.Background(), testChatID, 100, "1", "hello")
+
+	// The terminal answer lands (an is_error Result renders with the warning prefix).
+	waitUntil(t, func() bool {
+		text, _ := fc.snapshot()
+		return strings.Contains(text, "done")
+	})
+	// No Delete happened (the run was not resuming), and the freshly-captured id is
+	// kept so a genuinely new session continues.
+	if dels := sess.deletes(); len(dels) != 0 {
+		t.Fatalf("Delete calls = %v, want none on a fresh run", dels)
+	}
+	if id, ok := sess.get(); !ok || id != "new-id" {
+		t.Fatalf("session Get = (%q, %v), want (new-id, true)", id, ok)
+	}
+}
+
+// TestSessionNotClearedOnRunErrorWhileResuming asserts a RunError (process/
+// transport crash) while resuming does NOT clear the session — it is likely
+// transient, so the context is kept for a retry.
+func TestSessionNotClearedOnRunErrorWhileResuming(t *testing.T) {
+	fc := newFakeChat()
+	sess := newFakeSessions()
+	if err := sess.Set(testChatID, "keep-id"); err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+	fr := &runErrorRunner{init: "keep-id"}
+	svc, d := newTestServiceWithSessions(t, fr, fc, sess, 0)
+	defer d.Close()
+
+	svc.Handle(context.Background(), testChatID, 100, "1", "hello")
+
+	// The terminal error notice lands.
+	waitUntil(t, func() bool {
+		text, _ := fc.snapshot()
+		return strings.Contains(text, "transport crash")
+	})
+	// The session is preserved for a retry.
+	if id, ok := sess.get(); !ok || id != "keep-id" {
+		t.Fatalf("session Get = (%q, %v), want (keep-id, true)", id, ok)
+	}
+	if dels := sess.deletes(); len(dels) != 0 {
+		t.Fatalf("Delete calls = %v, want none on a RunError", dels)
+	}
+}
+
 // fixedOutbox resolves every chat to one fixed directory, for the finish-path
 // sweep tests.
 type fixedOutbox struct{ dir string }


### PR DESCRIPTION
## Summary

Fixes two bugs observed on the live bot. Each was fixed test-first (a failing reproduction test, then the fix).

## Bug 1 — `/start` leaked to the model

Only `/help`, `/new`, `/stop` were registered, so `/start` fell through to the default text handler and was sent to Claude as a prompt — the model then improvised a confusing "Unknown command… did you mean …" reply.

**Fix:** register a `/start` handler on both transports. It is gated by the same allow-list as the other commands, is **not** mention-gated, mutates no session, and starts no run — it replies with a short plain-English welcome + usage.
- `adapters/telegram/commands.go`: `WelcomeText` (greeting + `HelpText`).
- `cmd/flock-telegram/main.go`: `startHandler` + `commandMatch("start")` (structurally identical to `helpHandler`).
- `adapters/vk/receiver.go`: a `/start` case (after the allow-list gate) that replies via the notice sender and returns without dispatching.

## Bug 2 — a stale resume session permanently broke a chat ("the run ended with an error")

The per-chat session id was cleared only by `/new`. After a redeploy (a fresh container with a session id in the store that no longer exists in the CLI), `--resume <id>` returned an `is_error` result on **every** message until the user manually ran `/new` — the chat was stuck.

**Fix (surgical, in `core/chat`):** when a run that **was resuming** a stored session ends in an **`is_error` Result**, clear that chat's stored session so the next message self-heals with a fresh session. The trigger is the tight conjunction `resuming && finalErr==nil && ctx.Err()==nil && finalResult!=nil && finalResult.IsError` — it does **not** fire on a clean result, on a `RunError` (process/transport crash, likely transient — context kept), or on Stop/timeout. The clear runs after the event loop so a mid-run `storeSession` cannot undo it, and uses the same `Delete` primitive `/new` uses.
- Diagnostic: `Final()` now surfaces the result `Subtype` when an error result carries no text (`the run ended with an error (<subtype>)`).

## Verification

Via the CI image (`dev-tools`): `gofmt -l .` empty · `go build ./...` · `go vet ./...` · `golangci-lint run` **0 issues** · `go test -race ./...` **all green**, including the new test-first reproductions:
- Telegram/VK `/start` routed to the handler (not the model);
- session cleared on is_error-while-resuming; **not** cleared on a clean result, a fresh-run error, or a `RunError`.

## Tradeoff (intentional)

Bug 2's self-heal means an `is_error` turn during a resumed chat drops the conversation context (next message starts fresh). This is deliberate: a chat stuck forever on a poisoned session is worse than losing one turn's context. A `RunError` (transient crash) keeps the session.

## Not included (separate, pending info)

A third observed issue — a leftover live-progress "Working…" bubble duplicating the final answer — touches the Telegram `StreamDraft` path and depends on that platform feature's behavior. It is intentionally **out of this PR** to avoid a blind change to the live-progress path; it will land on this same branch once its root cause is confirmed from the bot's logs.
