### PR TITLE
build(deps): pin adapter Node base images to LTS; stop Dependabot major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,14 @@ updates:
     labels:
       - dependencies
       - docker
+    # The runtime base hosts the `claude` CLI and must stay on a Node LTS line.
+    # Node majors are bumped manually only once the next even release reaches LTS
+    # (e.g. node 26 becomes LTS in Oct 2026); ignore automatic major bumps so
+    # Dependabot stops re-proposing the non-LTS Current line every week.
+    ignore:
+      - dependency-name: node
+        update-types:
+          - version-update:semver-major
 
   - package-ecosystem: docker
     directory: /adapters/vk
@@ -32,6 +40,11 @@ updates:
     labels:
       - dependencies
       - docker
+    # Same LTS policy as the telegram adapter above: no automatic Node major bumps.
+    ignore:
+      - dependency-name: node
+        update-types:
+          - version-update:semver-major
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
Adds an `ignore` rule for Node `version-update:semver-major` to both Docker adapter entries (`telegram`, `vk`) in `.github/dependabot.yml`.

## Why
The adapter runtime images host the `claude` CLI (`@anthropic-ai/claude-code`), so the Node base must track an **LTS** line. Node 26 is the **Current (non-LTS)** release until **Oct 2026**, which is why the auto-proposed major bumps were declined:

- #7 (telegram 22→26) — closed, superseded by #8 which moved telegram to **node:24 (LTS)** instead.
- #14 (vk 24→26) — closed for the same reason; vk stays on **node:24**.

Without an ignore rule, Dependabot re-opens these major bumps every Monday. This pins both adapters to LTS and lets us bump the major **manually** once the next even release actually reaches LTS.

## Acceptance
- **AC1** — both `docker` adapter entries (`/adapters/telegram`, `/adapters/vk`) carry an `ignore` for `dependency-name: node` / `version-update:semver-major`.
- **AC2** — minor/patch Node updates and all other ecosystems are unaffected (only Node majors are ignored).
- **AC3** — no Dockerfile `FROM` changes; runtime stays on `node:24-bookworm-slim`.

## Verification
- `.github/dependabot.yml` indentation matches the existing `labels:` blocks; the `ignore` schema follows GitHub's documented config.
- Diff is config-only, no image or code changes.