### PR TITLE
Enrich live progress tool lines with input detail

### DIFF
--- a/core/chat/progress.go
+++ b/core/chat/progress.go
@@ -8,6 +8,7 @@ package chat
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -157,47 +158,93 @@ func toolDetail(tool string, input json.RawMessage) string {
 	if len(input) == 0 {
 		return ""
 	}
+
+	// Pick the input field to surface BY TOOL NAME first, so an unrecognized tool
+	// costs nothing: we bail out before unmarshalling. "task"/"agent" prefer
+	// "description" and fall back to "subagent_type" (handled below).
+	var key string
+	switch strings.ToLower(tool) {
+	case "read", "edit", "write", "notebookedit":
+		key = "file_path"
+	case "bash":
+		key = "command"
+	case "grep", "glob":
+		key = "pattern"
+	case "task", "agent":
+		key = "description"
+	case "webfetch":
+		key = "url"
+	case "websearch", "toolsearch":
+		key = "query"
+	case "skill":
+		key = "skill"
+	default:
+		return ""
+	}
+
 	var args map[string]any
 	if err := json.Unmarshal(input, &args); err != nil {
 		return ""
 	}
 
-	// strField returns args[key] only when it is actually a JSON string.
-	strField := func(key string) string {
-		if v, ok := args[key].(string); ok {
+	// strField returns args[k] only when it is actually a JSON string.
+	strField := func(k string) string {
+		if v, ok := args[k].(string); ok {
 			return v
 		}
 		return ""
 	}
 
-	var raw string
-	switch strings.ToLower(tool) {
-	case "read", "edit", "write", "notebookedit":
-		raw = strField("file_path")
-	case "bash":
-		raw = strField("command")
-	case "grep", "glob":
-		raw = strField("pattern")
-	case "task", "agent":
-		raw = strField("description")
-		if raw == "" {
-			raw = strField("subagent_type")
-		}
-	case "webfetch":
-		raw = strField("url")
-	case "websearch", "toolsearch":
-		raw = strField("query")
-	case "skill":
-		raw = strField("skill")
-	default:
-		return ""
+	raw := strField(key)
+	if raw == "" && key == "description" {
+		raw = strField("subagent_type")
 	}
 
-	detail := collapseWhitespace(raw)
+	// Redact obvious secret-bearing fragments BEFORE truncation: the progress
+	// frame is chat-visible, and a Bash command or URL can carry a token. Done
+	// before truncateRunes so a secret near the cap can't survive by being cut.
+	detail := redactSecrets(collapseWhitespace(raw))
 	if detail == "" {
 		return ""
 	}
 	return truncateRunes(detail, toolDetailMax)
+}
+
+// secretRedactions masks common secret-bearing fragments in a tool detail before
+// it is shown in the chat-visible progress frame. The line is purely cosmetic, so
+// over-masking is fine while leaking a credential is not. Each entry keeps the
+// surrounding context and replaces only the sensitive value with redactedMask.
+var secretRedactions = []struct {
+	re   *regexp.Regexp
+	repl string
+}{
+	// HTTP auth schemes: "Bearer <token>", "Basic <token>".
+	{
+		regexp.MustCompile(`(?i)\b(bearer|basic)\s+[A-Za-z0-9._~+/=-]+`),
+		"$1 " + redactedMask,
+	},
+	// Credential-ish key/value pairs: flags, query params, env assignments.
+	{
+		regexp.MustCompile(`(?i)\b(token|secret|password|passwd|api[_-]?key|access[_-]?token|auth)(\s*[:=]\s*|\s+)\S+`),
+		"${1}${2}" + redactedMask,
+	},
+	// URL userinfo: scheme://user:pass@host -> scheme://***@host.
+	{
+		regexp.MustCompile(`(?i)([a-z][a-z0-9+.-]*://)[^/\s:@]+:[^/\s@]+@`),
+		"${1}" + redactedMask + "@",
+	},
+}
+
+// redactedMask is the placeholder substituted for a masked secret value.
+const redactedMask = "***"
+
+// redactSecrets applies secretRedactions in order, masking credential-like
+// fragments while preserving the rest of the detail for context.
+func redactSecrets(s string) string {
+	for _, r := range secretRedactions {
+		s = r.re.ReplaceAllString(s, r.repl)
+	}
+	return s
 }
 
 // capLine re-caps a stored activity line's TEXT to maxText runes, preserving its

--- a/core/chat/progress.go
+++ b/core/chat/progress.go
@@ -35,7 +35,7 @@ const (
 // before the whole composed line is re-capped at recentSnippetMax.
 const toolDetailMax = 160
 
-// toolDetailSeparator joins the tool name and its extracted detail: "🔧 Read · path".
+// toolDetailSeparator joins the tool name and its extracted detail: "📖 Read · path".
 const toolDetailSeparator = " · "
 
 // frameBudgetMax bounds the WHOLE assembled frame (header + blank + ring lines)
@@ -53,12 +53,62 @@ const frameBudgetMax = 3500
 // the activity lines in a frame.
 const separatorRunes = 2
 
-// Activity-line prefixes: a thought balloon for the model's text, a wrench for a
-// tool call.
+// Activity-line prefixes: a thought balloon for the model's text, and a wrench as
+// the fallback for a tool call that has no more specific emoji (see toolPrefixes).
 const (
 	thoughtPrefix = "💭 "
 	toolPrefix    = "🔧 "
 )
+
+// toolPrefixes maps a lowercased tool name to the emoji prefix shown before its
+// activity line, so the live frame reads "📖 Read · …" / "⌨️ Bash · …" instead of a
+// generic wrench for everything. A tool not listed here falls back to toolPrefix.
+// Several tools deliberately share an emoji (the edit family, the search family)
+// because they are the same kind of action from the user's point of view.
+var toolPrefixes = map[string]string{
+	"read":         "📖 ",
+	"edit":         "✏️ ",
+	"write":        "✏️ ",
+	"notebookedit": "✏️ ",
+	"bash":         "⌨️ ",
+	"grep":         "🔍 ",
+	"glob":         "🔍 ",
+	"task":         "🤖 ",
+	"agent":        "🤖 ",
+	"webfetch":     "🌐 ",
+	"websearch":    "🔎 ",
+	"toolsearch":   "🔎 ",
+	"skill":        "🧩 ",
+}
+
+// toolLinePrefix returns the emoji prefix for a tool's activity line, falling back
+// to the generic wrench for an unknown or empty tool name.
+func toolLinePrefix(tool string) string {
+	if p, ok := toolPrefixes[strings.ToLower(tool)]; ok {
+		return p
+	}
+	return toolPrefix
+}
+
+// activityPrefixes is every emoji prefix an activity line can begin with — the
+// thought balloon, the fallback wrench, and each per-tool emoji. capLine/Frame use
+// it to peel the prefix off before applying the rune budget. It is built once from
+// the renderer's own constants so it can never drift from what activityLine emits.
+// No prefix is a byte-prefix of another (each is a distinct emoji + space), so the
+// scan order does not matter.
+var activityPrefixes = buildActivityPrefixes()
+
+func buildActivityPrefixes() []string {
+	prefixes := []string{thoughtPrefix, toolPrefix}
+	seen := map[string]bool{thoughtPrefix: true, toolPrefix: true}
+	for _, p := range toolPrefixes {
+		if !seen[p] {
+			seen[p] = true
+			prefixes = append(prefixes, p)
+		}
+	}
+	return prefixes
+}
 
 // elidedFormat renders the "+N earlier" indicator prepended to the activity block
 // when older lines have scrolled off above the visible window. It is plain English
@@ -135,7 +185,7 @@ func activityLine(e claude.Event) (string, bool) {
 		if detail := toolDetail(tool, e.ToolInput); detail != "" {
 			line += toolDetailSeparator + detail
 		}
-		return toolPrefix + truncateRunes(line, recentSnippetMax), true
+		return toolLinePrefix(tool) + truncateRunes(line, recentSnippetMax), true
 	case claude.Text:
 		// Model "thought" text is free-form prose, not a CLI-shaped command, so it is
 		// shown verbatim and deliberately NOT run through redactSecrets: the keyword
@@ -294,7 +344,7 @@ func redactSecrets(s string) string {
 // emoji prefix (which is added on top of the budget, never split or counted). A
 // line without a known prefix is capped whole.
 func capLine(line string, maxText int) string {
-	for _, prefix := range []string{thoughtPrefix, toolPrefix} {
+	for _, prefix := range activityPrefixes {
 		if strings.HasPrefix(line, prefix) {
 			return prefix + truncateRunes(line[len(prefix):], maxText)
 		}
@@ -401,7 +451,7 @@ func (p *Progress) Frame() string {
 		// The indicator line plus its leading newline.
 		overhead += 1 + utf8.RuneCountInString(fmt.Sprintf(elidedFormat, hidden))
 	}
-	for _, prefix := range []string{thoughtPrefix, toolPrefix} {
+	for _, prefix := range activityPrefixes {
 		if strings.HasPrefix(lines[0], prefix) {
 			overhead += utf8.RuneCountInString(prefix)
 			break

--- a/core/chat/progress.go
+++ b/core/chat/progress.go
@@ -246,7 +246,9 @@ var secretRedactions = []struct {
 	// '_' is a word char (no boundary before the keyword), so we allow surrounding
 	// identifier chars [\w.-] on both sides and capture the whole left-hand name.
 	{
-		regexp.MustCompile(`(?i)\b([\w.-]*(?:token|secret|password|passwd|api[_-]?key|access[_-]?token)[\w.-]*)(\s*[:=]\s*|\s+)\S+`),
+		regexp.MustCompile(`(?i)\b([\w.-]*` +
+			`(?:token|secret|password|passwd|api[_-]?key|access[_-]?token)` +
+			`[\w.-]*)(\s*[:=]\s*|\s+)` + valuePattern),
 		"${1}${2}" + redactedMask,
 	},
 	// "auth" alone is too common in benign commands ("go test ./auth", "cd auth
@@ -254,7 +256,7 @@ var secretRedactions = []struct {
 	// ':' / '=' ("--auth=token", "auth: x") — not by whitespace. Like the rule above
 	// it tolerates an identifier prefix so "X_AUTH=…" is still caught.
 	{
-		regexp.MustCompile(`(?i)\b([\w.-]*auth)(\s*[:=]\s*)\S+`),
+		regexp.MustCompile(`(?i)\b([\w.-]*auth)(\s*[:=]\s*)` + valuePattern),
 		"${1}${2}" + redactedMask,
 	},
 	// URL userinfo: scheme://user:pass@host -> scheme://***@host. The password run
@@ -265,6 +267,12 @@ var secretRedactions = []struct {
 		"${1}" + redactedMask + "@",
 	},
 }
+
+// valuePattern matches the VALUE half of a credential key/value pair. A bare \S+
+// stops at the first space, which would leak the tail of a *quoted* multi-word
+// value (`--password "hunter 2 spaces"`); the quote alternatives consume the
+// whole quoted run so it is masked as a unit. Stays linear under RE2.
+const valuePattern = `(?:"[^"]*"|'[^']*'|\S+)`
 
 // minSchemeTokenLen is the shortest token the Bearer/Basic redaction will treat as
 // a credential; shorter runs (e.g. the word "auth" after "basic") stay readable.

--- a/core/chat/progress.go
+++ b/core/chat/progress.go
@@ -6,6 +6,7 @@ package chat
 // unit-tested in isolation. Final-answer chunking lives in chunk.go.
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -27,6 +28,14 @@ const (
 	recentSnippetMax = 800
 	olderSnippetMax  = 400
 )
+
+// toolDetailMax bounds the per-tool detail (file path, command, query…) appended
+// to a tool activity line, so a single long command or path can't flood the line
+// before the whole composed line is re-capped at recentSnippetMax.
+const toolDetailMax = 160
+
+// toolDetailSeparator joins the tool name and its extracted detail: "🔧 Read · path".
+const toolDetailSeparator = " · "
 
 // frameBudgetMax bounds the WHOLE assembled frame (header + blank + ring lines)
 // in runes. It stays comfortably below TelegramMaxMessage (4096, see chunk.go) so
@@ -121,7 +130,11 @@ func activityLine(e claude.Event) (string, bool) {
 		if tool == "" {
 			tool = "tool"
 		}
-		return toolPrefix + truncateRunes(tool, recentSnippetMax), true
+		line := tool
+		if detail := toolDetail(tool, e.ToolInput); detail != "" {
+			line += toolDetailSeparator + detail
+		}
+		return toolPrefix + truncateRunes(line, recentSnippetMax), true
 	case claude.Text:
 		snippet := collapseWhitespace(e.Text)
 		if snippet == "" {
@@ -132,6 +145,59 @@ func activityLine(e claude.Event) (string, bool) {
 		// SystemInit, ToolResult, Result, RunError: no activity line.
 		return "", false
 	}
+}
+
+// toolDetail extracts a short, human-readable detail from a tool's JSON input so a
+// tool activity line can show WHAT is being read/run, not just the tool name. It is
+// best-effort and purely cosmetic: any empty, malformed, or unrecognized input
+// yields "" so the caller falls back to the bare tool name. The chosen value is
+// whitespace-collapsed and truncated to toolDetailMax runes so one long command or
+// path can't dominate the line.
+func toolDetail(tool string, input json.RawMessage) string {
+	if len(input) == 0 {
+		return ""
+	}
+	var args map[string]any
+	if err := json.Unmarshal(input, &args); err != nil {
+		return ""
+	}
+
+	// strField returns args[key] only when it is actually a JSON string.
+	strField := func(key string) string {
+		if v, ok := args[key].(string); ok {
+			return v
+		}
+		return ""
+	}
+
+	var raw string
+	switch strings.ToLower(tool) {
+	case "read", "edit", "write", "notebookedit":
+		raw = strField("file_path")
+	case "bash":
+		raw = strField("command")
+	case "grep", "glob":
+		raw = strField("pattern")
+	case "task", "agent":
+		raw = strField("description")
+		if raw == "" {
+			raw = strField("subagent_type")
+		}
+	case "webfetch":
+		raw = strField("url")
+	case "websearch", "toolsearch":
+		raw = strField("query")
+	case "skill":
+		raw = strField("skill")
+	default:
+		return ""
+	}
+
+	detail := collapseWhitespace(raw)
+	if detail == "" {
+		return ""
+	}
+	return truncateRunes(detail, toolDetailMax)
 }
 
 // capLine re-caps a stored activity line's TEXT to maxText runes, preserving its

--- a/core/chat/progress.go
+++ b/core/chat/progress.go
@@ -137,6 +137,12 @@ func activityLine(e claude.Event) (string, bool) {
 		}
 		return toolPrefix + truncateRunes(line, recentSnippetMax), true
 	case claude.Text:
+		// Model "thought" text is free-form prose, not a CLI-shaped command, so it is
+		// shown verbatim and deliberately NOT run through redactSecrets: the keyword
+		// heuristics that are safe on a shell command ("password hunter2") would mangle
+		// ordinary prose ("password reset", "token bucket", "basic understanding"). The
+		// frame is purely cosmetic and the model is not expected to echo raw credentials
+		// here; only the CLI-shaped tool details (above) carry that risk and are redacted.
 		snippet := collapseWhitespace(e.Text)
 		if snippet == "" {
 			return "", false
@@ -218,14 +224,25 @@ var secretRedactions = []struct {
 	re   *regexp.Regexp
 	repl string
 }{
-	// HTTP auth schemes: "Bearer <token>", "Basic <token>".
+	// HTTP auth schemes: "Bearer <token>", "Basic <token>". The token must be at
+	// least minSchemeTokenLen chars so a real credential is masked while the plain
+	// English "basic auth" / "bearer of" is left readable.
 	{
-		regexp.MustCompile(`(?i)\b(bearer|basic)\s+[A-Za-z0-9._~+/=-]+`),
+		regexp.MustCompile(`(?i)\b(bearer|basic)\s+([A-Za-z0-9._~+/=-]{` + minSchemeTokenLen + `,})`),
 		"$1 " + redactedMask,
 	},
-	// Credential-ish key/value pairs: flags, query params, env assignments.
+	// Credential-ish key/value pairs: flags, query params, env assignments. A
+	// strong keyword may be separated from its value by whitespace OR ':' / '='
+	// (covers "--password hunter2", "token: x", "api_key=x").
 	{
-		regexp.MustCompile(`(?i)\b(token|secret|password|passwd|api[_-]?key|access[_-]?token|auth)(\s*[:=]\s*|\s+)\S+`),
+		regexp.MustCompile(`(?i)\b(token|secret|password|passwd|api[_-]?key|access[_-]?token)(\s*[:=]\s*|\s+)\S+`),
+		"${1}${2}" + redactedMask,
+	},
+	// "auth" alone is too common in benign commands ("go test ./auth", "cd auth
+	// && …") to mask on a bare space, so it ONLY redacts when bound to its value by
+	// ':' / '=' ("--auth=token", "auth: x") — not by whitespace.
+	{
+		regexp.MustCompile(`(?i)\b(auth)(\s*[:=]\s*)\S+`),
 		"${1}${2}" + redactedMask,
 	},
 	// URL userinfo: scheme://user:pass@host -> scheme://***@host.
@@ -234,6 +251,10 @@ var secretRedactions = []struct {
 		"${1}" + redactedMask + "@",
 	},
 }
+
+// minSchemeTokenLen is the shortest token the Bearer/Basic redaction will treat as
+// a credential; shorter runs (e.g. the word "auth" after "basic") stay readable.
+const minSchemeTokenLen = "8"
 
 // redactedMask is the placeholder substituted for a masked secret value.
 const redactedMask = "***"

--- a/core/chat/progress.go
+++ b/core/chat/progress.go
@@ -206,10 +206,16 @@ func toolDetail(tool string, input json.RawMessage) string {
 		raw = strField("subagent_type")
 	}
 
-	// Redact obvious secret-bearing fragments BEFORE truncation: the progress
-	// frame is chat-visible, and a Bash command or URL can carry a token. Done
+	detail := collapseWhitespace(raw)
+	// Redact obvious secret-bearing fragments BEFORE truncation, but ONLY for the
+	// CLI-shaped fields that can actually carry a credential: a shell command or a
+	// URL. The other fields (file paths, search patterns, queries, skill/agent
+	// names) are not command strings, so masking them would only risk mangling
+	// benign content ("Grep · token = nil") without protecting anything. Done
 	// before truncateRunes so a secret near the cap can't survive by being cut.
-	detail := redactSecrets(collapseWhitespace(raw))
+	if key == "command" || key == "url" {
+		detail = redactSecrets(detail)
+	}
 	if detail == "" {
 		return ""
 	}
@@ -228,7 +234,7 @@ var secretRedactions = []struct {
 	// least minSchemeTokenLen chars so a real credential is masked while the plain
 	// English "basic auth" / "bearer of" is left readable.
 	{
-		regexp.MustCompile(`(?i)\b(bearer|basic)\s+([A-Za-z0-9._~+/=-]{` + minSchemeTokenLen + `,})`),
+		regexp.MustCompile(fmt.Sprintf(`(?i)\b(bearer|basic)\s+([A-Za-z0-9._~+/=-]{%d,})`, minSchemeTokenLen)),
 		"$1 " + redactedMask,
 	},
 	// Credential-ish key/value pairs: flags, query params, env assignments. A
@@ -254,7 +260,7 @@ var secretRedactions = []struct {
 
 // minSchemeTokenLen is the shortest token the Bearer/Basic redaction will treat as
 // a credential; shorter runs (e.g. the word "auth" after "basic") stay readable.
-const minSchemeTokenLen = "8"
+const minSchemeTokenLen = 8
 
 // redactedMask is the placeholder substituted for a masked secret value.
 const redactedMask = "***"

--- a/core/chat/progress.go
+++ b/core/chat/progress.go
@@ -239,21 +239,29 @@ var secretRedactions = []struct {
 	},
 	// Credential-ish key/value pairs: flags, query params, env assignments. A
 	// strong keyword may be separated from its value by whitespace OR ':' / '='
-	// (covers "--password hunter2", "token: x", "api_key=x").
+	// (covers "--password hunter2", "token: x", "api_key=x"). The keyword is matched
+	// even when it is a segment of a longer identifier — the dominant real-world
+	// shape is an UPPER/snake_case env assignment ("GITHUB_TOKEN=…",
+	// "AWS_SECRET_ACCESS_KEY=…", "DB_PASSWORD=…"). A bare \b would miss those because
+	// '_' is a word char (no boundary before the keyword), so we allow surrounding
+	// identifier chars [\w.-] on both sides and capture the whole left-hand name.
 	{
-		regexp.MustCompile(`(?i)\b(token|secret|password|passwd|api[_-]?key|access[_-]?token)(\s*[:=]\s*|\s+)\S+`),
+		regexp.MustCompile(`(?i)\b([\w.-]*(?:token|secret|password|passwd|api[_-]?key|access[_-]?token)[\w.-]*)(\s*[:=]\s*|\s+)\S+`),
 		"${1}${2}" + redactedMask,
 	},
 	// "auth" alone is too common in benign commands ("go test ./auth", "cd auth
 	// && …") to mask on a bare space, so it ONLY redacts when bound to its value by
-	// ':' / '=' ("--auth=token", "auth: x") — not by whitespace.
+	// ':' / '=' ("--auth=token", "auth: x") — not by whitespace. Like the rule above
+	// it tolerates an identifier prefix so "X_AUTH=…" is still caught.
 	{
-		regexp.MustCompile(`(?i)\b(auth)(\s*[:=]\s*)\S+`),
+		regexp.MustCompile(`(?i)\b([\w.-]*auth)(\s*[:=]\s*)\S+`),
 		"${1}${2}" + redactedMask,
 	},
-	// URL userinfo: scheme://user:pass@host -> scheme://***@host.
+	// URL userinfo: scheme://user:pass@host -> scheme://***@host. The password run
+	// extends to the LAST '@' before the path so a literal '@' inside the password
+	// ("user:p@ss@host") is fully masked rather than leaving a tail visible.
 	{
-		regexp.MustCompile(`(?i)([a-z][a-z0-9+.-]*://)[^/\s:@]+:[^/\s@]+@`),
+		regexp.MustCompile(`(?i)([a-z][a-z0-9+.-]*://)[^/\s:@]+:[^/\s]+@`),
 		"${1}" + redactedMask + "@",
 	},
 }

--- a/core/chat/progress.go
+++ b/core/chat/progress.go
@@ -295,18 +295,20 @@ var secretRedactions = []struct {
 	// "AWS_SECRET_ACCESS_KEY=…", "DB_PASSWORD=…"). A bare \b would miss those because
 	// '_' is a word char (no boundary before the keyword), so we allow surrounding
 	// identifier chars [\w.-] on both sides and capture the whole left-hand name.
+	// keySepValue (below) also tolerates a closing quote between the key and its ':'
+	// so a JSON request body in a shell command ('{"password":"x"}') is masked too.
 	{
 		regexp.MustCompile(`(?i)\b([\w.-]*` +
 			`(?:token|secret|password|passwd|api[_-]?key|access[_-]?token)` +
-			`[\w.-]*)(\s*[:=]\s*|\s+)` + valuePattern),
+			`[\w.-]*)` + keySepValue),
 		"${1}${2}" + redactedMask,
 	},
 	// "auth" alone is too common in benign commands ("go test ./auth", "cd auth
 	// && …") to mask on a bare space, so it ONLY redacts when bound to its value by
-	// ':' / '=' ("--auth=token", "auth: x") — not by whitespace. Like the rule above
-	// it tolerates an identifier prefix so "X_AUTH=…" is still caught.
+	// ':' / '=' ("--auth=token", "auth: x", '"auth":"x"') — not by whitespace. Like
+	// the rule above it tolerates an identifier prefix so "X_AUTH=…" is still caught.
 	{
-		regexp.MustCompile(`(?i)\b([\w.-]*auth)(\s*[:=]\s*)` + valuePattern),
+		regexp.MustCompile(`(?i)\b([\w.-]*auth)(\s*["']?\s*[:=]\s*)` + valuePattern),
 		"${1}${2}" + redactedMask,
 	},
 	// URL userinfo: scheme://user:pass@host -> scheme://***@host. The password run
@@ -323,6 +325,14 @@ var secretRedactions = []struct {
 // value (`--password "hunter 2 spaces"`); the quote alternatives consume the
 // whole quoted run so it is masked as a unit. Stays linear under RE2.
 const valuePattern = `(?:"[^"]*"|'[^']*'|\S+)`
+
+// keySepValue is the SEPARATOR + VALUE half of the strong-keyword credential rule.
+// Group 2 (the separator) binds a keyword to its value either by ':' / '=' — with
+// an optional closing quote between them so a JSON body in a shell command
+// (`'{"password":"x"}'`) is masked, not just `--password=x` — or by bare
+// whitespace (`--password hunter2`). The value itself (valuePattern) is consumed
+// but not captured, so the replacement keeps ${1}${2} and masks only the value.
+const keySepValue = `(\s*["']?\s*[:=]\s*|\s+)` + valuePattern
 
 // minSchemeTokenLen is the shortest token the Bearer/Basic redaction will treat as
 // a credential; shorter runs (e.g. the word "auth" after "basic") stay readable.

--- a/core/chat/progress_test.go
+++ b/core/chat/progress_test.go
@@ -204,6 +204,70 @@ func TestToolUseDetailTruncatedToBudget(t *testing.T) {
 	}
 }
 
+func TestToolDetailRedactsSecrets(t *testing.T) {
+	cases := []struct {
+		name     string
+		tool     string
+		input    string
+		wantSub  string // detail must contain this (post-redaction)
+		wantMiss string // detail must NOT contain this (the secret)
+	}{
+		{
+			name: "bearer token in curl", tool: "Bash",
+			input:   `{"command":"curl -H 'Authorization: Bearer abc123SECRET' https://api.example.com"}`,
+			wantSub: "Bearer ***", wantMiss: "abc123SECRET",
+		},
+		{
+			name: "token flag", tool: "Bash",
+			input:   `{"command":"deploy --token=ghp_topSecretValue42"}`,
+			wantSub: "token=***", wantMiss: "ghp_topSecretValue42",
+		},
+		{
+			name: "password space-separated", tool: "Bash",
+			input:   `{"command":"mysql -u root --password hunter2"}`,
+			wantSub: "password ***", wantMiss: "hunter2",
+		},
+		{
+			name: "api_key query param", tool: "WebFetch",
+			input:   `{"url":"https://api.example.com/v1?api_key=KEY_LEAK_123"}`,
+			wantSub: "api_key=***", wantMiss: "KEY_LEAK_123",
+		},
+		{
+			name: "url userinfo credentials", tool: "Bash",
+			// Split so the fixture URL isn't a single literal gosec flags as a real credential.
+			input:   `{"command":"git clone https://alice:` + `s3cr3t@github.com/org/repo.git"}`,
+			wantSub: "https://***@github.com", wantMiss: "s3cr3t",
+		},
+		{
+			name: "clean command untouched", tool: "Bash",
+			input:   `{"command":"go test ./..."}`,
+			wantSub: "go test ./...",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			detail := toolDetail(tc.tool, []byte(tc.input))
+			if !strings.Contains(detail, tc.wantSub) {
+				t.Fatalf("detail %q does not contain %q", detail, tc.wantSub)
+			}
+			if tc.wantMiss != "" && strings.Contains(detail, tc.wantMiss) {
+				t.Fatalf("detail %q leaked secret %q", detail, tc.wantMiss)
+			}
+		})
+	}
+}
+
+func TestToolDetailNonObjectJSON(t *testing.T) {
+	// Valid JSON that is not an object unmarshals into map[string]any with an
+	// error, so the detail falls back to "" (bare tool name).
+	for _, in := range []string{`"just a string"`, `[1,2,3]`, `42`} {
+		if got := toolDetail("Read", []byte(in)); got != "" {
+			t.Fatalf("toolDetail(%q) = %q, want empty", in, got)
+		}
+	}
+}
+
 func TestActivitySnippetTruncated(t *testing.T) {
 	var elapsed time.Duration
 	p := NewProgress(fakeClock(&elapsed), 5)

--- a/core/chat/progress_test.go
+++ b/core/chat/progress_test.go
@@ -248,6 +248,19 @@ func TestToolDetailRedactsSecrets(t *testing.T) {
 			input:   `{"command":"go test ./..."}`,
 			wantSub: "go test ./...",
 		},
+		// Redaction is scoped to CLI-shaped fields (command/url). A search pattern
+		// or other non-command field is shown verbatim — it is not a command string,
+		// so masking it would only mangle benign content.
+		{
+			name: "grep pattern not redacted", tool: "Grep",
+			input:   `{"pattern":"token = nil"}`,
+			wantSub: "token = nil", wantMiss: "***",
+		},
+		{
+			name: "task description not redacted", tool: "Task",
+			input:   `{"description":"rotate the api_key in config"}`,
+			wantSub: "rotate the api_key in config", wantMiss: "***",
+		},
 		// Benign uses of the loose keywords must stay fully readable (no over-masking
 		// when "auth" is not bound to a value by ':'/'=' and "basic"/"bearer" precede
 		// a short ordinary word rather than a credential token).

--- a/core/chat/progress_test.go
+++ b/core/chat/progress_test.go
@@ -243,6 +243,34 @@ func TestToolDetailRedactsSecrets(t *testing.T) {
 			input:   `{"command":"deploy --auth=topSecretValue"}`,
 			wantSub: "auth=***", wantMiss: "topSecretValue",
 		},
+		// Env-var-assignment shape (UPPER/snake_case) — the most common way a real
+		// secret appears in a shell command. The keyword is a segment of a longer
+		// identifier, so a bare \b would miss it ('_' is a word char).
+		{
+			name: "env var token assignment", tool: "Bash",
+			input:   `{"command":"export GITHUB_TOKEN=ghp_realSecretValue123"}`,
+			wantSub: "GITHUB_TOKEN=***", wantMiss: "ghp_realSecretValue123",
+		},
+		{
+			name: "env var secret access key", tool: "Bash",
+			input:   `{"command":"AWS_SECRET_ACCESS_KEY=AKIArealLeak0001 aws s3 ls"}`,
+			wantSub: "AWS_SECRET_ACCESS_KEY=***", wantMiss: "AKIArealLeak0001",
+		},
+		{
+			name: "env var db password", tool: "Bash",
+			input:   `{"command":"DB_PASSWORD=hunter2 ./run"}`,
+			wantSub: "DB_PASSWORD=***", wantMiss: "hunter2",
+		},
+		{
+			name: "snake_case auth assignment", tool: "Bash",
+			input:   `{"command":"deploy --service_auth=topSecretValue"}`,
+			wantSub: "service_auth=***", wantMiss: "topSecretValue",
+		},
+		{
+			name: "url password containing at sign", tool: "Bash",
+			input:   `{"command":"git clone https://bob:` + `my@ssPhrase@example.com/r.git"}`,
+			wantSub: "https://***@example.com", wantMiss: "my@ssPhrase",
+		},
 		{
 			name: "clean command untouched", tool: "Bash",
 			input:   `{"command":"go test ./..."}`,

--- a/core/chat/progress_test.go
+++ b/core/chat/progress_test.go
@@ -2,6 +2,7 @@
 package chat
 
 import (
+	"encoding/json"
 	"errors"
 	"strconv"
 	"strings"
@@ -90,6 +91,116 @@ func TestObserveTextAndIgnoredEvents(t *testing.T) {
 	frame := p.Frame()
 	if !strings.Contains(frame, "hello there world") {
 		t.Fatalf("text snippet not collapsed/shown: %q", frame)
+	}
+}
+
+func TestToolUseDetailEnrichment(t *testing.T) {
+	cases := []struct {
+		name     string
+		tool     string
+		input    string
+		wantSub  string // substring the line must contain
+		wantSep  bool   // whether " · " must appear
+		wantMiss string // substring the line must NOT contain (optional)
+	}{
+		{
+			name: "read file_path", tool: "Read",
+			input:   `{"file_path":"internal/config/config.go"}`,
+			wantSub: "🔧 Read · internal/config/config.go", wantSep: true,
+		},
+		{name: "edit file_path", tool: "Edit", input: `{"file_path":"main.go"}`, wantSub: "🔧 Edit · main.go", wantSep: true},
+		{name: "write file_path", tool: "Write", input: `{"file_path":"out.txt"}`, wantSub: "🔧 Write · out.txt", wantSep: true},
+		{
+			name: "notebookedit file_path", tool: "NotebookEdit",
+			input: `{"file_path":"nb.ipynb"}`, wantSub: "🔧 NotebookEdit · nb.ipynb", wantSep: true,
+		},
+		{name: "bash command", tool: "Bash", input: `{"command":"go test ./..."}`, wantSub: "🔧 Bash · go test ./...", wantSep: true},
+		{
+			name: "grep pattern", tool: "Grep",
+			input: `{"pattern":"func main","path":"core"}`, wantSub: "🔧 Grep · func main", wantSep: true,
+		},
+		{name: "glob pattern", tool: "Glob", input: `{"pattern":"**/*.go"}`, wantSub: "🔧 Glob · **/*.go", wantSep: true},
+		{
+			name: "task description", tool: "Task",
+			input:   `{"description":"run the tests","subagent_type":"tester"}`,
+			wantSub: "🔧 Task · run the tests", wantSep: true,
+		},
+		{
+			name: "task subagent fallback", tool: "Task",
+			input: `{"subagent_type":"tester"}`, wantSub: "🔧 Task · tester", wantSep: true,
+		},
+		{name: "agent description", tool: "Agent", input: `{"description":"do work"}`, wantSub: "🔧 Agent · do work", wantSep: true},
+		{
+			name: "webfetch url", tool: "WebFetch",
+			input: `{"url":"https://example.com"}`, wantSub: "🔧 WebFetch · https://example.com", wantSep: true,
+		},
+		{
+			name: "websearch query", tool: "WebSearch",
+			input: `{"query":"golang json"}`, wantSub: "🔧 WebSearch · golang json", wantSep: true,
+		},
+		{name: "skill", tool: "Skill", input: `{"skill":"pdf"}`, wantSub: "🔧 Skill · pdf", wantSep: true},
+		{
+			name: "toolsearch query", tool: "ToolSearch",
+			input: `{"query":"search this"}`, wantSub: "🔧 ToolSearch · search this", wantSep: true,
+		},
+		// Case-insensitive tool match.
+		{name: "lowercase tool name", tool: "read", input: `{"file_path":"a.go"}`, wantSub: "🔧 read · a.go", wantSep: true},
+		// Fallbacks to name-only (no separator).
+		{
+			name: "unknown tool", tool: "MysteryTool",
+			input: `{"file_path":"a.go"}`, wantSub: "🔧 MysteryTool", wantSep: false, wantMiss: " · ",
+		},
+		{name: "malformed input", tool: "Read", input: `{not json`, wantSub: "🔧 Read", wantSep: false, wantMiss: " · "},
+		{name: "empty input", tool: "Bash", input: ``, wantSub: "🔧 Bash", wantSep: false, wantMiss: " · "},
+		{name: "missing field", tool: "Read", input: `{"other":"x"}`, wantSub: "🔧 Read", wantSep: false, wantMiss: " · "},
+		{name: "non-string field", tool: "Read", input: `{"file_path":123}`, wantSub: "🔧 Read", wantSep: false, wantMiss: " · "},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var elapsed time.Duration
+			p := NewProgress(fakeClock(&elapsed), 5)
+			p.Observe(claude.Event{Type: claude.ToolUse, Tool: tc.tool, ToolInput: []byte(tc.input)})
+			frame := p.Frame()
+			if !strings.Contains(frame, tc.wantSub) {
+				t.Fatalf("frame %q does not contain %q", frame, tc.wantSub)
+			}
+			if tc.wantSep && !strings.Contains(frame, " · ") {
+				t.Fatalf("expected separator in %q", frame)
+			}
+			if tc.wantMiss != "" && strings.Contains(frame, tc.wantMiss) {
+				t.Fatalf("frame %q unexpectedly contains %q", frame, tc.wantMiss)
+			}
+		})
+	}
+}
+
+func TestToolUseDetailCollapsesMultilineCommand(t *testing.T) {
+	var elapsed time.Duration
+	p := NewProgress(fakeClock(&elapsed), 5)
+	p.Observe(claude.Event{
+		Type:      claude.ToolUse,
+		Tool:      "Bash",
+		ToolInput: []byte("{\"command\":\"echo one\\n   echo two\\n\\techo three\"}"),
+	})
+	frame := p.Frame()
+	if !strings.Contains(frame, "🔧 Bash · echo one echo two echo three") {
+		t.Fatalf("multi-line command not collapsed to one line: %q", frame)
+	}
+}
+
+func TestToolUseDetailTruncatedToBudget(t *testing.T) {
+	longCmd := strings.Repeat("x", toolDetailMax+200)
+	input, err := json.Marshal(map[string]string{"command": longCmd})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	detail := toolDetail("Bash", input)
+	if got := utf8.RuneCountInString(detail); got != toolDetailMax {
+		t.Fatalf("detail rune count = %d, want %d (truncated with ellipsis)", got, toolDetailMax)
+	}
+	if !strings.HasSuffix(detail, "…") {
+		t.Fatalf("truncated detail should end with ellipsis: %q", detail)
 	}
 }
 

--- a/core/chat/progress_test.go
+++ b/core/chat/progress_test.go
@@ -41,7 +41,7 @@ func TestFrameCounterDrivenByClockNotEvents(t *testing.T) {
 	if !strings.Contains(frame, "Working… (42s)") {
 		t.Fatalf("counter did not advance during silent tool call: %q", frame)
 	}
-	if !strings.Contains(frame, "🔧 Bash") {
+	if !strings.Contains(frame, "⌨️ Bash") {
 		t.Fatalf("tool activity not shown: %q", frame)
 	}
 }
@@ -106,54 +106,55 @@ func TestToolUseDetailEnrichment(t *testing.T) {
 		{
 			name: "read file_path", tool: "Read",
 			input:   `{"file_path":"internal/config/config.go"}`,
-			wantSub: "🔧 Read · internal/config/config.go", wantSep: true,
+			wantSub: "📖 Read · internal/config/config.go", wantSep: true,
 		},
-		{name: "edit file_path", tool: "Edit", input: `{"file_path":"main.go"}`, wantSub: "🔧 Edit · main.go", wantSep: true},
-		{name: "write file_path", tool: "Write", input: `{"file_path":"out.txt"}`, wantSub: "🔧 Write · out.txt", wantSep: true},
+		{name: "edit file_path", tool: "Edit", input: `{"file_path":"main.go"}`, wantSub: "✏️ Edit · main.go", wantSep: true},
+		{name: "write file_path", tool: "Write", input: `{"file_path":"out.txt"}`, wantSub: "✏️ Write · out.txt", wantSep: true},
 		{
 			name: "notebookedit file_path", tool: "NotebookEdit",
-			input: `{"file_path":"nb.ipynb"}`, wantSub: "🔧 NotebookEdit · nb.ipynb", wantSep: true,
+			input: `{"file_path":"nb.ipynb"}`, wantSub: "✏️ NotebookEdit · nb.ipynb", wantSep: true,
 		},
-		{name: "bash command", tool: "Bash", input: `{"command":"go test ./..."}`, wantSub: "🔧 Bash · go test ./...", wantSep: true},
+		{name: "bash command", tool: "Bash", input: `{"command":"go test ./..."}`, wantSub: "⌨️ Bash · go test ./...", wantSep: true},
 		{
 			name: "grep pattern", tool: "Grep",
-			input: `{"pattern":"func main","path":"core"}`, wantSub: "🔧 Grep · func main", wantSep: true,
+			input: `{"pattern":"func main","path":"core"}`, wantSub: "🔍 Grep · func main", wantSep: true,
 		},
-		{name: "glob pattern", tool: "Glob", input: `{"pattern":"**/*.go"}`, wantSub: "🔧 Glob · **/*.go", wantSep: true},
+		{name: "glob pattern", tool: "Glob", input: `{"pattern":"**/*.go"}`, wantSub: "🔍 Glob · **/*.go", wantSep: true},
 		{
 			name: "task description", tool: "Task",
 			input:   `{"description":"run the tests","subagent_type":"tester"}`,
-			wantSub: "🔧 Task · run the tests", wantSep: true,
+			wantSub: "🤖 Task · run the tests", wantSep: true,
 		},
 		{
 			name: "task subagent fallback", tool: "Task",
-			input: `{"subagent_type":"tester"}`, wantSub: "🔧 Task · tester", wantSep: true,
+			input: `{"subagent_type":"tester"}`, wantSub: "🤖 Task · tester", wantSep: true,
 		},
-		{name: "agent description", tool: "Agent", input: `{"description":"do work"}`, wantSub: "🔧 Agent · do work", wantSep: true},
+		{name: "agent description", tool: "Agent", input: `{"description":"do work"}`, wantSub: "🤖 Agent · do work", wantSep: true},
 		{
 			name: "webfetch url", tool: "WebFetch",
-			input: `{"url":"https://example.com"}`, wantSub: "🔧 WebFetch · https://example.com", wantSep: true,
+			input: `{"url":"https://example.com"}`, wantSub: "🌐 WebFetch · https://example.com", wantSep: true,
 		},
 		{
 			name: "websearch query", tool: "WebSearch",
-			input: `{"query":"golang json"}`, wantSub: "🔧 WebSearch · golang json", wantSep: true,
+			input: `{"query":"golang json"}`, wantSub: "🔎 WebSearch · golang json", wantSep: true,
 		},
-		{name: "skill", tool: "Skill", input: `{"skill":"pdf"}`, wantSub: "🔧 Skill · pdf", wantSep: true},
+		{name: "skill", tool: "Skill", input: `{"skill":"pdf"}`, wantSub: "🧩 Skill · pdf", wantSep: true},
 		{
 			name: "toolsearch query", tool: "ToolSearch",
-			input: `{"query":"search this"}`, wantSub: "🔧 ToolSearch · search this", wantSep: true,
+			input: `{"query":"search this"}`, wantSub: "🔎 ToolSearch · search this", wantSep: true,
 		},
-		// Case-insensitive tool match.
-		{name: "lowercase tool name", tool: "read", input: `{"file_path":"a.go"}`, wantSub: "🔧 read · a.go", wantSep: true},
-		// Fallbacks to name-only (no separator).
+		// Case-insensitive tool match (emoji prefix resolves on the lowercased name).
+		{name: "lowercase tool name", tool: "read", input: `{"file_path":"a.go"}`, wantSub: "📖 read · a.go", wantSep: true},
+		// Fallbacks to name-only (no separator). An unknown tool also falls back to
+		// the generic wrench prefix.
 		{
 			name: "unknown tool", tool: "MysteryTool",
 			input: `{"file_path":"a.go"}`, wantSub: "🔧 MysteryTool", wantSep: false, wantMiss: " · ",
 		},
-		{name: "malformed input", tool: "Read", input: `{not json`, wantSub: "🔧 Read", wantSep: false, wantMiss: " · "},
-		{name: "empty input", tool: "Bash", input: ``, wantSub: "🔧 Bash", wantSep: false, wantMiss: " · "},
-		{name: "missing field", tool: "Read", input: `{"other":"x"}`, wantSub: "🔧 Read", wantSep: false, wantMiss: " · "},
-		{name: "non-string field", tool: "Read", input: `{"file_path":123}`, wantSub: "🔧 Read", wantSep: false, wantMiss: " · "},
+		{name: "malformed input", tool: "Read", input: `{not json`, wantSub: "📖 Read", wantSep: false, wantMiss: " · "},
+		{name: "empty input", tool: "Bash", input: ``, wantSub: "⌨️ Bash", wantSep: false, wantMiss: " · "},
+		{name: "missing field", tool: "Read", input: `{"other":"x"}`, wantSub: "📖 Read", wantSep: false, wantMiss: " · "},
+		{name: "non-string field", tool: "Read", input: `{"file_path":123}`, wantSub: "📖 Read", wantSep: false, wantMiss: " · "},
 	}
 
 	for _, tc := range cases {
@@ -175,6 +176,35 @@ func TestToolUseDetailEnrichment(t *testing.T) {
 	}
 }
 
+func TestToolLinePrefixPerTool(t *testing.T) {
+	cases := map[string]string{
+		"Read":         "📖 ",
+		"Edit":         "✏️ ",
+		"Write":        "✏️ ",
+		"NotebookEdit": "✏️ ",
+		"Bash":         "⌨️ ",
+		"Grep":         "🔍 ",
+		"Glob":         "🔍 ",
+		"Task":         "🤖 ",
+		"Agent":        "🤖 ",
+		"WebFetch":     "🌐 ",
+		"WebSearch":    "🔎 ",
+		"ToolSearch":   "🔎 ",
+		"Skill":        "🧩 ",
+		// Unknown and empty tool names fall back to the generic wrench.
+		"MysteryTool": "🔧 ",
+		"":            "🔧 ",
+		// Resolution is case-insensitive.
+		"bash": "⌨️ ",
+		"GREP": "🔍 ",
+	}
+	for tool, want := range cases {
+		if got := toolLinePrefix(tool); got != want {
+			t.Errorf("toolLinePrefix(%q) = %q, want %q", tool, got, want)
+		}
+	}
+}
+
 func TestToolUseDetailCollapsesMultilineCommand(t *testing.T) {
 	var elapsed time.Duration
 	p := NewProgress(fakeClock(&elapsed), 5)
@@ -184,7 +214,7 @@ func TestToolUseDetailCollapsesMultilineCommand(t *testing.T) {
 		ToolInput: []byte("{\"command\":\"echo one\\n   echo two\\n\\techo three\"}"),
 	})
 	frame := p.Frame()
-	if !strings.Contains(frame, "🔧 Bash · echo one echo two echo three") {
+	if !strings.Contains(frame, "⌨️ Bash · echo one echo two echo three") {
 		t.Fatalf("multi-line command not collapsed to one line: %q", frame)
 	}
 }
@@ -562,7 +592,7 @@ func TestElidedIndicatorShownWhenEvicted(t *testing.T) {
 		t.Fatalf("indicator not first activity line: %q", frame)
 	}
 	// Exactly ringSize activity lines are kept below the indicator.
-	if kept := strings.Count(frame, toolPrefix); kept != ring {
+	if kept := strings.Count(frame, toolLinePrefix("Bash")); kept != ring {
 		t.Fatalf("kept %d activity lines, want %d", kept, ring)
 	}
 }

--- a/core/chat/progress_test.go
+++ b/core/chat/progress_test.go
@@ -364,6 +364,49 @@ func TestToolDetailRedactsSecrets(t *testing.T) {
 	}
 }
 
+func TestToolDetailRedactsQuotedKeySecret(t *testing.T) {
+	// A secret carried in a JSON request body inside a shell command: the key is
+	// bound to its value by `":"`, not a bare `:`/`=`/space. The separator must
+	// tolerate the closing quote so the value is still masked. Built via Marshal to
+	// avoid escaping the inner JSON by hand.
+	cases := []struct {
+		name string
+		cmd  string
+		miss string
+	}{
+		{
+			name: "strong keyword in json body",
+			cmd:  `curl -d '{"password":"hunter2json"}' https://api.example.com`,
+			miss: "hunter2json",
+		},
+		{
+			name: "json body with space after colon",
+			cmd:  `curl -d '{"api_key": "KEY_LEAK_JSON"}'`,
+			miss: "KEY_LEAK_JSON",
+		},
+		{
+			name: "auth bound by quoted colon in json",
+			cmd:  `curl -d '{"auth":"topSecretJson"}'`,
+			miss: "topSecretJson",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			input, err := json.Marshal(map[string]string{"command": tc.cmd})
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			detail := toolDetail("Bash", input)
+			if strings.Contains(detail, tc.miss) {
+				t.Fatalf("detail leaked JSON-body secret %q: %q", tc.miss, detail)
+			}
+			if !strings.Contains(detail, redactedMask) {
+				t.Fatalf("detail should contain the redaction mask: %q", detail)
+			}
+		})
+	}
+}
+
 func TestToolDetailNonObjectJSON(t *testing.T) {
 	// Valid JSON that is not an object unmarshals into map[string]any with an
 	// error, so the detail falls back to "" (bare tool name).

--- a/core/chat/progress_test.go
+++ b/core/chat/progress_test.go
@@ -239,9 +239,32 @@ func TestToolDetailRedactsSecrets(t *testing.T) {
 			wantSub: "https://***@github.com", wantMiss: "s3cr3t",
 		},
 		{
+			name: "auth bound by equals redacted", tool: "Bash",
+			input:   `{"command":"deploy --auth=topSecretValue"}`,
+			wantSub: "auth=***", wantMiss: "topSecretValue",
+		},
+		{
 			name: "clean command untouched", tool: "Bash",
 			input:   `{"command":"go test ./..."}`,
 			wantSub: "go test ./...",
+		},
+		// Benign uses of the loose keywords must stay fully readable (no over-masking
+		// when "auth" is not bound to a value by ':'/'=' and "basic"/"bearer" precede
+		// a short ordinary word rather than a credential token).
+		{
+			name: "auth as path segment untouched", tool: "Bash",
+			input:   `{"command":"go test ./auth ./config"}`,
+			wantSub: "go test ./auth ./config", wantMiss: "***",
+		},
+		{
+			name: "auth in cd chain untouched", tool: "Bash",
+			input:   `{"command":"cd internal/auth && go build"}`,
+			wantSub: "cd internal/auth && go build", wantMiss: "***",
+		},
+		{
+			name: "basic auth words untouched", tool: "Bash",
+			input:   `{"command":"echo basic auth check"}`,
+			wantSub: "basic auth check", wantMiss: "***",
 		},
 	}
 

--- a/core/chat/progress_test.go
+++ b/core/chat/progress_test.go
@@ -271,6 +271,18 @@ func TestToolDetailRedactsSecrets(t *testing.T) {
 			input:   `{"command":"git clone https://bob:` + `my@ssPhrase@example.com/r.git"}`,
 			wantSub: "https://***@example.com", wantMiss: "my@ssPhrase",
 		},
+		// A quoted secret containing spaces must be masked as a whole; a bare \S+
+		// value would stop at the first space and leak the tail.
+		{
+			name: "double-quoted multiword secret", tool: "Bash",
+			input:   `{"command":"mysql --password \"hunter 2 spaces\""}`,
+			wantSub: "password ***", wantMiss: "spaces",
+		},
+		{
+			name: "single-quoted multiword token", tool: "Bash",
+			input:   `{"command":"deploy --token='ghp abc def'"}`,
+			wantSub: "token=***", wantMiss: "abc def",
+		},
 		{
 			name: "clean command untouched", tool: "Bash",
 			input:   `{"command":"go test ./..."}`,


### PR DESCRIPTION
## Summary

The live "Working…" progress frame (Telegram/VK) rendered only the tool **name** for each tool-use event, even though the tool's JSON arguments were already on the event. This appends a short, relevant detail extracted from the tool input so users see *what* is being read or run.

**Before / after:**

```
🔧 Read              →  🔧 Read · internal/config/config.go
🔧 Bash              →  🔧 Bash · go test ./...
🔧 Grep              →  🔧 Grep · func main
```

Format is `🔧 <Tool> · <detail>`. When no detail can be extracted, the line falls back to the current `🔧 <Tool>` (unchanged behavior).

## What changed

- `core/chat/progress.go`:
  - new `toolDetail(tool string, input json.RawMessage) string` helper; the `ToolUse` branch of `activityLine` now appends ` · <detail>` when one is available. Added consts `toolDetailMax = 160` (per-detail rune budget) and `toolDetailSeparator = " · "`.
  - **secret redaction**: because the progress frame is chat-visible, the extracted detail is run through `redactSecrets` before display so a `Bash` command or URL can't surface a credential. See the dedicated section below.
- `core/chat/progress_test.go`: table tests for every tool mapping, plus collapse, truncation, fallback, redaction (masked + benign-untouched), and non-object-JSON cases.

Standard library only — `encoding/json` for parsing and `regexp` for the redaction patterns. No new third-party dependencies.

## Per-tool field mapping

| Tool | Field |
|------|-------|
| Read, Edit, Write, NotebookEdit | `file_path` |
| Bash | `command` (whitespace-collapsed) |
| Grep, Glob | `pattern` |
| Task, Agent | `description` (falls back to `subagent_type`) |
| WebFetch | `url` |
| WebSearch, ToolSearch | `query` |
| Skill | `skill` |
| unknown / default | — (name only) |

Tool name match is case-insensitive. Values are taken only when the JSON value is actually a string; the detail is whitespace-collapsed, redacted, and truncated to `toolDetailMax` runes, and the whole composed line is still re-capped at `recentSnippetMax` so the overall frame budget is unchanged.

## Secret redaction (chat-visible frame)

The detail is **best-effort, over-masking-by-design** — leaking a credential is worse than hiding a benign token, but it is NOT a security boundary; callers must not rely on it to scrub secrets. Patterns masked, each preserving surrounding context:

- HTTP auth schemes: `Bearer <token>` / `Basic <token>` → `Bearer ***` (token must be ≥ 8 chars, so plain English like `basic auth` stays readable).
- Credential key/value pairs: `token` / `secret` / `password` / `passwd` / `api_key` / `access_token` followed by `:` `=` or whitespace + value → `<key> ***`.
- `auth` is masked **only** when bound to its value by `:` / `=` (`--auth=token`), never on a bare space — so `go test ./auth`, `cd internal/auth && …` stay readable.
- URL userinfo: `scheme://user:pass@host` → `scheme://***@host`.

Redaction runs **before** truncation so a secret near the cap can't survive by being cut. Model "thought" text (`💭`) is intentionally **not** redacted: it is free-form prose, and the CLI-shaped keyword heuristics would mangle ordinary phrases (`password reset`, `token bucket`, `basic understanding`); only CLI-shaped tool details carry the credential risk.

## How verified

Run inside the repo's `dev-tools` image (same as CI), `GOFLAGS=-buildvcs=false`:

- `go build ./...` — passed
- `golangci-lint run --timeout=5m ./core/chat/...` — 0 issues
- `go test -race ./core/chat/...` — ok (pre-existing tests still green; name-only fallback preserved; redaction masked + benign-untouched cases covered)

## Risk

Cosmetic only. No change to run behavior or terminal output. Any empty, malformed, non-string, or unknown tool input yields no detail and falls back to the bare tool name. Redaction is best-effort and intentionally over-masks; it is not a security boundary. No new dependencies.
