### PR TITLE
feat(telegram): Rich Messages Stage 0 — ENABLE_RICH_MESSAGES flag + CanSendRich capability

### DIFF
--- a/adapters/telegram/.env.example
+++ b/adapters/telegram/.env.example
@@ -29,6 +29,10 @@ REQUIRE_GROUP_MENTION=false
 # Published-PR review/fix loop (Gitea poller + on-PR review). false (default) = off: build +
 # open a PR, then stop. true = react to PR comments and run the on-PR review loop.
 ENABLE_PR_REVIEW=false
+# Bot API 10.1 rich messages (structured blocks + native rich draft). false (default) = off:
+# the legacy Markdown→HTML rendering, unchanged. true = render rich (Telegram only; falls back
+# to Markdown→HTML/plain on any error). See docs/rich-messages-plan.md.
+ENABLE_RICH_MESSAGES=false
 BOT_MEM_LIMIT=3g                # consumed by docker-compose mem_limit, not the bot
 
 # ===== GIT (optional) — clone repos + open PRs from chat. Works with Gitea/GitHub/GitLab. =====

--- a/adapters/telegram/bot.go
+++ b/adapters/telegram/bot.go
@@ -32,21 +32,28 @@ const telegramMaxMessageRunes = 4096
 // botChat implements core/chat.Transport over a *bot.Bot.
 type botChat struct {
 	b *bot.Bot
+	// enableRich reports the Capabilities().CanSendRich flag, sourced from the
+	// ENABLE_RICH_MESSAGES config. Stage 0 only surfaces it; the rich render paths
+	// are wired in later stages (see docs/rich-messages-plan.md).
+	enableRich bool
 }
 
 // NewBotChat adapts a *bot.Bot to the core/chat.Transport interface used by the
-// Service.
-func NewBotChat(b *bot.Bot) chat.Transport {
-	return &botChat{b: b}
+// Service. enableRich sets Capabilities().CanSendRich (from ENABLE_RICH_MESSAGES);
+// pass false to keep the legacy MarkdownToHTML/plain rendering.
+func NewBotChat(b *bot.Bot, enableRich bool) chat.Transport {
+	return &botChat{b: b, enableRich: enableRich}
 }
 
-// Capabilities reports Telegram's full feature set: it can send documents and
-// its message cap is 4096 runes. With these flags the neutral Service behaves
-// exactly as before.
+// Capabilities reports Telegram's full feature set: it can send documents, its
+// message cap is 4096 runes, and it can render rich messages when enableRich is
+// set. With these flags the neutral Service behaves exactly as before when rich
+// is off.
 func (c *botChat) Capabilities() chat.Capabilities {
 	return chat.Capabilities{
 		CanSendDocument: true,
 		MaxMessageRunes: telegramMaxMessageRunes,
+		CanSendRich:     c.enableRich,
 	}
 }
 

--- a/adapters/telegram/capabilities_test.go
+++ b/adapters/telegram/capabilities_test.go
@@ -1,0 +1,24 @@
+//nolint:testpackage // whitebox: asserts the unexported botChat wiring of the rich-capability flag
+package telegram
+
+import "testing"
+
+// TestCapabilitiesRichFollowsFlag asserts the Bot API 10.1 rich capability is
+// surfaced from the ENABLE_RICH_MESSAGES flag threaded through NewBotChat, and
+// that the always-on Telegram capabilities are unaffected. Capabilities() does
+// not touch the *bot.Bot, so a nil bot is sufficient here.
+func TestCapabilitiesRichFollowsFlag(t *testing.T) {
+	for _, enableRich := range []bool{false, true} {
+		caps := NewBotChat(nil, enableRich).Capabilities()
+		if caps.CanSendRich != enableRich {
+			t.Errorf("NewBotChat(_, %t).Capabilities().CanSendRich = %t, want %t",
+				enableRich, caps.CanSendRich, enableRich)
+		}
+		if !caps.CanSendDocument {
+			t.Errorf("CanSendDocument = false, want true (enableRich=%t)", enableRich)
+		}
+		if caps.MaxMessageRunes != telegramMaxMessageRunes {
+			t.Errorf("MaxMessageRunes = %d, want %d", caps.MaxMessageRunes, telegramMaxMessageRunes)
+		}
+	}
+}

--- a/adapters/telegram/deploy/roles/claude_tg_bot/templates/env.j2
+++ b/adapters/telegram/deploy/roles/claude_tg_bot/templates/env.j2
@@ -49,6 +49,9 @@ REQUIRE_GROUP_MENTION={{ require_group_mention | default(false) | string | lower
 # Published-PR review/fix loop (poller + CLAUDE.md Phase 2). false (default) = off:
 # build + open a PR, then stop; no on-PR review or comment reactions.
 ENABLE_PR_REVIEW={{ enable_pr_review | default(false) | string | lower }}
+# Bot API 10.1 rich messages (structured blocks + native rich draft). false (default) = off:
+# legacy Markdown→HTML rendering; true = render rich (Telegram only, falls back on any error).
+ENABLE_RICH_MESSAGES={{ enable_rich_messages | default(false) | string | lower }}
 {% if webhook_domain %}
 
 # === WEBHOOK SERVER (PR monitoring) ===

--- a/adapters/vk/bot_test.go
+++ b/adapters/vk/bot_test.go
@@ -23,6 +23,12 @@ func TestCapabilities(t *testing.T) {
 	if caps.MaxMessageRunes != vkMaxMessageRunes {
 		t.Errorf("MaxMessageRunes = %d, want %d", caps.MaxMessageRunes, vkMaxMessageRunes)
 	}
+	// VK has no Bot API 10.1 rich support: the additive CanSendRich field must stay
+	// at its zero value so the VK adapter keeps the legacy rendering with no change
+	// (docs/rich-messages-plan.md §6).
+	if caps.CanSendRich {
+		t.Errorf("capabilities = %+v, want CanSendRich false (VK has no rich support)", caps)
+	}
 }
 
 func TestSendRendersStopKeyboardAndUniqueRandomID(t *testing.T) {

--- a/cmd/flock-telegram/main.go
+++ b/cmd/flock-telegram/main.go
@@ -231,7 +231,7 @@ func run() int {
 
 	svc = chat.New(chat.Config{
 		Runner:     runner,
-		Transport:  telegram.NewBotChat(b),
+		Transport:  telegram.NewBotChat(b, cfg.EnableRichMessages),
 		Dispatcher: disp,
 		Workspace:  ws,
 		Sessions:   sessions,

--- a/cmd/flock-telegram/media_routing_test.go
+++ b/cmd/flock-telegram/media_routing_test.go
@@ -127,7 +127,7 @@ func newMediaHarness(t *testing.T, maxUpload int64) *mediaTestHarness {
 	disp := dispatch.New(2)
 	svc := chat.New(chat.Config{
 		Runner:     runner,
-		Transport:  telegram.NewBotChat(b),
+		Transport:  telegram.NewBotChat(b, false),
 		Dispatcher: disp,
 		Workspace:  &fakeWorkspace{dir: t.TempDir()},
 		Logger:     logger,

--- a/core/chat/transport.go
+++ b/core/chat/transport.go
@@ -66,4 +66,12 @@ type Capabilities struct {
 	// MaxMessageRunes is the platform's max message length in runes, fed to the
 	// chunker (Telegram 4096). A non-positive value selects a safe default.
 	MaxMessageRunes int
+	// CanSendRich: the platform can render Bot API 10.1 rich messages (structured
+	// blocks + a native rich draft) instead of the legacy MarkdownToHTML/plain
+	// path. It is purely additive — false (the zero value) keeps a transport on the
+	// exact pre-rich behaviour, so a platform that does not set it (VK) needs no
+	// change. Telegram sets it from the ENABLE_RICH_MESSAGES flag; even there the
+	// rich path always falls back to MarkdownToHTML/plain on any error, so the flag
+	// is a feature toggle, never a hard dependency.
+	CanSendRich bool
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -101,6 +101,15 @@ type Config struct {
 	// always handled regardless. See plan §5.
 	RequireGroupMention bool `env:"REQUIRE_GROUP_MENTION" envDefault:"false"`
 
+	// EnableRichMessages toggles Bot API 10.1 rich rendering in the Telegram
+	// adapter (structured blocks + native rich draft). Default false: the adapter
+	// uses the legacy MarkdownToHTML/plain path and behaves exactly as before. When
+	// true it is surfaced via the Telegram Capabilities().CanSendRich flag; the rich
+	// path still falls back to MarkdownToHTML/plain on any error, so flipping this on
+	// can never break delivery. VK ignores it (no rich support). See
+	// docs/rich-messages-plan.md.
+	EnableRichMessages bool `env:"ENABLE_RICH_MESSAGES" envDefault:"false"`
+
 	// Team-loop knobs rendered into each workspace's CLAUDE.md (mirrors the
 	// values the Python entrypoint substituted). Kept as strings since they are
 	// substituted verbatim into the template.


### PR DESCRIPTION
**Stage 0 of `docs/rich-messages-plan.md`** (PR #22). Wires the Bot API 10.1 rich-messages feature flag end-to-end, **with no rendering yet** — the plumbing is provably inert. Flag off (default) → behaviour byte-identical to `main`.

## Changes
- **`core/chat/transport.go`** — append `Capabilities.CanSendRich bool` (additive; zero value `false`).
- **`internal/config`** — add `EnableRichMessages` (`ENABLE_RICH_MESSAGES`, default `false`).
- **`adapters/telegram`** — thread the flag through `NewBotChat(b, enableRich)` into `Capabilities().CanSendRich`.
- **`.env.example` + Ansible `env.j2`** — document the flag (default off).
- **Tests** — assert Telegram `CanSendRich` follows the flag; assert VK `CanSendRich == false`.

## VK-safety invariant (plan §6)
- `git diff origin/main -- adapters/vk/bot.go adapters/vk/api.go` → **empty** (VK production code untouched).
- Only a guard assertion (+6 lines) added to `adapters/vk/bot_test.go` — the prescribed §6 point-3 check.
- VK `Capabilities()` is a struct literal → `CanSendRich` is `false` by zero value, no edit needed.

## Acceptance (AC) — all green via the repo's own runner
- **AC1** `CanSendRich` follows the config flag on Telegram, is `false` on VK — `go test ./adapters/...` ✅
- **AC2** flag off → no behaviour change — full suite + existing golden tests green ✅
- **AC3** build/lint/types clean — `go build ./...`, `go vet ./...`, `golangci-lint run` → **0 issues** ✅

Verified in the `dev-tools` container (mirrors CI): `go build`, `go vet`, `go test -race ./...` (all packages ok), `golangci-lint run` (0 issues).

Part of the Rich Messages initiative; flag-dark, merges independently.