### PR TITLE
feat(core): Rich Messages Stage 1 — neutral rich IR + Markdown parser

### DIFF
--- a/core/chat/rich/markdown.go
+++ b/core/chat/rich/markdown.go
@@ -1,0 +1,305 @@
+package rich
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Block-shape matchers. Kept intentionally close to MarkdownToHTML's regex set so
+// FromMarkdown classifies the same Markdown subset; the table/ordered-list
+// matchers are the unambiguous additions the rich IR can represent.
+var (
+	reHeading = regexp.MustCompile(`^(#{1,6})\s+(.+?)\s*$`)
+	reULItem  = regexp.MustCompile(`^[-*+]\s+(.*)$`)
+	reOLItem  = regexp.MustCompile(`^\d+[.)]\s+(.*)$`)
+)
+
+// tableHeaderRows is how many rows precede a pipe table's body: the header row
+// plus the separator row.
+const tableHeaderRows = 2
+
+// FromMarkdown parses the Markdown subset the assistant emits into the neutral
+// rich IR. It is TOTAL and best-effort: it never panics, and any line it cannot
+// classify becomes a Paragraph, so a serializer always has something valid to
+// emit (mirroring MarkdownToHTML's "degrade to escaped literal" guarantee). For
+// any input containing a non-blank line it returns at least one Block; an
+// empty/whitespace-only input returns a Message with no blocks.
+func FromMarkdown(md string) Message {
+	lines := strings.Split(md, "\n")
+	var blocks []Block
+	for i := 0; i < len(lines); {
+		s := lines[i]
+		switch {
+		case blankLine(s):
+			i++ // blank line: a block separator, nothing emitted
+		case fenceLine(s):
+			var blk Block
+			blk, i = parseFence(lines, i)
+			blocks = append(blocks, blk)
+		case headingLine(s):
+			blocks = append(blocks, parseHeading(s))
+			i++
+		case tableStart(lines, i):
+			var blk Block
+			blk, i = parseTable(lines, i)
+			blocks = append(blocks, blk)
+		case quoteLine(s):
+			var blk Block
+			blk, i = parseQuote(lines, i)
+			blocks = append(blocks, blk)
+		case listLine(s):
+			var blk Block
+			blk, i = parseList(lines, i)
+			blocks = append(blocks, blk)
+		default:
+			var blk Block
+			blk, i = parseParagraph(lines, i)
+			blocks = append(blocks, blk)
+		}
+	}
+	return Message{Blocks: blocks}
+}
+
+// --- line predicates ---
+
+func blankLine(s string) bool   { return strings.TrimSpace(s) == "" }
+func fenceLine(s string) bool   { return strings.HasPrefix(strings.TrimSpace(s), "```") }
+func headingLine(s string) bool { return reHeading.MatchString(strings.TrimSpace(s)) }
+func quoteLine(s string) bool   { return strings.HasPrefix(strings.TrimSpace(s), ">") }
+
+func listLine(s string) bool {
+	t := strings.TrimSpace(s)
+	return reULItem.MatchString(t) || reOLItem.MatchString(t)
+}
+
+// tableStart reports whether line i begins a pipe table: a row containing "|"
+// immediately followed by a separator row (cells of only -, :, and spaces). The
+// mandatory separator is what keeps a prose line that merely contains "|" from
+// being misread as a table.
+func tableStart(lines []string, i int) bool {
+	if i+1 >= len(lines) {
+		return false
+	}
+	return strings.Contains(lines[i], "|") && isTableSeparator(lines[i+1])
+}
+
+// isBlockStart reports whether line i begins a non-paragraph block (or is blank),
+// so parseParagraph knows where to stop without requiring a blank-line separator.
+func isBlockStart(lines []string, i int) bool {
+	s := lines[i]
+	return blankLine(s) || fenceLine(s) || headingLine(s) ||
+		quoteLine(s) || listLine(s) || tableStart(lines, i)
+}
+
+// --- block parsers (each returns the parsed block and the next line index) ---
+
+// parseFence consumes a ``` fenced code block starting at line i, capturing the
+// optional info-string as Lang and the verbatim body. An unterminated fence runs
+// to EOF (best-effort), so a stray ``` never drops the rest of the message.
+func parseFence(lines []string, i int) (Block, int) {
+	lang := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(lines[i]), "```"))
+	var body []string
+	j := i + 1
+	for j < len(lines) {
+		if strings.TrimSpace(lines[j]) == "```" {
+			j++ // consume the closing fence
+			break
+		}
+		body = append(body, lines[j])
+		j++
+	}
+	return Code{Lang: lang, Text: strings.Join(body, "\n")}, j
+}
+
+func parseHeading(s string) Block {
+	m := reHeading.FindStringSubmatch(strings.TrimSpace(s))
+	return Heading{Level: len(m[1]), Text: parseInline(m[2])}
+}
+
+// parseQuote consumes consecutive ">"-prefixed lines, strips the marker (and one
+// optional following space) from each, and joins them into one inline run.
+func parseQuote(lines []string, i int) (Block, int) {
+	var parts []string
+	j := i
+	for j < len(lines) && quoteLine(lines[j]) {
+		t := strings.TrimSpace(lines[j])
+		t = strings.TrimPrefix(t, ">")
+		t = strings.TrimPrefix(t, " ")
+		parts = append(parts, t)
+		j++
+	}
+	return Quote{Text: parseInline(strings.Join(parts, " "))}, j
+}
+
+// parseList consumes consecutive list items. Ordered-ness is taken from the first
+// item; each item's text after its marker becomes one inline run.
+func parseList(lines []string, i int) (Block, int) {
+	ordered := reOLItem.MatchString(strings.TrimSpace(lines[i]))
+	var items []Inline
+	j := i
+	for j < len(lines) && listLine(lines[j]) {
+		t := strings.TrimSpace(lines[j])
+		var text string
+		if m := reOLItem.FindStringSubmatch(t); m != nil {
+			text = m[1]
+		} else if m := reULItem.FindStringSubmatch(t); m != nil {
+			text = m[1]
+		}
+		items = append(items, parseInline(text))
+		j++
+	}
+	return List{Ordered: ordered, Items: items}, j
+}
+
+// parseParagraph consumes consecutive lines until a blank line or the start of
+// another block, joining them into one inline run.
+func parseParagraph(lines []string, i int) (Block, int) {
+	var parts []string
+	j := i
+	for j < len(lines) {
+		if j > i && isBlockStart(lines, j) {
+			break
+		}
+		parts = append(parts, strings.TrimSpace(lines[j]))
+		j++
+	}
+	return Paragraph{Text: parseInline(strings.Join(parts, " "))}, j
+}
+
+// parseTable consumes a pipe table: the header row at i, the separator at i+1,
+// then body rows until a non-row/blank line.
+func parseTable(lines []string, i int) (Block, int) {
+	header := splitRow(lines[i])
+	var rows [][]string
+	j := i + tableHeaderRows // skip header + separator
+	for j < len(lines) && strings.Contains(lines[j], "|") && !blankLine(lines[j]) {
+		rows = append(rows, splitRow(lines[j]))
+		j++
+	}
+	return Table{Header: header, Rows: rows}, j
+}
+
+// isTableSeparator reports whether a line is a pipe-table separator: every
+// pipe-delimited cell is non-empty and contains only '-', ':' and spaces.
+func isTableSeparator(line string) bool {
+	cells := splitRow(line)
+	if len(cells) == 0 {
+		return false
+	}
+	for _, c := range cells {
+		if c == "" {
+			return false
+		}
+		for _, r := range c {
+			if r != '-' && r != ':' && r != ' ' {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// splitRow splits a pipe-table row into trimmed cells, dropping the optional
+// leading/trailing outer pipes.
+func splitRow(line string) []string {
+	s := strings.TrimSpace(line)
+	s = strings.TrimPrefix(s, "|")
+	s = strings.TrimSuffix(s, "|")
+	parts := strings.Split(s, "|")
+	for i := range parts {
+		parts[i] = strings.TrimSpace(parts[i])
+	}
+	return parts
+}
+
+// --- inline parser ---
+
+// parseInline splits one logical run of text into styled spans. It recognizes the
+// same inline subset as MarkdownToHTML: inline code (`…`), links ([text](url)),
+// and bold (**…** or __…__). Matching is non-nested and left-to-right; an
+// unterminated marker is emitted as literal text, so the function is total and
+// never panics.
+func parseInline(s string) Inline {
+	var spans []Span
+	var plain strings.Builder
+	flush := func() {
+		if plain.Len() > 0 {
+			spans = append(spans, Span{Text: plain.String()})
+			plain.Reset()
+		}
+	}
+	for i := 0; i < len(s); {
+		if sp, n, ok := matchInline(s, i); ok {
+			flush()
+			spans = append(spans, sp)
+			i += n
+			continue
+		}
+		_ = plain.WriteByte(s[i]) // strings.Builder.WriteByte never returns an error
+		i++
+	}
+	flush()
+	return Inline{Spans: spans}
+}
+
+// matchInline tries to match one inline construct at position i, returning the
+// span, the number of bytes consumed, and whether a match was found. Order is by
+// priority: code first (its body is verbatim), then links, then bold.
+func matchInline(s string, i int) (Span, int, bool) {
+	switch {
+	case s[i] == '`':
+		if end := strings.IndexByte(s[i+1:], '`'); end >= 0 {
+			consumed := 1 + end + 1 // opening backtick + body + closing backtick
+			return Span{Text: s[i+1 : i+1+end], Code: true}, consumed, true
+		}
+	case s[i] == '[':
+		if sp, n, ok := matchLink(s, i); ok {
+			return sp, n, true
+		}
+	case strings.HasPrefix(s[i:], "**"):
+		if body, n, ok := matchDelim(s, i, "**"); ok {
+			return Span{Text: body, Bold: true}, n, true
+		}
+	case strings.HasPrefix(s[i:], "__"):
+		if body, n, ok := matchDelim(s, i, "__"); ok {
+			return Span{Text: body, Bold: true}, n, true
+		}
+	}
+	return Span{}, 0, false
+}
+
+// matchDelim matches a paired delimiter d (e.g. "**") at position i, returning the
+// non-empty body between the pair and the total bytes consumed.
+func matchDelim(s string, i int, d string) (string, int, bool) {
+	start := i + len(d)
+	if start > len(s) {
+		return "", 0, false
+	}
+	idx := strings.Index(s[start:], d)
+	if idx <= 0 { // <=0 also rejects an empty body (****)
+		return "", 0, false
+	}
+	return s[start : start+idx], len(d) + idx + len(d), true
+}
+
+// matchLink matches a [text](url) link at position i (s[i] == '['). text may not
+// contain a ']' and url may not contain whitespace or ')', matching the
+// MarkdownToHTML link regex.
+func matchLink(s string, i int) (Span, int, bool) {
+	closeBracket := strings.IndexByte(s[i:], ']')
+	if closeBracket < 0 || i+closeBracket+1 >= len(s) || s[i+closeBracket+1] != '(' {
+		return Span{}, 0, false
+	}
+	text := s[i+1 : i+closeBracket]
+	rest := s[i+closeBracket+2:] // after "]("
+	closeParen := strings.IndexByte(rest, ')')
+	if closeParen < 0 {
+		return Span{}, 0, false
+	}
+	url := rest[:closeParen]
+	if url == "" || strings.ContainsAny(url, " \t\n") {
+		return Span{}, 0, false
+	}
+	consumed := closeBracket + 1 + 1 + closeParen + 1 // [text] + ( + url + )
+	return Span{Text: text, URL: url}, consumed, true
+}

--- a/core/chat/rich/rich.go
+++ b/core/chat/rich/rich.go
@@ -1,0 +1,94 @@
+// Package rich is a platform-neutral intermediate representation (IR) for
+// structured "rich" messages, plus a Markdown parser (FromMarkdown) that builds
+// it. It is the shared core the Telegram adapter will serialize to Bot API 10.1
+// rich messages (see docs/rich-messages-plan.md). It has no platform imports and
+// is fully unit-testable in isolation; other adapters (VK) never import it, so
+// adding this package cannot change their behaviour.
+//
+// Scope (Stage 1): the IR models exactly what FromMarkdown produces today — the
+// same Markdown subset MarkdownToHTML recognizes (fenced/inline code, **/__ bold,
+// ATX headings, [text](url) links, -/*/+ bullets, blockquotes), plus the
+// unambiguous extras the rich target can render that flat HTML could not (ordered
+// lists and pipe tables). Blocks that have no Markdown source and are built
+// programmatically by later stages (a Thinking reasoning block, a collapsible
+// Details block) are intentionally NOT defined here — each is added with the
+// stage that produces it, so the IR never carries an unconstructed type.
+package rich
+
+// Span is one run of inline text carrying zero or more independent style flags.
+// The model is deliberately FLAT (no nesting) and best-effort, matching
+// MarkdownToHTML's conservatism. Code and URL are special: a Code span's Text is
+// the verbatim code (never re-parsed), and a span with a non-empty URL is a link
+// to that target. Only the styles FromMarkdown emits are modelled (Bold, Code,
+// links); italic/strikethrough are omitted on purpose — single-`*`/`_` emphasis
+// false-matches the snake_case and glob text developers send constantly, so it is
+// not parsed, and a field with no producer would be dead weight.
+type Span struct {
+	// Text is the span's literal text (already unescaped; for a Code span it is the
+	// verbatim code between the backticks).
+	Text string
+	// URL, when non-empty, makes this span a link to that target. Text is the link
+	// label.
+	URL string
+	// Bold marks the span as strong/bold (Markdown **…** or __…__).
+	Bold bool
+	// Code marks the span as inline code (Markdown `…`); Text is verbatim.
+	Code bool
+}
+
+// Inline is a sequence of styled spans forming one logical run of text (one
+// heading, one paragraph, one list item, one blockquote).
+type Inline struct {
+	Spans []Span
+}
+
+// Block is one structural element of a rich Message. The set is a small sealed
+// interface (the isBlock marker is unexported) so a serializer can switch over it
+// exhaustively without a default surprise.
+type Block interface{ isBlock() }
+
+// Paragraph is a run of body text.
+type Paragraph struct{ Text Inline }
+
+// Heading is a section heading; Level is 1..6 (ATX #..######).
+type Heading struct {
+	Level int
+	Text  Inline
+}
+
+// Code is a preformatted code block; Lang is the optional fence info-string
+// (e.g. "go"), Text is the verbatim body with no trailing newline.
+type Code struct {
+	Lang string
+	Text string
+}
+
+// List is a bullet (Ordered=false) or numbered (Ordered=true) list. Each item is
+// a single inline run; nested lists are flattened best-effort into items.
+type List struct {
+	Ordered bool
+	Items   []Inline
+}
+
+// Quote is a blockquote; consecutive ">" lines are joined into one inline run.
+type Quote struct{ Text Inline }
+
+// Table is a pipe table: a header row plus zero or more body rows, each a slice
+// of already-trimmed cell strings. Cells are plain text (not re-parsed inline) in
+// Stage 1 — kept simple and unambiguous.
+type Table struct {
+	Header []string
+	Rows   [][]string
+}
+
+func (Paragraph) isBlock() {}
+func (Heading) isBlock()   {}
+func (Code) isBlock()      {}
+func (List) isBlock()      {}
+func (Quote) isBlock()     {}
+func (Table) isBlock()     {}
+
+// Message is a complete rich message: an ordered list of blocks.
+type Message struct {
+	Blocks []Block
+}

--- a/core/chat/rich/rich_test.go
+++ b/core/chat/rich/rich_test.go
@@ -1,0 +1,184 @@
+package rich_test
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/duckbugio/flock/core/chat/rich"
+)
+
+// inl builds an Inline from spans for terse expectations.
+func inl(spans ...rich.Span) rich.Inline { return rich.Inline{Spans: spans} }
+
+// text is the common case: a single plain span.
+func text(s string) rich.Inline { return inl(rich.Span{Text: s}) }
+
+func TestFromMarkdown(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want rich.Message
+	}{
+		{
+			name: "plain paragraph",
+			in:   "hello world",
+			want: rich.Message{Blocks: []rich.Block{rich.Paragraph{Text: text("hello world")}}},
+		},
+		{
+			name: "heading levels",
+			in:   "### Sub heading",
+			want: rich.Message{Blocks: []rich.Block{rich.Heading{Level: 3, Text: text("Sub heading")}}},
+		},
+		{
+			name: "fenced code with lang",
+			in:   "```go\nx := 1\ny := 2\n```",
+			want: rich.Message{Blocks: []rich.Block{rich.Code{Lang: "go", Text: "x := 1\ny := 2"}}},
+		},
+		{
+			name: "unterminated fence runs to EOF",
+			in:   "```\nstill code",
+			want: rich.Message{Blocks: []rich.Block{rich.Code{Lang: "", Text: "still code"}}},
+		},
+		{
+			name: "bullet list",
+			in:   "- a\n- b\n* c",
+			want: rich.Message{Blocks: []rich.Block{rich.List{Ordered: false, Items: []rich.Inline{
+				text("a"), text("b"), text("c"),
+			}}}},
+		},
+		{
+			name: "ordered list",
+			in:   "1. first\n2. second",
+			want: rich.Message{Blocks: []rich.Block{rich.List{Ordered: true, Items: []rich.Inline{
+				text("first"), text("second"),
+			}}}},
+		},
+		{
+			name: "blockquote joins lines",
+			in:   "> line one\n> line two",
+			want: rich.Message{Blocks: []rich.Block{rich.Quote{Text: text("line one line two")}}},
+		},
+		{
+			name: "link inside paragraph",
+			in:   "see [docs](https://x.y) now",
+			want: rich.Message{Blocks: []rich.Block{rich.Paragraph{Text: inl(
+				rich.Span{Text: "see "},
+				rich.Span{Text: "docs", URL: "https://x.y"},
+				rich.Span{Text: " now"},
+			)}}},
+		},
+		{
+			name: "bold and inline code",
+			in:   "a **b** and `c` end",
+			want: rich.Message{Blocks: []rich.Block{rich.Paragraph{Text: inl(
+				rich.Span{Text: "a "},
+				rich.Span{Text: "b", Bold: true},
+				rich.Span{Text: " and "},
+				rich.Span{Text: "c", Code: true},
+				rich.Span{Text: " end"},
+			)}}},
+		},
+		{
+			name: "underscore bold, not snake_case italic",
+			in:   "use __NOW__ on foo_bar_baz",
+			want: rich.Message{Blocks: []rich.Block{rich.Paragraph{Text: inl(
+				rich.Span{Text: "use "},
+				rich.Span{Text: "NOW", Bold: true},
+				rich.Span{Text: " on foo_bar_baz"},
+			)}}},
+		},
+		{
+			name: "pipe table",
+			in:   "| H1 | H2 |\n| --- | :-: |\n| a | b |\n| c | d |",
+			want: rich.Message{Blocks: []rich.Block{rich.Table{
+				Header: []string{"H1", "H2"},
+				Rows:   [][]string{{"a", "b"}, {"c", "d"}},
+			}}},
+		},
+		{
+			name: "pipe in prose is not a table (no separator)",
+			in:   "a | b is not a table",
+			want: rich.Message{Blocks: []rich.Block{rich.Paragraph{Text: text("a | b is not a table")}}},
+		},
+		{
+			name: "unterminated bold is literal",
+			in:   "a **b c",
+			want: rich.Message{Blocks: []rich.Block{rich.Paragraph{Text: text("a **b c")}}},
+		},
+		{
+			name: "mixed document",
+			in:   "# Title\n\nintro line\n\n```\ncode\n```\n\n- one\n- two\n\n> quote",
+			want: rich.Message{Blocks: []rich.Block{
+				rich.Heading{Level: 1, Text: text("Title")},
+				rich.Paragraph{Text: text("intro line")},
+				rich.Code{Lang: "", Text: "code"},
+				rich.List{Ordered: false, Items: []rich.Inline{text("one"), text("two")}},
+				rich.Quote{Text: text("quote")},
+			}},
+		},
+		{
+			name: "empty input yields no blocks",
+			in:   "",
+			want: rich.Message{},
+		},
+		{
+			name: "whitespace-only yields no blocks",
+			in:   "   \n\n  ",
+			want: rich.Message{},
+		},
+		{
+			name: "paragraph stops at list without blank line",
+			in:   "intro\n- item",
+			want: rich.Message{Blocks: []rich.Block{
+				rich.Paragraph{Text: text("intro")},
+				rich.List{Ordered: false, Items: []rich.Inline{text("item")}},
+			}},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := rich.FromMarkdown(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("FromMarkdown(%q)\n got = %#v\nwant = %#v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFromMarkdownTotal asserts the parser is total: it never panics and always
+// returns at least one block for any input that contains a non-blank line.
+func TestFromMarkdownTotal(t *testing.T) {
+	inputs := []string{
+		"", " ", "\n\n", "```", "```go", "[", "[x]", "[x](", "[x]()",
+		"**", "****", "__", "`", "| |", "|---", "###", "#", "> ", "- ",
+		"1.", "1. ", "a\n\n\n\nb", strings.Repeat("**a** ", 100),
+		"```\n```\n```", "| a | b |\n| - |", "***bold-italic***",
+	}
+	for _, in := range inputs {
+		t.Run("input", func(t *testing.T) {
+			msg := rich.FromMarkdown(in) // must not panic
+			if strings.TrimSpace(in) != "" && len(msg.Blocks) == 0 {
+				t.Errorf("FromMarkdown(%q) returned no blocks for non-blank input", in)
+			}
+		})
+	}
+}
+
+// FuzzFromMarkdown runs the parser under the fuzzer (and its seed corpus in normal
+// test runs), asserting it never panics and honours the "non-blank input → ≥1
+// block" invariant.
+func FuzzFromMarkdown(f *testing.F) {
+	for _, s := range []string{
+		"# h", "```go\nx\n```", "- a\n- b", "> q", "a [l](u) b",
+		"| a | b |\n| - | - |\n| 1 | 2 |", "**x** `y` __z__",
+	} {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, in string) {
+		msg := rich.FromMarkdown(in)
+		if strings.TrimSpace(in) != "" && len(msg.Blocks) == 0 {
+			t.Errorf("non-blank input %q produced no blocks", in)
+		}
+	})
+}


### PR DESCRIPTION
**Stage 1 of `docs/rich-messages-plan.md`** (PR #22). Adds the platform-neutral intermediate representation (IR) for structured rich messages, plus `FromMarkdown` that builds it. **Pure package, no adapter wiring** — nothing renders rich yet.

## Changes
- **`core/chat/rich/rich.go`** — `Span`/`Inline` + a closed `Block` set (`Paragraph`, `Heading`, `Code`, `List`, `Quote`, `Table`) + `Message`.
- **`core/chat/rich/markdown.go`** — `FromMarkdown`: parses the same Markdown subset `MarkdownToHTML` recognizes (fenced/inline code, `**`/`__` bold, ATX headings, `[text](url)` links, `-/*/+` bullets, blockquotes) plus the unambiguous extras the rich target can render (ordered lists, pipe tables). Total & best-effort: never panics; unknown input → `Paragraph`; non-blank input always yields ≥1 block; unterminated fences/markers degrade to literal text.
- **`core/chat/rich/rich_test.go`** — table-driven mapping tests, a totality test, and a `Fuzz` target.

## Scope decisions (altitude — no dead code)
- The IR models **exactly what `FromMarkdown` produces**. **Italic/strikethrough are not parsed**: single-`*`/`_` emphasis false-matches the `snake_case` and glob text developers send constantly, so a `Strike`/`Italic` field with no safe producer would be dead weight.
- The programmatic-only `Thinking` (reasoning) and `Details` (collapsible) blocks are **deferred to the stages that build them** (Stage 3/4), so the IR never carries an unconstructed type.

This is a slight, deliberate trim of the doc's illustrative §3.2 signature — which §3.2 explicitly licenses ("real signatures to lock in Stage 1").

## VK-safety invariant (plan §6)
- Only `core/chat/rich/**` is added; **no file under `adapters/` changes** — `git status -- adapters/` is empty.
- VK never imports the package; its behaviour is untouched.

## Acceptance (AC) — all green via the repo's runner
- **AC1** representative Markdown (code fence, heading, bullet & ordered lists, blockquote, link-in-paragraph, pipe table, bold/inline-code) maps to the expected IR — `go test ./core/chat/rich/...` ✅
- **AC2** parser is total: no panic + ≥1 block for non-blank input across adversarial inputs + fuzz seeds ✅
- **AC3** build/lint/types clean — `go build`, `go vet`, `golangci-lint run` → **0 issues** ✅; full `go test -race ./...` green ✅

Independent of Stage 0; merges on its own.