### PR TITLE
feat: Rich Messages Stages 2–3 — Telegram rich rendering + native draft streaming (provisional wire, flag-off)

### DIFF
--- a/adapters/telegram/.env.example
+++ b/adapters/telegram/.env.example
@@ -29,6 +29,10 @@ REQUIRE_GROUP_MENTION=false
 # Published-PR review/fix loop (Gitea poller + on-PR review). false (default) = off: build +
 # open a PR, then stop. true = react to PR comments and run the on-PR review loop.
 ENABLE_PR_REVIEW=false
+# Bot API 10.1 rich messages (structured blocks + native rich draft). false (default) = off:
+# the legacy Markdown→HTML rendering, unchanged. true = render rich (Telegram only; falls back
+# to Markdown→HTML/plain on any error). See docs/rich-messages-plan.md.
+ENABLE_RICH_MESSAGES=false
 BOT_MEM_LIMIT=3g                # consumed by docker-compose mem_limit, not the bot
 
 # ===== GIT (optional) — clone repos + open PRs from chat. Works with Gitea/GitHub/GitLab. =====

--- a/adapters/telegram/bot.go
+++ b/adapters/telegram/bot.go
@@ -201,6 +201,24 @@ func (c *botChat) tryEditRich(
 	return c.rich.edit(ctx, chatID, messageID, msg, stopMarkup(stopRunID)) == nil
 }
 
+// StreamRichDraft implements the optional chat.RichDrafter extension: it streams
+// the structured progress frame as a Bot API 10.1 rich draft (sendRichMessageDraft),
+// putting the model's reasoning in a dedicated Thinking block. An error is returned
+// to the Service, which then flips off the draft path and falls back to editing the
+// anchor — the same contract as a failed StreamDraft. It is only ever called when
+// enableRich is set (the Service gates on Capabilities().CanSendRich), so c.rich is
+// non-nil here; the guard is defensive.
+func (c *botChat) StreamRichDraft(ctx context.Context, chatID chat.ChatID, draftID string, frame rich.Message) error {
+	if c.rich == nil {
+		return errRichUnavailable
+	}
+	return c.rich.streamDraft(ctx, parseChatID(chatID), draftID, toInputRichMessage(frame))
+}
+
+// errRichUnavailable signals the Service to use the plain draft/edit path; it is a
+// defensive guard, since StreamRichDraft is only reached when rich is enabled.
+var errRichUnavailable = errors.New("telegram: rich transport not configured")
+
 // isParseError reports whether err is Telegram rejecting our parse_mode markup
 // (a 400 "can't parse entities"). Only such errors warrant the plain-text retry;
 // a transport/Not-Found error would fail identically, so retrying it risks a

--- a/adapters/telegram/bot.go
+++ b/adapters/telegram/bot.go
@@ -19,6 +19,7 @@ import (
 	"github.com/go-telegram/bot/models"
 
 	"github.com/duckbugio/flock/core/chat"
+	"github.com/duckbugio/flock/core/chat/rich"
 )
 
 // stopCallbackPrefix is the inline-button callback_data prefix carrying the run
@@ -33,16 +34,24 @@ const telegramMaxMessageRunes = 4096
 type botChat struct {
 	b *bot.Bot
 	// enableRich reports the Capabilities().CanSendRich flag, sourced from the
-	// ENABLE_RICH_MESSAGES config. Stage 0 only surfaces it; the rich render paths
-	// are wired in later stages (see docs/rich-messages-plan.md).
+	// ENABLE_RICH_MESSAGES config (see docs/rich-messages-plan.md).
 	enableRich bool
+	// rich serializes and sends Bot API 10.1 rich messages. It is non-nil only when
+	// enableRich is set; every call site treats a rich error as "fall back to the
+	// legacy MarkdownToHTML/plain path", so the rich path is never load-bearing.
+	rich richTransport
 }
 
 // NewBotChat adapts a *bot.Bot to the core/chat.Transport interface used by the
-// Service. enableRich sets Capabilities().CanSendRich (from ENABLE_RICH_MESSAGES);
-// pass false to keep the legacy MarkdownToHTML/plain rendering.
+// Service. enableRich sets Capabilities().CanSendRich (from ENABLE_RICH_MESSAGES)
+// and, when set, wires the rich HTTP transport over the bot's token; pass false to
+// keep the legacy MarkdownToHTML/plain rendering.
 func NewBotChat(b *bot.Bot, enableRich bool) chat.Transport {
-	return &botChat{b: b, enableRich: enableRich}
+	c := &botChat{b: b, enableRich: enableRich}
+	if enableRich {
+		c.rich = newHTTPRichTransport(b.Token(), defaultTelegramAPIBase, nil)
+	}
+	return c
 }
 
 // Capabilities reports Telegram's full feature set: it can send documents, its
@@ -72,6 +81,12 @@ func parseMessageID(messageID chat.MessageID) int {
 }
 
 func (c *botChat) Send(ctx context.Context, chatID chat.ChatID, text, stopRunID string, asMarkdown bool) (chat.MessageID, error) {
+	// Rich path first (when enabled and the message is markdown-rendered). Any
+	// failure falls through to the legacy HTML/plain path below — the rich render
+	// never costs the user the answer.
+	if id, ok := c.trySendRich(ctx, parseChatID(chatID), text, stopRunID, asMarkdown); ok {
+		return id, nil
+	}
 	params := &bot.SendMessageParams{
 		ChatID:      parseChatID(chatID),
 		Text:        text,
@@ -98,6 +113,10 @@ func (c *botChat) Send(ctx context.Context, chatID chat.ChatID, text, stopRunID 
 func (c *botChat) Edit(
 	ctx context.Context, chatID chat.ChatID, messageID chat.MessageID, text, stopRunID string, asMarkdown bool,
 ) error {
+	// Rich path first; on any failure fall through to the legacy HTML/plain edit.
+	if c.tryEditRich(ctx, parseChatID(chatID), parseMessageID(messageID), text, stopRunID, asMarkdown) {
+		return nil
+	}
 	params := &bot.EditMessageTextParams{
 		ChatID:      parseChatID(chatID),
 		MessageID:   parseMessageID(messageID),
@@ -149,6 +168,37 @@ func (c *botChat) StreamDraft(ctx context.Context, chatID chat.ChatID, draftID, 
 		_, err = c.b.SendMessageDraft(ctx, params)
 	}
 	return err
+}
+
+// trySendRich attempts to send text as a Bot API 10.1 rich message. It returns
+// (id, true) on success; ("", false) tells Send to fall back to the legacy
+// HTML/plain path. It is a no-op (false) unless rich is enabled, asMarkdown is
+// set, and the text is non-empty — so plain sends and the rich-off build keep
+// their exact previous behaviour.
+func (c *botChat) trySendRich(
+	ctx context.Context, chatID int64, text, stopRunID string, asMarkdown bool,
+) (chat.MessageID, bool) {
+	if !c.enableRich || c.rich == nil || !asMarkdown || text == "" {
+		return "", false
+	}
+	msg := toInputRichMessage(rich.FromMarkdown(text))
+	id, err := c.rich.send(ctx, chatID, msg, stopMarkup(stopRunID))
+	if err != nil {
+		return "", false // any rich failure → legacy fallback
+	}
+	return strconv.Itoa(id), true
+}
+
+// tryEditRich is the Edit counterpart of trySendRich: it returns true when the
+// rich edit succeeded, false to fall back to the legacy HTML/plain edit.
+func (c *botChat) tryEditRich(
+	ctx context.Context, chatID int64, messageID int, text, stopRunID string, asMarkdown bool,
+) bool {
+	if !c.enableRich || c.rich == nil || !asMarkdown || text == "" {
+		return false
+	}
+	msg := toInputRichMessage(rich.FromMarkdown(text))
+	return c.rich.edit(ctx, chatID, messageID, msg, stopMarkup(stopRunID)) == nil
 }
 
 // isParseError reports whether err is Telegram rejecting our parse_mode markup

--- a/adapters/telegram/bot.go
+++ b/adapters/telegram/bot.go
@@ -32,21 +32,28 @@ const telegramMaxMessageRunes = 4096
 // botChat implements core/chat.Transport over a *bot.Bot.
 type botChat struct {
 	b *bot.Bot
+	// enableRich reports the Capabilities().CanSendRich flag, sourced from the
+	// ENABLE_RICH_MESSAGES config. Stage 0 only surfaces it; the rich render paths
+	// are wired in later stages (see docs/rich-messages-plan.md).
+	enableRich bool
 }
 
 // NewBotChat adapts a *bot.Bot to the core/chat.Transport interface used by the
-// Service.
-func NewBotChat(b *bot.Bot) chat.Transport {
-	return &botChat{b: b}
+// Service. enableRich sets Capabilities().CanSendRich (from ENABLE_RICH_MESSAGES);
+// pass false to keep the legacy MarkdownToHTML/plain rendering.
+func NewBotChat(b *bot.Bot, enableRich bool) chat.Transport {
+	return &botChat{b: b, enableRich: enableRich}
 }
 
-// Capabilities reports Telegram's full feature set: it can send documents and
-// its message cap is 4096 runes. With these flags the neutral Service behaves
-// exactly as before.
+// Capabilities reports Telegram's full feature set: it can send documents, its
+// message cap is 4096 runes, and it can render rich messages when enableRich is
+// set. With these flags the neutral Service behaves exactly as before when rich
+// is off.
 func (c *botChat) Capabilities() chat.Capabilities {
 	return chat.Capabilities{
 		CanSendDocument: true,
 		MaxMessageRunes: telegramMaxMessageRunes,
+		CanSendRich:     c.enableRich,
 	}
 }
 

--- a/adapters/telegram/bot_rich_test.go
+++ b/adapters/telegram/bot_rich_test.go
@@ -1,0 +1,167 @@
+//nolint:testpackage // whitebox: tests the unexported rich gating/fallback in Send/Edit
+package telegram
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/go-telegram/bot"
+	"github.com/go-telegram/bot/models"
+)
+
+// fakeRich is a stub richTransport: it records calls and returns a configured id
+// or error so the gating/fallback decisions can be tested without HTTP.
+type fakeRich struct {
+	sendID  int
+	sendErr error
+	editErr error
+	sendN   int32
+	editN   int32
+}
+
+func (f *fakeRich) send(_ context.Context, _ int64, _ inputRichMessage, _ models.ReplyMarkup) (int, error) {
+	atomic.AddInt32(&f.sendN, 1)
+	return f.sendID, f.sendErr
+}
+
+func (f *fakeRich) edit(_ context.Context, _ int64, _ int, _ inputRichMessage, _ models.ReplyMarkup) error {
+	atomic.AddInt32(&f.editN, 1)
+	return f.editErr
+}
+
+// legacyBotServer builds a *bot.Bot pointed at a fake Bot API that counts the
+// legacy sendMessage/editMessageText calls and always succeeds.
+func legacyBotServer(t *testing.T, sendHits, editHits *int32) *bot.Bot {
+	t.Helper()
+	ok := func(w http.ResponseWriter, _ *http.Request) {
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"ok":     true,
+			"result": map[string]any{"message_id": 99, "chat": map[string]any{"id": 1}, "date": 0},
+		}); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/bot123:ABC/sendMessage", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(sendHits, 1)
+		ok(w, r)
+	})
+	mux.HandleFunc("/bot123:ABC/editMessageText", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(editHits, 1)
+		ok(w, r)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	b, err := bot.New("123:ABC", bot.WithSkipGetMe(), bot.WithServerURL(srv.URL))
+	if err != nil {
+		t.Fatalf("bot.New: %v", err)
+	}
+	return b
+}
+
+func TestTrySendRichGating(t *testing.T) {
+	fr := &fakeRich{sendID: 11}
+	tests := []struct {
+		name       string
+		enableRich bool
+		rich       richTransport
+		asMarkdown bool
+		text       string
+		wantOK     bool
+	}{
+		{"rich disabled", false, fr, true, "hi", false},
+		{"nil transport", true, nil, true, "hi", false},
+		{"not markdown", true, fr, false, "hi", false},
+		{"empty text", true, fr, true, "", false},
+		{"all set", true, fr, true, "hi", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &botChat{enableRich: tc.enableRich, rich: tc.rich}
+			id, ok := c.trySendRich(context.Background(), 1, tc.text, "", tc.asMarkdown)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if ok && id != "11" {
+				t.Errorf("id = %q, want 11", id)
+			}
+		})
+	}
+}
+
+// TestSendRichSuccessSkipsLegacy: a successful rich send returns the rich id and
+// never touches the legacy sendMessage endpoint.
+func TestSendRichSuccessSkipsLegacy(t *testing.T) {
+	var sendHits, editHits int32
+	b := legacyBotServer(t, &sendHits, &editHits)
+	c := &botChat{b: b, enableRich: true, rich: &fakeRich{sendID: 4242}}
+
+	id, err := c.Send(context.Background(), "555", "# Hi\n\nbody", "", true)
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if id != "4242" {
+		t.Errorf("id = %q, want 4242 (rich id)", id)
+	}
+	if atomic.LoadInt32(&sendHits) != 0 {
+		t.Errorf("legacy sendMessage called %d times, want 0 (rich succeeded)", sendHits)
+	}
+}
+
+// TestSendRichErrorFallsBackToLegacy: a rich failure falls through to the legacy
+// sendMessage, which delivers the answer.
+func TestSendRichErrorFallsBackToLegacy(t *testing.T) {
+	var sendHits, editHits int32
+	b := legacyBotServer(t, &sendHits, &editHits)
+	fr := &fakeRich{sendErr: errors.New("rich boom")}
+	c := &botChat{b: b, enableRich: true, rich: fr}
+
+	id, err := c.Send(context.Background(), "555", "hello", "", true)
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if id != "99" {
+		t.Errorf("id = %q, want 99 (legacy fallback)", id)
+	}
+	if atomic.LoadInt32(&fr.sendN) != 1 {
+		t.Errorf("rich send attempts = %d, want 1", fr.sendN)
+	}
+	if atomic.LoadInt32(&sendHits) != 1 {
+		t.Errorf("legacy sendMessage hits = %d, want 1 (fallback)", sendHits)
+	}
+}
+
+// TestEditRichErrorFallsBackToLegacy mirrors the Send fallback for Edit.
+func TestEditRichErrorFallsBackToLegacy(t *testing.T) {
+	var sendHits, editHits int32
+	b := legacyBotServer(t, &sendHits, &editHits)
+	fr := &fakeRich{editErr: errors.New("rich boom")}
+	c := &botChat{b: b, enableRich: true, rich: fr}
+
+	if err := c.Edit(context.Background(), "555", "7", "progress", "run-1", true); err != nil {
+		t.Fatalf("Edit: %v", err)
+	}
+	if atomic.LoadInt32(&editHits) != 1 {
+		t.Errorf("legacy editMessageText hits = %d, want 1 (fallback)", editHits)
+	}
+}
+
+// TestSendRichDisabledUsesLegacy: with the flag off, Send takes the legacy path
+// untouched (no rich transport configured).
+func TestSendRichDisabledUsesLegacy(t *testing.T) {
+	var sendHits, editHits int32
+	b := legacyBotServer(t, &sendHits, &editHits)
+	c := &botChat{b: b, enableRich: false} // rich nil — exactly today's behaviour
+
+	if _, err := c.Send(context.Background(), "555", "hello", "", true); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if atomic.LoadInt32(&sendHits) != 1 {
+		t.Errorf("legacy sendMessage hits = %d, want 1", sendHits)
+	}
+}

--- a/adapters/telegram/bot_rich_test.go
+++ b/adapters/telegram/bot_rich_test.go
@@ -12,16 +12,21 @@ import (
 
 	"github.com/go-telegram/bot"
 	"github.com/go-telegram/bot/models"
+
+	"github.com/duckbugio/flock/core/chat/rich"
 )
 
 // fakeRich is a stub richTransport: it records calls and returns a configured id
 // or error so the gating/fallback decisions can be tested without HTTP.
 type fakeRich struct {
-	sendID  int
-	sendErr error
-	editErr error
-	sendN   int32
-	editN   int32
+	sendID    int
+	sendErr   error
+	editErr   error
+	draftErr  error
+	sendN     int32
+	editN     int32
+	draftN    int32
+	lastDraft inputRichMessage
 }
 
 func (f *fakeRich) send(_ context.Context, _ int64, _ inputRichMessage, _ models.ReplyMarkup) (int, error) {
@@ -32,6 +37,12 @@ func (f *fakeRich) send(_ context.Context, _ int64, _ inputRichMessage, _ models
 func (f *fakeRich) edit(_ context.Context, _ int64, _ int, _ inputRichMessage, _ models.ReplyMarkup) error {
 	atomic.AddInt32(&f.editN, 1)
 	return f.editErr
+}
+
+func (f *fakeRich) streamDraft(_ context.Context, _ int64, _ string, msg inputRichMessage) error {
+	atomic.AddInt32(&f.draftN, 1)
+	f.lastDraft = msg
+	return f.draftErr
 }
 
 // legacyBotServer builds a *bot.Bot pointed at a fake Bot API that counts the
@@ -148,6 +159,34 @@ func TestEditRichErrorFallsBackToLegacy(t *testing.T) {
 	}
 	if atomic.LoadInt32(&editHits) != 1 {
 		t.Errorf("legacy editMessageText hits = %d, want 1 (fallback)", editHits)
+	}
+}
+
+// TestStreamRichDraftSerializesAndStreams: the optional RichDrafter path
+// serializes the frame and calls the transport's streamDraft.
+func TestStreamRichDraftSerializesAndStreams(t *testing.T) {
+	fr := &fakeRich{}
+	c := &botChat{enableRich: true, rich: fr}
+	frame := rich.Message{Blocks: []rich.Block{rich.Thinking{Text: "reasoning"}}}
+
+	if err := c.StreamRichDraft(context.Background(), "555", "draft-1", frame); err != nil {
+		t.Fatalf("StreamRichDraft: %v", err)
+	}
+	if atomic.LoadInt32(&fr.draftN) != 1 {
+		t.Fatalf("streamDraft calls = %d, want 1", fr.draftN)
+	}
+	if len(fr.lastDraft.Blocks) != 1 || fr.lastDraft.Blocks[0].Type != blockThinking ||
+		fr.lastDraft.Blocks[0].Reasoning != "reasoning" {
+		t.Errorf("streamed payload = %+v, want one thinking block", fr.lastDraft)
+	}
+}
+
+// TestStreamRichDraftNilTransport: a defensive nil transport returns an error so
+// the Service falls back to the plain draft/edit path.
+func TestStreamRichDraftNilTransport(t *testing.T) {
+	c := &botChat{enableRich: true, rich: nil}
+	if err := c.StreamRichDraft(context.Background(), "1", "d", rich.Message{}); err == nil {
+		t.Error("StreamRichDraft with nil transport returned nil, want error")
 	}
 }
 

--- a/adapters/telegram/capabilities_test.go
+++ b/adapters/telegram/capabilities_test.go
@@ -1,15 +1,22 @@
 //nolint:testpackage // whitebox: asserts the unexported botChat wiring of the rich-capability flag
 package telegram
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/go-telegram/bot"
+)
 
 // TestCapabilitiesRichFollowsFlag asserts the Bot API 10.1 rich capability is
 // surfaced from the ENABLE_RICH_MESSAGES flag threaded through NewBotChat, and
-// that the always-on Telegram capabilities are unaffected. Capabilities() does
-// not touch the *bot.Bot, so a nil bot is sufficient here.
+// that the always-on Telegram capabilities are unaffected.
 func TestCapabilitiesRichFollowsFlag(t *testing.T) {
+	b, err := bot.New("123:ABC", bot.WithSkipGetMe())
+	if err != nil {
+		t.Fatalf("bot.New: %v", err)
+	}
 	for _, enableRich := range []bool{false, true} {
-		caps := NewBotChat(nil, enableRich).Capabilities()
+		caps := NewBotChat(b, enableRich).Capabilities()
 		if caps.CanSendRich != enableRich {
 			t.Errorf("NewBotChat(_, %t).Capabilities().CanSendRich = %t, want %t",
 				enableRich, caps.CanSendRich, enableRich)

--- a/adapters/telegram/capabilities_test.go
+++ b/adapters/telegram/capabilities_test.go
@@ -1,0 +1,24 @@
+//nolint:testpackage // whitebox: asserts the unexported botChat wiring of the rich-capability flag
+package telegram
+
+import "testing"
+
+// TestCapabilitiesRichFollowsFlag asserts the Bot API 10.1 rich capability is
+// surfaced from the ENABLE_RICH_MESSAGES flag threaded through NewBotChat, and
+// that the always-on Telegram capabilities are unaffected. Capabilities() does
+// not touch the *bot.Bot, so a nil bot is sufficient here.
+func TestCapabilitiesRichFollowsFlag(t *testing.T) {
+	for _, enableRich := range []bool{false, true} {
+		caps := NewBotChat(nil, enableRich).Capabilities()
+		if caps.CanSendRich != enableRich {
+			t.Errorf("NewBotChat(_, %t).Capabilities().CanSendRich = %t, want %t",
+				enableRich, caps.CanSendRich, enableRich)
+		}
+		if !caps.CanSendDocument {
+			t.Errorf("CanSendDocument = false, want true (enableRich=%t)", enableRich)
+		}
+		if caps.MaxMessageRunes != telegramMaxMessageRunes {
+			t.Errorf("MaxMessageRunes = %d, want %d", caps.MaxMessageRunes, telegramMaxMessageRunes)
+		}
+	}
+}

--- a/adapters/telegram/deploy/roles/claude_tg_bot/templates/env.j2
+++ b/adapters/telegram/deploy/roles/claude_tg_bot/templates/env.j2
@@ -49,6 +49,9 @@ REQUIRE_GROUP_MENTION={{ require_group_mention | default(false) | string | lower
 # Published-PR review/fix loop (poller + CLAUDE.md Phase 2). false (default) = off:
 # build + open a PR, then stop; no on-PR review or comment reactions.
 ENABLE_PR_REVIEW={{ enable_pr_review | default(false) | string | lower }}
+# Bot API 10.1 rich messages (structured blocks + native rich draft). false (default) = off:
+# legacy Markdown→HTML rendering; true = render rich (Telegram only, falls back on any error).
+ENABLE_RICH_MESSAGES={{ enable_rich_messages | default(false) | string | lower }}
 {% if webhook_domain %}
 
 # === WEBHOOK SERVER (PR monitoring) ===

--- a/adapters/telegram/richtransport.go
+++ b/adapters/telegram/richtransport.go
@@ -24,6 +24,7 @@ const defaultTelegramAPIBase = "https://api.telegram.org"
 type richTransport interface {
 	send(ctx context.Context, chatID int64, msg inputRichMessage, markup models.ReplyMarkup) (messageID int, err error)
 	edit(ctx context.Context, chatID int64, messageID int, msg inputRichMessage, markup models.ReplyMarkup) error
+	streamDraft(ctx context.Context, chatID int64, draftID string, msg inputRichMessage) error
 }
 
 // httpRichTransport calls the rich methods directly over HTTP. It exists because
@@ -75,6 +76,18 @@ func (t *httpRichTransport) edit(
 		body["reply_markup"] = markup
 	}
 	_, err := t.call(ctx, "editMessageText", body)
+	return err
+}
+
+// streamDraft streams an ephemeral rich draft preview keyed by draftID
+// (sendRichMessageDraft), the rich counterpart of the lib's SendMessageDraft. A
+// draft carries no inline keyboard, so no markup is passed (the Stop button rides
+// the separate anchor message, as on the legacy draft path).
+func (t *httpRichTransport) streamDraft(
+	ctx context.Context, chatID int64, draftID string, msg inputRichMessage,
+) error {
+	body := map[string]any{"chat_id": chatID, "draft_id": draftID, "rich_message": msg}
+	_, err := t.call(ctx, "sendRichMessageDraft", body)
 	return err
 }
 

--- a/adapters/telegram/richtransport.go
+++ b/adapters/telegram/richtransport.go
@@ -1,0 +1,121 @@
+package telegram
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/go-telegram/bot/models"
+)
+
+// defaultTelegramAPIBase is the Bot API origin the rich HTTP shim targets,
+// matching the go-telegram/bot default. The lib keeps its own server URL private
+// (no accessor), so the shim defaults to the same value; a deployment using a
+// custom Telegram server URL would need this overridden too (a known limitation
+// of the provisional shim, removed once the lib models the rich methods natively).
+const defaultTelegramAPIBase = "https://api.telegram.org"
+
+// richTransport sends Bot API 10.1 rich messages. It is an interface so the
+// adapter's Send/Edit can be unit-tested with a fake, and so the provisional HTTP
+// shim is swappable when the upstream lib gains native rich support.
+type richTransport interface {
+	send(ctx context.Context, chatID int64, msg inputRichMessage, markup models.ReplyMarkup) (messageID int, err error)
+	edit(ctx context.Context, chatID int64, messageID int, msg inputRichMessage, markup models.ReplyMarkup) error
+}
+
+// httpRichTransport calls the rich methods directly over HTTP. It exists because
+// go-telegram/bot v1.21.0 (the latest) does not expose them; it reuses the bot's
+// token (b.Token()) and posts JSON to <base>/bot<token>/<method>, exactly the
+// endpoint shape the lib itself uses (see FileDownloadLink). The token rides the
+// path as the Bot API requires and is never logged here.
+type httpRichTransport struct {
+	token string
+	base  string
+	hc    *http.Client
+}
+
+func newHTTPRichTransport(token, base string, hc *http.Client) *httpRichTransport {
+	if base == "" {
+		base = defaultTelegramAPIBase
+	}
+	if hc == nil {
+		hc = http.DefaultClient
+	}
+	return &httpRichTransport{token: token, base: base, hc: hc}
+}
+
+func (t *httpRichTransport) send(
+	ctx context.Context, chatID int64, msg inputRichMessage, markup models.ReplyMarkup,
+) (int, error) {
+	body := map[string]any{"chat_id": chatID, "rich_message": msg}
+	if markup != nil {
+		body["reply_markup"] = markup
+	}
+	raw, err := t.call(ctx, "sendRichMessage", body)
+	if err != nil {
+		return 0, err
+	}
+	var res struct {
+		MessageID int `json:"message_id"` //nolint:tagliatelle // Telegram Bot API uses snake_case.
+	}
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return 0, fmt.Errorf("decode sendRichMessage result: %w", err)
+	}
+	return res.MessageID, nil
+}
+
+func (t *httpRichTransport) edit(
+	ctx context.Context, chatID int64, messageID int, msg inputRichMessage, markup models.ReplyMarkup,
+) error {
+	body := map[string]any{"chat_id": chatID, "message_id": messageID, "rich_message": msg}
+	if markup != nil {
+		body["reply_markup"] = markup
+	}
+	_, err := t.call(ctx, "editMessageText", body)
+	return err
+}
+
+// apiEnvelope is the subset of the Bot API response envelope the shim reads.
+type apiEnvelope struct {
+	OK          bool            `json:"ok"`
+	Description string          `json:"description"`
+	Result      json.RawMessage `json:"result"`
+}
+
+// call POSTs a JSON body to a Bot API method and returns the raw "result" on
+// success, or an error (HTTP, transport, or ok:false) the caller turns into a
+// fallback to the legacy rendering.
+func (t *httpRichTransport) call(ctx context.Context, method string, body map[string]any) (json.RawMessage, error) {
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal %s body: %w", method, err)
+	}
+	url := fmt.Sprintf("%s/bot%s/%s", t.base, t.token, method)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(buf))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := t.hc.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	var env apiEnvelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		return nil, fmt.Errorf("decode %s envelope: %w", method, err)
+	}
+	if !env.OK {
+		return nil, fmt.Errorf("telegram %s failed: %s", method, env.Description)
+	}
+	return env.Result, nil
+}

--- a/adapters/telegram/richtransport_test.go
+++ b/adapters/telegram/richtransport_test.go
@@ -1,0 +1,99 @@
+//nolint:testpackage // whitebox: tests the unexported rich HTTP shim
+package telegram
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/duckbugio/flock/core/chat/rich"
+)
+
+// richRecordingServer is a fake Bot API that records the last method path and
+// JSON body, and returns a canned envelope.
+type richRecordingServer struct {
+	srv      *httptest.Server
+	lastPath string
+	lastBody map[string]any
+}
+
+func newRichServer(t *testing.T, reply string) *richRecordingServer {
+	t.Helper()
+	rs := &richRecordingServer{}
+	rs.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rs.lastPath = r.URL.Path
+		data, _ := io.ReadAll(r.Body)
+		rs.lastBody = map[string]any{}
+		_ = json.Unmarshal(data, &rs.lastBody)
+		_, _ = io.WriteString(w, reply)
+	}))
+	t.Cleanup(rs.srv.Close)
+	return rs
+}
+
+func TestHTTPRichTransportSend(t *testing.T) {
+	rs := newRichServer(t, `{"ok":true,"result":{"message_id":4242}}`)
+	tr := newHTTPRichTransport("123:ABC", rs.srv.URL, rs.srv.Client())
+
+	msg := toInputRichMessage(rich2(t))
+	id, err := tr.send(context.Background(), 555, msg, stopMarkup("run-1"))
+	if err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if id != 4242 {
+		t.Errorf("message id = %d, want 4242", id)
+	}
+	if !strings.HasSuffix(rs.lastPath, "/bot123:ABC/sendRichMessage") {
+		t.Errorf("path = %q, want .../bot123:ABC/sendRichMessage", rs.lastPath)
+	}
+	if _, ok := rs.lastBody["rich_message"]; !ok {
+		t.Errorf("body %v missing rich_message", rs.lastBody)
+	}
+	if rs.lastBody["chat_id"].(float64) != 555 {
+		t.Errorf("chat_id = %v, want 555", rs.lastBody["chat_id"])
+	}
+	if _, ok := rs.lastBody["reply_markup"]; !ok {
+		t.Errorf("body %v missing reply_markup (Stop button)", rs.lastBody)
+	}
+}
+
+func TestHTTPRichTransportEdit(t *testing.T) {
+	rs := newRichServer(t, `{"ok":true,"result":{"message_id":7}}`)
+	tr := newHTTPRichTransport("123:ABC", rs.srv.URL, rs.srv.Client())
+
+	err := tr.edit(context.Background(), 555, 7, toInputRichMessage(rich2(t)), nil)
+	if err != nil {
+		t.Fatalf("edit: %v", err)
+	}
+	if !strings.HasSuffix(rs.lastPath, "/editMessageText") {
+		t.Errorf("path = %q, want .../editMessageText", rs.lastPath)
+	}
+	if rs.lastBody["message_id"].(float64) != 7 {
+		t.Errorf("message_id = %v, want 7", rs.lastBody["message_id"])
+	}
+}
+
+// TestHTTPRichTransportAPIError asserts an ok:false envelope becomes an error
+// (which the adapter turns into a legacy fallback).
+func TestHTTPRichTransportAPIError(t *testing.T) {
+	rs := newRichServer(t, `{"ok":false,"description":"RICH_MESSAGE_INVALID"}`)
+	tr := newHTTPRichTransport("123:ABC", rs.srv.URL, rs.srv.Client())
+
+	_, err := tr.send(context.Background(), 1, toInputRichMessage(rich2(t)), nil)
+	if err == nil {
+		t.Fatal("send with ok:false returned nil error, want failure")
+	}
+	if !strings.Contains(err.Error(), "RICH_MESSAGE_INVALID") {
+		t.Errorf("error %v missing API description", err)
+	}
+}
+
+// rich2 builds a small representative message for transport tests.
+func rich2(t *testing.T) rich.Message {
+	t.Helper()
+	return rich.FromMarkdown("# Title\n\nhello **world**")
+}

--- a/adapters/telegram/richtransport_test.go
+++ b/adapters/telegram/richtransport_test.go
@@ -92,6 +92,25 @@ func TestHTTPRichTransportAPIError(t *testing.T) {
 	}
 }
 
+func TestHTTPRichTransportStreamDraft(t *testing.T) {
+	rs := newRichServer(t, `{"ok":true,"result":true}`)
+	tr := newHTTPRichTransport("123:ABC", rs.srv.URL, rs.srv.Client())
+
+	err := tr.streamDraft(context.Background(), 555, "draft-1", toInputRichMessage(rich2(t)))
+	if err != nil {
+		t.Fatalf("streamDraft: %v", err)
+	}
+	if !strings.HasSuffix(rs.lastPath, "/sendRichMessageDraft") {
+		t.Errorf("path = %q, want .../sendRichMessageDraft", rs.lastPath)
+	}
+	if rs.lastBody["draft_id"] != "draft-1" {
+		t.Errorf("draft_id = %v, want draft-1", rs.lastBody["draft_id"])
+	}
+	if _, ok := rs.lastBody["rich_message"]; !ok {
+		t.Errorf("body %v missing rich_message", rs.lastBody)
+	}
+}
+
 // rich2 builds a small representative message for transport tests.
 func rich2(t *testing.T) rich.Message {
 	t.Helper()

--- a/adapters/telegram/richwire.go
+++ b/adapters/telegram/richwire.go
@@ -32,6 +32,7 @@ const (
 	blockList         = "list"            // RichBlockList
 	blockQuote        = "block_quotation" // RichBlockBlockQuotation
 	blockTable        = "table"           // RichBlockTable
+	blockThinking     = "thinking"        // RichBlockThinking
 )
 
 // inputRichMessage is the top-level payload of sendRichMessage /
@@ -44,15 +45,16 @@ type inputRichMessage struct {
 // (rather than an interface with a custom marshaler) keeps the provisional wire
 // definition in one readable place; unused fields are omitted via omitempty.
 type richBlock struct {
-	Type     string     `json:"type"`
-	Text     *richText  `json:"text,omitempty"`     // paragraph, section_heading, block_quotation
-	Level    int        `json:"level,omitempty"`    // section_heading (1..6)
-	Language string     `json:"language,omitempty"` // preformatted (fence info-string)
-	Code     string     `json:"code,omitempty"`     // preformatted (verbatim body)
-	Ordered  bool       `json:"ordered,omitempty"`  // list
-	Items    []richText `json:"items,omitempty"`    // list
-	Header   []string   `json:"header,omitempty"`   // table
-	Rows     [][]string `json:"rows,omitempty"`     // table
+	Type      string     `json:"type"`
+	Text      *richText  `json:"text,omitempty"`      // paragraph, section_heading, block_quotation
+	Level     int        `json:"level,omitempty"`     // section_heading (1..6)
+	Language  string     `json:"language,omitempty"`  // preformatted (fence info-string)
+	Code      string     `json:"code,omitempty"`      // preformatted (verbatim body)
+	Ordered   bool       `json:"ordered,omitempty"`   // list
+	Items     []richText `json:"items,omitempty"`     // list
+	Header    []string   `json:"header,omitempty"`    // table
+	Rows      [][]string `json:"rows,omitempty"`      // table
+	Reasoning string     `json:"reasoning,omitempty"` // thinking
 }
 
 // richText is a run of formatted inline text. The published RichText* styling
@@ -100,6 +102,8 @@ func toRichBlock(b rich.Block) richBlock {
 		return richBlock{Type: blockQuote, Text: toRichText(v.Text)}
 	case rich.Table:
 		return richBlock{Type: blockTable, Header: v.Header, Rows: v.Rows}
+	case rich.Thinking:
+		return richBlock{Type: blockThinking, Reasoning: v.Text}
 	default:
 		return richBlock{Type: blockParagraph, Text: &richText{}}
 	}

--- a/adapters/telegram/richwire.go
+++ b/adapters/telegram/richwire.go
@@ -1,0 +1,122 @@
+package telegram
+
+import "github.com/duckbugio/flock/core/chat/rich"
+
+// ============================================================================
+// PROVISIONAL Bot API 10.1 rich-message wire types.
+//
+// This is the ONE place that encodes the on-the-wire JSON shape of the rich
+// message payload. As of this writing the schema is NOT yet verifiable: the
+// upstream go-telegram/bot lib (v1.21.0, the latest) does not model these types,
+// and the published Bot API 10.1 changelog lists the class NAMES
+// (InputRichMessage, RichBlockParagraph, RichBlockPreformatted, RichBlockTable,
+// …) but not their field-level JSON. The field names and the "type" discriminator
+// strings below are therefore derived from those published class names plus
+// Telegram's invariant JSON conventions (snake_case fields; a "type" tag on
+// polymorphic objects, as InputMedia/PassportElementError use).
+//
+// This is safe because the whole rich path is OFF by default (ENABLE_RICH_MESSAGES)
+// and every call site falls back to the legacy MarkdownToHTML/plain rendering on
+// ANY error — so a wrong field name degrades to today's output, never a failure.
+// When the lib gains the types (swap to them) or a live API/sample verifies the
+// schema, THIS FILE is the only thing to correct; the serializer and transport
+// above/below it stay put.
+// ============================================================================
+
+// Block "type" discriminator strings (snake_cased from the RichBlock* class
+// names). Only the blocks the serializer currently emits are defined.
+const (
+	blockParagraph    = "paragraph"       // RichBlockParagraph
+	blockHeading      = "section_heading" // RichBlockSectionHeading
+	blockPreformatted = "preformatted"    // RichBlockPreformatted
+	blockList         = "list"            // RichBlockList
+	blockQuote        = "block_quotation" // RichBlockBlockQuotation
+	blockTable        = "table"           // RichBlockTable
+)
+
+// inputRichMessage is the top-level payload of sendRichMessage /
+// editMessageText(rich_message) / sendRichMessageDraft.
+type inputRichMessage struct {
+	Blocks []richBlock `json:"blocks"`
+}
+
+// richBlock is one polymorphic block, discriminated by Type. A single flat struct
+// (rather than an interface with a custom marshaler) keeps the provisional wire
+// definition in one readable place; unused fields are omitted via omitempty.
+type richBlock struct {
+	Type     string     `json:"type"`
+	Text     *richText  `json:"text,omitempty"`     // paragraph, section_heading, block_quotation
+	Level    int        `json:"level,omitempty"`    // section_heading (1..6)
+	Language string     `json:"language,omitempty"` // preformatted (fence info-string)
+	Code     string     `json:"code,omitempty"`     // preformatted (verbatim body)
+	Ordered  bool       `json:"ordered,omitempty"`  // list
+	Items    []richText `json:"items,omitempty"`    // list
+	Header   []string   `json:"header,omitempty"`   // table
+	Rows     [][]string `json:"rows,omitempty"`     // table
+}
+
+// richText is a run of formatted inline text. The published RichText* styling
+// classes (RichTextBold, RichTextCode, RichTextUrl, …) imply a per-run style; we
+// model the subset FromMarkdown emits (bold, inline code, links) as flags on each
+// run.
+type richText struct {
+	Runs []richTextRun `json:"runs"`
+}
+
+type richTextRun struct {
+	Text string `json:"text"`
+	Bold bool   `json:"bold,omitempty"`
+	Code bool   `json:"code,omitempty"`
+	URL  string `json:"url,omitempty"` // non-empty → the run is a link
+}
+
+// ----------------------------------------------------------------------------
+// Serializer: neutral rich IR -> the wire payload. This mapping is stable and
+// fully testable regardless of the provisional field names above.
+// ----------------------------------------------------------------------------
+
+// toInputRichMessage converts the neutral rich.Message IR into the wire payload.
+// It is total: an unmapped block type degrades to an empty paragraph so the
+// payload is always valid (mirroring FromMarkdown's best-effort guarantee).
+func toInputRichMessage(m rich.Message) inputRichMessage {
+	out := inputRichMessage{}
+	for _, b := range m.Blocks {
+		out.Blocks = append(out.Blocks, toRichBlock(b))
+	}
+	return out
+}
+
+func toRichBlock(b rich.Block) richBlock {
+	switch v := b.(type) {
+	case rich.Paragraph:
+		return richBlock{Type: blockParagraph, Text: toRichText(v.Text)}
+	case rich.Heading:
+		return richBlock{Type: blockHeading, Level: v.Level, Text: toRichText(v.Text)}
+	case rich.Code:
+		return richBlock{Type: blockPreformatted, Language: v.Lang, Code: v.Text}
+	case rich.List:
+		return richBlock{Type: blockList, Ordered: v.Ordered, Items: toRichTexts(v.Items)}
+	case rich.Quote:
+		return richBlock{Type: blockQuote, Text: toRichText(v.Text)}
+	case rich.Table:
+		return richBlock{Type: blockTable, Header: v.Header, Rows: v.Rows}
+	default:
+		return richBlock{Type: blockParagraph, Text: &richText{}}
+	}
+}
+
+func toRichText(in rich.Inline) *richText {
+	rt := &richText{}
+	for _, s := range in.Spans {
+		rt.Runs = append(rt.Runs, richTextRun{Text: s.Text, Bold: s.Bold, Code: s.Code, URL: s.URL})
+	}
+	return rt
+}
+
+func toRichTexts(in []rich.Inline) []richText {
+	out := make([]richText, 0, len(in))
+	for _, t := range in {
+		out = append(out, *toRichText(t))
+	}
+	return out
+}

--- a/adapters/telegram/richwire_test.go
+++ b/adapters/telegram/richwire_test.go
@@ -1,0 +1,89 @@
+//nolint:testpackage // whitebox: tests the unexported rich wire serializer
+package telegram
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/duckbugio/flock/core/chat/rich"
+)
+
+func span(text string) rich.Inline { return rich.Inline{Spans: []rich.Span{{Text: text}}} }
+
+// TestToInputRichMessageMapsEveryBlock asserts each neutral IR block maps to the
+// expected wire block type and carries its fields.
+func TestToInputRichMessageMapsEveryBlock(t *testing.T) {
+	m := rich.Message{Blocks: []rich.Block{
+		rich.Heading{Level: 2, Text: span("Title")},
+		rich.Paragraph{Text: rich.Inline{Spans: []rich.Span{
+			{Text: "see "},
+			{Text: "docs", URL: "https://x.y"},
+			{Text: " and "},
+			{Text: "b", Bold: true},
+			{Text: "c", Code: true},
+		}}},
+		rich.Code{Lang: "go", Text: "x := 1"},
+		rich.List{Ordered: true, Items: []rich.Inline{span("one"), span("two")}},
+		rich.Quote{Text: span("q")},
+		rich.Table{Header: []string{"H1", "H2"}, Rows: [][]string{{"a", "b"}}},
+	}}
+
+	got := toInputRichMessage(m)
+	if len(got.Blocks) != len(m.Blocks) {
+		t.Fatalf("block count = %d, want %d", len(got.Blocks), len(m.Blocks))
+	}
+
+	if h := got.Blocks[0]; h.Type != blockHeading || h.Level != 2 || h.Text == nil || h.Text.Runs[0].Text != "Title" {
+		t.Errorf("heading block = %+v", h)
+	}
+	if p := got.Blocks[1]; p.Type != blockParagraph || p.Text == nil || len(p.Text.Runs) != 5 {
+		t.Fatalf("paragraph block = %+v", p)
+	} else {
+		runs := p.Text.Runs
+		if runs[1].URL != "https://x.y" || runs[1].Text != "docs" {
+			t.Errorf("link run = %+v", runs[1])
+		}
+		if !runs[3].Bold || !runs[4].Code {
+			t.Errorf("bold/code runs = %+v / %+v", runs[3], runs[4])
+		}
+	}
+	if c := got.Blocks[2]; c.Type != blockPreformatted || c.Language != "go" || c.Code != "x := 1" {
+		t.Errorf("code block = %+v", c)
+	}
+	if l := got.Blocks[3]; l.Type != blockList || !l.Ordered || len(l.Items) != 2 || l.Items[0].Runs[0].Text != "one" {
+		t.Errorf("list block = %+v", l)
+	}
+	if q := got.Blocks[4]; q.Type != blockQuote || q.Text == nil || q.Text.Runs[0].Text != "q" {
+		t.Errorf("quote block = %+v", q)
+	}
+	if tb := got.Blocks[5]; tb.Type != blockTable || len(tb.Header) != 2 || tb.Rows[0][1] != "b" {
+		t.Errorf("table block = %+v", tb)
+	}
+}
+
+// TestToInputRichMessageJSONShape asserts the serialized payload carries the
+// "blocks"/"type"/"runs" shape the wire expects (a regression guard on the
+// provisional schema — the single place to update if field names are corrected).
+func TestToInputRichMessageJSONShape(t *testing.T) {
+	m := rich.Message{Blocks: []rich.Block{rich.Paragraph{Text: span("hi")}}}
+	b, err := json.Marshal(toInputRichMessage(m))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	js := string(b)
+	for _, want := range []string{`"blocks"`, `"type":"paragraph"`, `"runs"`, `"text":"hi"`} {
+		if !strings.Contains(js, want) {
+			t.Errorf("payload %s missing %s", js, want)
+		}
+	}
+}
+
+// TestToInputRichMessageEmpty asserts an empty IR serializes to an empty block
+// list without panicking.
+func TestToInputRichMessageEmpty(t *testing.T) {
+	got := toInputRichMessage(rich.Message{})
+	if len(got.Blocks) != 0 {
+		t.Errorf("empty message produced %d blocks, want 0", len(got.Blocks))
+	}
+}

--- a/adapters/telegram/richwire_test.go
+++ b/adapters/telegram/richwire_test.go
@@ -79,6 +79,19 @@ func TestToInputRichMessageJSONShape(t *testing.T) {
 	}
 }
 
+// TestToInputRichMessageThinking asserts the programmatic Thinking block maps to
+// a "thinking" wire block carrying the reasoning text.
+func TestToInputRichMessageThinking(t *testing.T) {
+	m := rich.Message{Blocks: []rich.Block{rich.Thinking{Text: "step 1\nstep 2"}}}
+	got := toInputRichMessage(m)
+	if len(got.Blocks) != 1 || got.Blocks[0].Type != blockThinking {
+		t.Fatalf("blocks = %+v, want one thinking block", got.Blocks)
+	}
+	if got.Blocks[0].Reasoning != "step 1\nstep 2" {
+		t.Errorf("reasoning = %q, want the joined thoughts", got.Blocks[0].Reasoning)
+	}
+}
+
 // TestToInputRichMessageEmpty asserts an empty IR serializes to an empty block
 // list without panicking.
 func TestToInputRichMessageEmpty(t *testing.T) {

--- a/adapters/vk/bot_test.go
+++ b/adapters/vk/bot_test.go
@@ -23,6 +23,12 @@ func TestCapabilities(t *testing.T) {
 	if caps.MaxMessageRunes != vkMaxMessageRunes {
 		t.Errorf("MaxMessageRunes = %d, want %d", caps.MaxMessageRunes, vkMaxMessageRunes)
 	}
+	// VK has no Bot API 10.1 rich support: the additive CanSendRich field must stay
+	// at its zero value so the VK adapter keeps the legacy rendering with no change
+	// (docs/rich-messages-plan.md §6).
+	if caps.CanSendRich {
+		t.Errorf("capabilities = %+v, want CanSendRich false (VK has no rich support)", caps)
+	}
 }
 
 func TestSendRendersStopKeyboardAndUniqueRandomID(t *testing.T) {

--- a/cmd/flock-telegram/main.go
+++ b/cmd/flock-telegram/main.go
@@ -231,7 +231,7 @@ func run() int {
 
 	svc = chat.New(chat.Config{
 		Runner:     runner,
-		Transport:  telegram.NewBotChat(b),
+		Transport:  telegram.NewBotChat(b, cfg.EnableRichMessages),
 		Dispatcher: disp,
 		Workspace:  ws,
 		Sessions:   sessions,

--- a/cmd/flock-telegram/media_routing_test.go
+++ b/cmd/flock-telegram/media_routing_test.go
@@ -127,7 +127,7 @@ func newMediaHarness(t *testing.T, maxUpload int64) *mediaTestHarness {
 	disp := dispatch.New(2)
 	svc := chat.New(chat.Config{
 		Runner:     runner,
-		Transport:  telegram.NewBotChat(b),
+		Transport:  telegram.NewBotChat(b, false),
 		Dispatcher: disp,
 		Workspace:  &fakeWorkspace{dir: t.TempDir()},
 		Logger:     logger,

--- a/core/chat/progress.go
+++ b/core/chat/progress.go
@@ -13,6 +13,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/duckbugio/flock/core/chat/rich"
 	"github.com/duckbugio/flock/core/claude"
 )
 
@@ -475,6 +476,55 @@ func (p *Progress) Frame() string {
 		budget = 1
 	}
 	return assemble([]string{capLine(lines[0], budget)})
+}
+
+// RichFrame renders the current progress as a structured rich Message, the
+// neutral IR a RichDrafter transport streams as a Bot API 10.1 rich draft. It
+// mirrors Frame()'s content — the same ring, the same per-recency caps — but
+// SEPARATES the model's reasoning into a single collapsible Thinking block
+// instead of interleaving it with tool activity, which is the whole point of the
+// rich draft. Layout: the "Working… (Ns)" header paragraph, an optional "+N
+// earlier" indicator, the Thinking block (when any reasoning is in the ring), then
+// one paragraph per tool-activity line (keeping its emoji prefix). Transports
+// without RichDrafter keep using Frame(); VK is unaffected.
+func (p *Progress) RichFrame() rich.Message {
+	secs := int64(p.elapsed() / time.Second)
+	if secs < 0 {
+		secs = 0
+	}
+	spin := spinnerFrames[secs%int64(len(spinnerFrames))]
+	header := fmt.Sprintf("%s Working… (%s)", spin, formatElapsed(secs))
+
+	blocks := []rich.Block{paragraph(header)}
+	if hidden := p.total - len(p.ring); hidden > 0 {
+		blocks = append(blocks, paragraph(fmt.Sprintf(elidedFormat, hidden)))
+	}
+
+	var thoughts, tools []string
+	for i, line := range p.ring {
+		maxText := olderSnippetMax
+		if i == len(p.ring)-1 {
+			maxText = recentSnippetMax
+		}
+		capped := capLine(line, maxText)
+		if strings.HasPrefix(capped, thoughtPrefix) {
+			thoughts = append(thoughts, strings.TrimPrefix(capped, thoughtPrefix))
+		} else {
+			tools = append(tools, capped)
+		}
+	}
+	if len(thoughts) > 0 {
+		blocks = append(blocks, rich.Thinking{Text: strings.Join(thoughts, "\n")})
+	}
+	for _, t := range tools {
+		blocks = append(blocks, paragraph(t))
+	}
+	return rich.Message{Blocks: blocks}
+}
+
+// paragraph wraps a plain string as a single-span rich paragraph block.
+func paragraph(s string) rich.Block {
+	return rich.Paragraph{Text: rich.Inline{Spans: []rich.Span{{Text: s}}}}
 }
 
 // Final renders the terminal message text for a successful run result. A

--- a/core/chat/progress_test.go
+++ b/core/chat/progress_test.go
@@ -10,12 +10,59 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/duckbugio/flock/core/chat/rich"
 	"github.com/duckbugio/flock/core/claude"
 )
 
 // fakeClock returns a controllable elapsed function for deterministic frames.
 func fakeClock(d *time.Duration) func() time.Duration {
 	return func() time.Duration { return *d }
+}
+
+// TestRichFrameSeparatesReasoning asserts RichFrame routes the model's reasoning
+// into a single Thinking block and tool activity into paragraphs, with the
+// Working header first — the structured layout a rich draft renders.
+func TestRichFrameSeparatesReasoning(t *testing.T) {
+	var elapsed time.Duration
+	p := NewProgress(fakeClock(&elapsed), 5)
+	p.Observe(claude.Event{Type: claude.Text, Text: "first thought"})
+	p.Observe(claude.Event{Type: claude.ToolUse, Tool: "Bash"})
+	p.Observe(claude.Event{Type: claude.Text, Text: "second thought"})
+
+	msg := p.RichFrame()
+	if len(msg.Blocks) == 0 {
+		t.Fatal("RichFrame returned no blocks")
+	}
+	// Header paragraph first.
+	if h, ok := msg.Blocks[0].(rich.Paragraph); !ok || !strings.Contains(h.Text.Spans[0].Text, "Working…") {
+		t.Fatalf("first block = %+v, want a Working header paragraph", msg.Blocks[0])
+	}
+	// Exactly one Thinking block, joining both thoughts; no tool emoji leaks in.
+	var thinking *rich.Thinking
+	tools := 0
+	for _, b := range msg.Blocks {
+		switch v := b.(type) {
+		case rich.Thinking:
+			tv := v
+			thinking = &tv
+		case rich.Paragraph:
+			if strings.Contains(v.Text.Spans[0].Text, "Bash") {
+				tools++
+			}
+		}
+	}
+	if thinking == nil {
+		t.Fatal("no Thinking block; reasoning was not separated")
+	}
+	if !strings.Contains(thinking.Text, "first thought") || !strings.Contains(thinking.Text, "second thought") {
+		t.Errorf("thinking text = %q, want both thoughts joined", thinking.Text)
+	}
+	if strings.Contains(thinking.Text, thoughtPrefix) {
+		t.Errorf("thinking text %q still carries the 💭 prefix", thinking.Text)
+	}
+	if tools != 1 {
+		t.Errorf("tool paragraphs = %d, want 1 (the Bash line)", tools)
+	}
 }
 
 func TestFrameCounterDrivenByClockNotEvents(t *testing.T) {

--- a/core/chat/rich/markdown.go
+++ b/core/chat/rich/markdown.go
@@ -1,0 +1,305 @@
+package rich
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Block-shape matchers. Kept intentionally close to MarkdownToHTML's regex set so
+// FromMarkdown classifies the same Markdown subset; the table/ordered-list
+// matchers are the unambiguous additions the rich IR can represent.
+var (
+	reHeading = regexp.MustCompile(`^(#{1,6})\s+(.+?)\s*$`)
+	reULItem  = regexp.MustCompile(`^[-*+]\s+(.*)$`)
+	reOLItem  = regexp.MustCompile(`^\d+[.)]\s+(.*)$`)
+)
+
+// tableHeaderRows is how many rows precede a pipe table's body: the header row
+// plus the separator row.
+const tableHeaderRows = 2
+
+// FromMarkdown parses the Markdown subset the assistant emits into the neutral
+// rich IR. It is TOTAL and best-effort: it never panics, and any line it cannot
+// classify becomes a Paragraph, so a serializer always has something valid to
+// emit (mirroring MarkdownToHTML's "degrade to escaped literal" guarantee). For
+// any input containing a non-blank line it returns at least one Block; an
+// empty/whitespace-only input returns a Message with no blocks.
+func FromMarkdown(md string) Message {
+	lines := strings.Split(md, "\n")
+	var blocks []Block
+	for i := 0; i < len(lines); {
+		s := lines[i]
+		switch {
+		case blankLine(s):
+			i++ // blank line: a block separator, nothing emitted
+		case fenceLine(s):
+			var blk Block
+			blk, i = parseFence(lines, i)
+			blocks = append(blocks, blk)
+		case headingLine(s):
+			blocks = append(blocks, parseHeading(s))
+			i++
+		case tableStart(lines, i):
+			var blk Block
+			blk, i = parseTable(lines, i)
+			blocks = append(blocks, blk)
+		case quoteLine(s):
+			var blk Block
+			blk, i = parseQuote(lines, i)
+			blocks = append(blocks, blk)
+		case listLine(s):
+			var blk Block
+			blk, i = parseList(lines, i)
+			blocks = append(blocks, blk)
+		default:
+			var blk Block
+			blk, i = parseParagraph(lines, i)
+			blocks = append(blocks, blk)
+		}
+	}
+	return Message{Blocks: blocks}
+}
+
+// --- line predicates ---
+
+func blankLine(s string) bool   { return strings.TrimSpace(s) == "" }
+func fenceLine(s string) bool   { return strings.HasPrefix(strings.TrimSpace(s), "```") }
+func headingLine(s string) bool { return reHeading.MatchString(strings.TrimSpace(s)) }
+func quoteLine(s string) bool   { return strings.HasPrefix(strings.TrimSpace(s), ">") }
+
+func listLine(s string) bool {
+	t := strings.TrimSpace(s)
+	return reULItem.MatchString(t) || reOLItem.MatchString(t)
+}
+
+// tableStart reports whether line i begins a pipe table: a row containing "|"
+// immediately followed by a separator row (cells of only -, :, and spaces). The
+// mandatory separator is what keeps a prose line that merely contains "|" from
+// being misread as a table.
+func tableStart(lines []string, i int) bool {
+	if i+1 >= len(lines) {
+		return false
+	}
+	return strings.Contains(lines[i], "|") && isTableSeparator(lines[i+1])
+}
+
+// isBlockStart reports whether line i begins a non-paragraph block (or is blank),
+// so parseParagraph knows where to stop without requiring a blank-line separator.
+func isBlockStart(lines []string, i int) bool {
+	s := lines[i]
+	return blankLine(s) || fenceLine(s) || headingLine(s) ||
+		quoteLine(s) || listLine(s) || tableStart(lines, i)
+}
+
+// --- block parsers (each returns the parsed block and the next line index) ---
+
+// parseFence consumes a ``` fenced code block starting at line i, capturing the
+// optional info-string as Lang and the verbatim body. An unterminated fence runs
+// to EOF (best-effort), so a stray ``` never drops the rest of the message.
+func parseFence(lines []string, i int) (Block, int) {
+	lang := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(lines[i]), "```"))
+	var body []string
+	j := i + 1
+	for j < len(lines) {
+		if strings.TrimSpace(lines[j]) == "```" {
+			j++ // consume the closing fence
+			break
+		}
+		body = append(body, lines[j])
+		j++
+	}
+	return Code{Lang: lang, Text: strings.Join(body, "\n")}, j
+}
+
+func parseHeading(s string) Block {
+	m := reHeading.FindStringSubmatch(strings.TrimSpace(s))
+	return Heading{Level: len(m[1]), Text: parseInline(m[2])}
+}
+
+// parseQuote consumes consecutive ">"-prefixed lines, strips the marker (and one
+// optional following space) from each, and joins them into one inline run.
+func parseQuote(lines []string, i int) (Block, int) {
+	var parts []string
+	j := i
+	for j < len(lines) && quoteLine(lines[j]) {
+		t := strings.TrimSpace(lines[j])
+		t = strings.TrimPrefix(t, ">")
+		t = strings.TrimPrefix(t, " ")
+		parts = append(parts, t)
+		j++
+	}
+	return Quote{Text: parseInline(strings.Join(parts, " "))}, j
+}
+
+// parseList consumes consecutive list items. Ordered-ness is taken from the first
+// item; each item's text after its marker becomes one inline run.
+func parseList(lines []string, i int) (Block, int) {
+	ordered := reOLItem.MatchString(strings.TrimSpace(lines[i]))
+	var items []Inline
+	j := i
+	for j < len(lines) && listLine(lines[j]) {
+		t := strings.TrimSpace(lines[j])
+		var text string
+		if m := reOLItem.FindStringSubmatch(t); m != nil {
+			text = m[1]
+		} else if m := reULItem.FindStringSubmatch(t); m != nil {
+			text = m[1]
+		}
+		items = append(items, parseInline(text))
+		j++
+	}
+	return List{Ordered: ordered, Items: items}, j
+}
+
+// parseParagraph consumes consecutive lines until a blank line or the start of
+// another block, joining them into one inline run.
+func parseParagraph(lines []string, i int) (Block, int) {
+	var parts []string
+	j := i
+	for j < len(lines) {
+		if j > i && isBlockStart(lines, j) {
+			break
+		}
+		parts = append(parts, strings.TrimSpace(lines[j]))
+		j++
+	}
+	return Paragraph{Text: parseInline(strings.Join(parts, " "))}, j
+}
+
+// parseTable consumes a pipe table: the header row at i, the separator at i+1,
+// then body rows until a non-row/blank line.
+func parseTable(lines []string, i int) (Block, int) {
+	header := splitRow(lines[i])
+	var rows [][]string
+	j := i + tableHeaderRows // skip header + separator
+	for j < len(lines) && strings.Contains(lines[j], "|") && !blankLine(lines[j]) {
+		rows = append(rows, splitRow(lines[j]))
+		j++
+	}
+	return Table{Header: header, Rows: rows}, j
+}
+
+// isTableSeparator reports whether a line is a pipe-table separator: every
+// pipe-delimited cell is non-empty and contains only '-', ':' and spaces.
+func isTableSeparator(line string) bool {
+	cells := splitRow(line)
+	if len(cells) == 0 {
+		return false
+	}
+	for _, c := range cells {
+		if c == "" {
+			return false
+		}
+		for _, r := range c {
+			if r != '-' && r != ':' && r != ' ' {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// splitRow splits a pipe-table row into trimmed cells, dropping the optional
+// leading/trailing outer pipes.
+func splitRow(line string) []string {
+	s := strings.TrimSpace(line)
+	s = strings.TrimPrefix(s, "|")
+	s = strings.TrimSuffix(s, "|")
+	parts := strings.Split(s, "|")
+	for i := range parts {
+		parts[i] = strings.TrimSpace(parts[i])
+	}
+	return parts
+}
+
+// --- inline parser ---
+
+// parseInline splits one logical run of text into styled spans. It recognizes the
+// same inline subset as MarkdownToHTML: inline code (`…`), links ([text](url)),
+// and bold (**…** or __…__). Matching is non-nested and left-to-right; an
+// unterminated marker is emitted as literal text, so the function is total and
+// never panics.
+func parseInline(s string) Inline {
+	var spans []Span
+	var plain strings.Builder
+	flush := func() {
+		if plain.Len() > 0 {
+			spans = append(spans, Span{Text: plain.String()})
+			plain.Reset()
+		}
+	}
+	for i := 0; i < len(s); {
+		if sp, n, ok := matchInline(s, i); ok {
+			flush()
+			spans = append(spans, sp)
+			i += n
+			continue
+		}
+		_ = plain.WriteByte(s[i]) // strings.Builder.WriteByte never returns an error
+		i++
+	}
+	flush()
+	return Inline{Spans: spans}
+}
+
+// matchInline tries to match one inline construct at position i, returning the
+// span, the number of bytes consumed, and whether a match was found. Order is by
+// priority: code first (its body is verbatim), then links, then bold.
+func matchInline(s string, i int) (Span, int, bool) {
+	switch {
+	case s[i] == '`':
+		if end := strings.IndexByte(s[i+1:], '`'); end >= 0 {
+			consumed := 1 + end + 1 // opening backtick + body + closing backtick
+			return Span{Text: s[i+1 : i+1+end], Code: true}, consumed, true
+		}
+	case s[i] == '[':
+		if sp, n, ok := matchLink(s, i); ok {
+			return sp, n, true
+		}
+	case strings.HasPrefix(s[i:], "**"):
+		if body, n, ok := matchDelim(s, i, "**"); ok {
+			return Span{Text: body, Bold: true}, n, true
+		}
+	case strings.HasPrefix(s[i:], "__"):
+		if body, n, ok := matchDelim(s, i, "__"); ok {
+			return Span{Text: body, Bold: true}, n, true
+		}
+	}
+	return Span{}, 0, false
+}
+
+// matchDelim matches a paired delimiter d (e.g. "**") at position i, returning the
+// non-empty body between the pair and the total bytes consumed.
+func matchDelim(s string, i int, d string) (string, int, bool) {
+	start := i + len(d)
+	if start > len(s) {
+		return "", 0, false
+	}
+	idx := strings.Index(s[start:], d)
+	if idx <= 0 { // <=0 also rejects an empty body (****)
+		return "", 0, false
+	}
+	return s[start : start+idx], len(d) + idx + len(d), true
+}
+
+// matchLink matches a [text](url) link at position i (s[i] == '['). text may not
+// contain a ']' and url may not contain whitespace or ')', matching the
+// MarkdownToHTML link regex.
+func matchLink(s string, i int) (Span, int, bool) {
+	closeBracket := strings.IndexByte(s[i:], ']')
+	if closeBracket < 0 || i+closeBracket+1 >= len(s) || s[i+closeBracket+1] != '(' {
+		return Span{}, 0, false
+	}
+	text := s[i+1 : i+closeBracket]
+	rest := s[i+closeBracket+2:] // after "]("
+	closeParen := strings.IndexByte(rest, ')')
+	if closeParen < 0 {
+		return Span{}, 0, false
+	}
+	url := rest[:closeParen]
+	if url == "" || strings.ContainsAny(url, " \t\n") {
+		return Span{}, 0, false
+	}
+	consumed := closeBracket + 1 + 1 + closeParen + 1 // [text] + ( + url + )
+	return Span{Text: text, URL: url}, consumed, true
+}

--- a/core/chat/rich/rich.go
+++ b/core/chat/rich/rich.go
@@ -1,0 +1,94 @@
+// Package rich is a platform-neutral intermediate representation (IR) for
+// structured "rich" messages, plus a Markdown parser (FromMarkdown) that builds
+// it. It is the shared core the Telegram adapter will serialize to Bot API 10.1
+// rich messages (see docs/rich-messages-plan.md). It has no platform imports and
+// is fully unit-testable in isolation; other adapters (VK) never import it, so
+// adding this package cannot change their behaviour.
+//
+// Scope (Stage 1): the IR models exactly what FromMarkdown produces today — the
+// same Markdown subset MarkdownToHTML recognizes (fenced/inline code, **/__ bold,
+// ATX headings, [text](url) links, -/*/+ bullets, blockquotes), plus the
+// unambiguous extras the rich target can render that flat HTML could not (ordered
+// lists and pipe tables). Blocks that have no Markdown source and are built
+// programmatically by later stages (a Thinking reasoning block, a collapsible
+// Details block) are intentionally NOT defined here — each is added with the
+// stage that produces it, so the IR never carries an unconstructed type.
+package rich
+
+// Span is one run of inline text carrying zero or more independent style flags.
+// The model is deliberately FLAT (no nesting) and best-effort, matching
+// MarkdownToHTML's conservatism. Code and URL are special: a Code span's Text is
+// the verbatim code (never re-parsed), and a span with a non-empty URL is a link
+// to that target. Only the styles FromMarkdown emits are modelled (Bold, Code,
+// links); italic/strikethrough are omitted on purpose — single-`*`/`_` emphasis
+// false-matches the snake_case and glob text developers send constantly, so it is
+// not parsed, and a field with no producer would be dead weight.
+type Span struct {
+	// Text is the span's literal text (already unescaped; for a Code span it is the
+	// verbatim code between the backticks).
+	Text string
+	// URL, when non-empty, makes this span a link to that target. Text is the link
+	// label.
+	URL string
+	// Bold marks the span as strong/bold (Markdown **…** or __…__).
+	Bold bool
+	// Code marks the span as inline code (Markdown `…`); Text is verbatim.
+	Code bool
+}
+
+// Inline is a sequence of styled spans forming one logical run of text (one
+// heading, one paragraph, one list item, one blockquote).
+type Inline struct {
+	Spans []Span
+}
+
+// Block is one structural element of a rich Message. The set is a small sealed
+// interface (the isBlock marker is unexported) so a serializer can switch over it
+// exhaustively without a default surprise.
+type Block interface{ isBlock() }
+
+// Paragraph is a run of body text.
+type Paragraph struct{ Text Inline }
+
+// Heading is a section heading; Level is 1..6 (ATX #..######).
+type Heading struct {
+	Level int
+	Text  Inline
+}
+
+// Code is a preformatted code block; Lang is the optional fence info-string
+// (e.g. "go"), Text is the verbatim body with no trailing newline.
+type Code struct {
+	Lang string
+	Text string
+}
+
+// List is a bullet (Ordered=false) or numbered (Ordered=true) list. Each item is
+// a single inline run; nested lists are flattened best-effort into items.
+type List struct {
+	Ordered bool
+	Items   []Inline
+}
+
+// Quote is a blockquote; consecutive ">" lines are joined into one inline run.
+type Quote struct{ Text Inline }
+
+// Table is a pipe table: a header row plus zero or more body rows, each a slice
+// of already-trimmed cell strings. Cells are plain text (not re-parsed inline) in
+// Stage 1 — kept simple and unambiguous.
+type Table struct {
+	Header []string
+	Rows   [][]string
+}
+
+func (Paragraph) isBlock() {}
+func (Heading) isBlock()   {}
+func (Code) isBlock()      {}
+func (List) isBlock()      {}
+func (Quote) isBlock()     {}
+func (Table) isBlock()     {}
+
+// Message is a complete rich message: an ordered list of blocks.
+type Message struct {
+	Blocks []Block
+}

--- a/core/chat/rich/rich.go
+++ b/core/chat/rich/rich.go
@@ -81,12 +81,20 @@ type Table struct {
 	Rows   [][]string
 }
 
+// Thinking is a block of model reasoning, rendered as a dedicated collapsible
+// "thinking" section (RichBlockThinking) rather than crammed into the inline
+// activity stream. It has no Markdown source — it is built programmatically (the
+// live progress frame routes the model's reasoning lines here; see
+// Progress.RichFrame).
+type Thinking struct{ Text string }
+
 func (Paragraph) isBlock() {}
 func (Heading) isBlock()   {}
 func (Code) isBlock()      {}
 func (List) isBlock()      {}
 func (Quote) isBlock()     {}
 func (Table) isBlock()     {}
+func (Thinking) isBlock()  {}
 
 // Message is a complete rich message: an ordered list of blocks.
 type Message struct {

--- a/core/chat/rich/rich_test.go
+++ b/core/chat/rich/rich_test.go
@@ -1,0 +1,184 @@
+package rich_test
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/duckbugio/flock/core/chat/rich"
+)
+
+// inl builds an Inline from spans for terse expectations.
+func inl(spans ...rich.Span) rich.Inline { return rich.Inline{Spans: spans} }
+
+// text is the common case: a single plain span.
+func text(s string) rich.Inline { return inl(rich.Span{Text: s}) }
+
+func TestFromMarkdown(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want rich.Message
+	}{
+		{
+			name: "plain paragraph",
+			in:   "hello world",
+			want: rich.Message{Blocks: []rich.Block{rich.Paragraph{Text: text("hello world")}}},
+		},
+		{
+			name: "heading levels",
+			in:   "### Sub heading",
+			want: rich.Message{Blocks: []rich.Block{rich.Heading{Level: 3, Text: text("Sub heading")}}},
+		},
+		{
+			name: "fenced code with lang",
+			in:   "```go\nx := 1\ny := 2\n```",
+			want: rich.Message{Blocks: []rich.Block{rich.Code{Lang: "go", Text: "x := 1\ny := 2"}}},
+		},
+		{
+			name: "unterminated fence runs to EOF",
+			in:   "```\nstill code",
+			want: rich.Message{Blocks: []rich.Block{rich.Code{Lang: "", Text: "still code"}}},
+		},
+		{
+			name: "bullet list",
+			in:   "- a\n- b\n* c",
+			want: rich.Message{Blocks: []rich.Block{rich.List{Ordered: false, Items: []rich.Inline{
+				text("a"), text("b"), text("c"),
+			}}}},
+		},
+		{
+			name: "ordered list",
+			in:   "1. first\n2. second",
+			want: rich.Message{Blocks: []rich.Block{rich.List{Ordered: true, Items: []rich.Inline{
+				text("first"), text("second"),
+			}}}},
+		},
+		{
+			name: "blockquote joins lines",
+			in:   "> line one\n> line two",
+			want: rich.Message{Blocks: []rich.Block{rich.Quote{Text: text("line one line two")}}},
+		},
+		{
+			name: "link inside paragraph",
+			in:   "see [docs](https://x.y) now",
+			want: rich.Message{Blocks: []rich.Block{rich.Paragraph{Text: inl(
+				rich.Span{Text: "see "},
+				rich.Span{Text: "docs", URL: "https://x.y"},
+				rich.Span{Text: " now"},
+			)}}},
+		},
+		{
+			name: "bold and inline code",
+			in:   "a **b** and `c` end",
+			want: rich.Message{Blocks: []rich.Block{rich.Paragraph{Text: inl(
+				rich.Span{Text: "a "},
+				rich.Span{Text: "b", Bold: true},
+				rich.Span{Text: " and "},
+				rich.Span{Text: "c", Code: true},
+				rich.Span{Text: " end"},
+			)}}},
+		},
+		{
+			name: "underscore bold, not snake_case italic",
+			in:   "use __NOW__ on foo_bar_baz",
+			want: rich.Message{Blocks: []rich.Block{rich.Paragraph{Text: inl(
+				rich.Span{Text: "use "},
+				rich.Span{Text: "NOW", Bold: true},
+				rich.Span{Text: " on foo_bar_baz"},
+			)}}},
+		},
+		{
+			name: "pipe table",
+			in:   "| H1 | H2 |\n| --- | :-: |\n| a | b |\n| c | d |",
+			want: rich.Message{Blocks: []rich.Block{rich.Table{
+				Header: []string{"H1", "H2"},
+				Rows:   [][]string{{"a", "b"}, {"c", "d"}},
+			}}},
+		},
+		{
+			name: "pipe in prose is not a table (no separator)",
+			in:   "a | b is not a table",
+			want: rich.Message{Blocks: []rich.Block{rich.Paragraph{Text: text("a | b is not a table")}}},
+		},
+		{
+			name: "unterminated bold is literal",
+			in:   "a **b c",
+			want: rich.Message{Blocks: []rich.Block{rich.Paragraph{Text: text("a **b c")}}},
+		},
+		{
+			name: "mixed document",
+			in:   "# Title\n\nintro line\n\n```\ncode\n```\n\n- one\n- two\n\n> quote",
+			want: rich.Message{Blocks: []rich.Block{
+				rich.Heading{Level: 1, Text: text("Title")},
+				rich.Paragraph{Text: text("intro line")},
+				rich.Code{Lang: "", Text: "code"},
+				rich.List{Ordered: false, Items: []rich.Inline{text("one"), text("two")}},
+				rich.Quote{Text: text("quote")},
+			}},
+		},
+		{
+			name: "empty input yields no blocks",
+			in:   "",
+			want: rich.Message{},
+		},
+		{
+			name: "whitespace-only yields no blocks",
+			in:   "   \n\n  ",
+			want: rich.Message{},
+		},
+		{
+			name: "paragraph stops at list without blank line",
+			in:   "intro\n- item",
+			want: rich.Message{Blocks: []rich.Block{
+				rich.Paragraph{Text: text("intro")},
+				rich.List{Ordered: false, Items: []rich.Inline{text("item")}},
+			}},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := rich.FromMarkdown(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("FromMarkdown(%q)\n got = %#v\nwant = %#v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFromMarkdownTotal asserts the parser is total: it never panics and always
+// returns at least one block for any input that contains a non-blank line.
+func TestFromMarkdownTotal(t *testing.T) {
+	inputs := []string{
+		"", " ", "\n\n", "```", "```go", "[", "[x]", "[x](", "[x]()",
+		"**", "****", "__", "`", "| |", "|---", "###", "#", "> ", "- ",
+		"1.", "1. ", "a\n\n\n\nb", strings.Repeat("**a** ", 100),
+		"```\n```\n```", "| a | b |\n| - |", "***bold-italic***",
+	}
+	for _, in := range inputs {
+		t.Run("input", func(t *testing.T) {
+			msg := rich.FromMarkdown(in) // must not panic
+			if strings.TrimSpace(in) != "" && len(msg.Blocks) == 0 {
+				t.Errorf("FromMarkdown(%q) returned no blocks for non-blank input", in)
+			}
+		})
+	}
+}
+
+// FuzzFromMarkdown runs the parser under the fuzzer (and its seed corpus in normal
+// test runs), asserting it never panics and honours the "non-blank input → ≥1
+// block" invariant.
+func FuzzFromMarkdown(f *testing.F) {
+	for _, s := range []string{
+		"# h", "```go\nx\n```", "- a\n- b", "> q", "a [l](u) b",
+		"| a | b |\n| - | - |\n| 1 | 2 |", "**x** `y` __z__",
+	} {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, in string) {
+		msg := rich.FromMarkdown(in)
+		if strings.TrimSpace(in) != "" && len(msg.Blocks) == 0 {
+			t.Errorf("non-blank input %q produced no blocks", in)
+		}
+	})
+}

--- a/core/chat/service.go
+++ b/core/chat/service.go
@@ -378,7 +378,7 @@ func (s *Service) run(ctx context.Context, chatID ChatID, userID int64, prompt s
 
 	// Seed the live preview immediately so it appears without waiting for a tick.
 	if draftStreaming {
-		if err := s.chat.StreamDraft(ctx, chatID, runID, prog.Frame(), true); err != nil {
+		if err := s.sendDraft(ctx, chatID, runID, prog); err != nil {
 			draftStreaming = false
 			s.log.Debug("draft streaming unsupported; falling back to edits", "error", err)
 		} else {
@@ -397,7 +397,7 @@ func (s *Service) run(ctx context.Context, chatID ChatID, userID int64, prompt s
 			return
 		}
 		if draftStreaming {
-			err := s.chat.StreamDraft(ctx, chatID, runID, frame, true)
+			err := s.sendDraft(ctx, chatID, runID, prog)
 			if err == nil {
 				lastSent = frame
 				return
@@ -500,6 +500,19 @@ loop:
 		//nolint:contextcheck // intentionally detached; the nudge runs post-completion.
 		s.nudge.maybeNudge(chatID)
 	}
+}
+
+// sendDraft pushes the live progress as an ephemeral draft preview. When the
+// transport implements RichDrafter AND reports CanSendRich, it streams a
+// structured rich draft (RichFrame, with reasoning in a Thinking block);
+// otherwise it streams the flat string frame via StreamDraft. Both share the same
+// error contract, so a failure flips the caller off the draft path identically. A
+// transport without rich support (VK) always takes the StreamDraft branch.
+func (s *Service) sendDraft(ctx context.Context, chatID ChatID, draftID string, prog *Progress) error {
+	if rd, ok := s.chat.(RichDrafter); ok && s.chat.Capabilities().CanSendRich {
+		return rd.StreamRichDraft(ctx, chatID, draftID, prog.RichFrame())
+	}
+	return s.chat.StreamDraft(ctx, chatID, draftID, prog.Frame(), true)
 }
 
 // recordCost accumulates a completed run's USD cost onto userID's running total

--- a/core/chat/service_test.go
+++ b/core/chat/service_test.go
@@ -15,10 +15,41 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/duckbugio/flock/core/chat/rich"
 	"github.com/duckbugio/flock/core/claude"
 	"github.com/duckbugio/flock/core/dispatch"
 	"github.com/duckbugio/flock/core/session"
 )
+
+// TestSendDraftRoutesByCapability asserts sendDraft uses the optional RichDrafter
+// path only when the transport implements it AND reports CanSendRich, and the
+// plain StreamDraft path otherwise — the VK-safe seam (VK reports neither).
+func TestSendDraftRoutesByCapability(t *testing.T) {
+	p := NewProgress(func() time.Duration { return 0 }, 5)
+
+	t.Run("rich capable -> StreamRichDraft", func(t *testing.T) {
+		f := newFakeChat()
+		f.canRich = true
+		s := &Service{chat: f}
+		if err := s.sendDraft(context.Background(), "1", "d", p); err != nil {
+			t.Fatalf("sendDraft: %v", err)
+		}
+		if f.richN != 1 || len(f.drafts) != 0 {
+			t.Errorf("richN=%d drafts=%d, want rich path (1,0)", f.richN, len(f.drafts))
+		}
+	})
+
+	t.Run("not rich capable -> StreamDraft", func(t *testing.T) {
+		f := newFakeChat() // canRich false → plain path even though it implements RichDrafter
+		s := &Service{chat: f}
+		if err := s.sendDraft(context.Background(), "1", "d", p); err != nil {
+			t.Fatalf("sendDraft: %v", err)
+		}
+		if f.richN != 0 || len(f.drafts) != 1 {
+			t.Errorf("richN=%d drafts=%d, want plain path (0,1)", f.richN, len(f.drafts))
+		}
+	})
+}
 
 // Shared fixture values used across multiple run-loop tests.
 const (
@@ -54,6 +85,8 @@ type fakeChat struct {
 	draftErr error    // when set, StreamDraft returns it (simulates no draft support)
 	editErr  error    // when set, Edit returns it (e.g. a 429 to exercise throttling)
 	edits    int      // count of Edit calls (progress + final), for the throttle test
+	canRich  bool     // when set, Capabilities reports CanSendRich (rich draft path)
+	richN    int      // count of StreamRichDraft calls (the optional RichDrafter path)
 }
 
 func newFakeChat() *fakeChat {
@@ -67,7 +100,7 @@ func newFakeChat() *fakeChat {
 // Capabilities reports a full-capability transport so the fake drives the same
 // run-loop path Telegram does (documents, 4096 cap).
 func (f *fakeChat) Capabilities() Capabilities {
-	return Capabilities{CanSendDocument: true, MaxMessageRunes: TelegramMaxMessage}
+	return Capabilities{CanSendDocument: true, MaxMessageRunes: TelegramMaxMessage, CanSendRich: f.canRich}
 }
 
 func (f *fakeChat) Send(_ context.Context, _ ChatID, text, stopRunID string, _ bool) (MessageID, error) {
@@ -108,6 +141,18 @@ func (f *fakeChat) StreamDraft(_ context.Context, _ ChatID, _, text string, asMa
 	}
 	f.drafts = append(f.drafts, text)
 	f.draftMD = append(f.draftMD, asMarkdown)
+	return nil
+}
+
+// StreamRichDraft implements the optional RichDrafter extension so a rich-capable
+// fake can be exercised; it records the call and returns draftErr like StreamDraft.
+func (f *fakeChat) StreamRichDraft(_ context.Context, _ ChatID, _ string, _ rich.Message) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.draftErr != nil {
+		return f.draftErr
+	}
+	f.richN++
 	return nil
 }
 

--- a/core/chat/transport.go
+++ b/core/chat/transport.go
@@ -66,4 +66,12 @@ type Capabilities struct {
 	// MaxMessageRunes is the platform's max message length in runes, fed to the
 	// chunker (Telegram 4096). A non-positive value selects a safe default.
 	MaxMessageRunes int
+	// CanSendRich: the platform can render Bot API 10.1 rich messages (structured
+	// blocks + a native rich draft) instead of the legacy MarkdownToHTML/plain
+	// path. It is purely additive — false (the zero value) keeps a transport on the
+	// exact pre-rich behaviour, so a platform that does not set it (VK) needs no
+	// change. Telegram sets it from the ENABLE_RICH_MESSAGES flag; even there the
+	// rich path always falls back to MarkdownToHTML/plain on any error, so the flag
+	// is a feature toggle, never a hard dependency.
+	CanSendRich bool
 }

--- a/core/chat/transport.go
+++ b/core/chat/transport.go
@@ -3,6 +3,8 @@ package chat
 import (
 	"context"
 	"io"
+
+	"github.com/duckbugio/flock/core/chat/rich"
 )
 
 // ChatID is an opaque, transport-defined chat identifier. Telegram uses numeric
@@ -54,6 +56,18 @@ type Transport interface {
 	// Capabilities reports what this platform can do, so the Service can adapt to
 	// platforms weaker than Telegram instead of erroring on a missing primitive.
 	Capabilities() Capabilities
+}
+
+// RichDrafter is an OPTIONAL Transport extension: a transport that can stream a
+// structured rich draft (a Bot API 10.1 rich message, with the model's reasoning
+// in a dedicated Thinking block) instead of the flat string StreamDraft frame. The
+// Service type-asserts for it and uses StreamRichDraft only when the transport
+// both implements it AND reports Capabilities().CanSendRich; a transport that does
+// neither (VK) is entirely unaffected and keeps using StreamDraft. A
+// StreamRichDraft error has the same contract as a StreamDraft error: the run
+// loop flips off the draft path and falls back to editing the anchor message.
+type RichDrafter interface {
+	StreamRichDraft(ctx context.Context, chatID ChatID, draftID string, frame rich.Message) error
 }
 
 // Capabilities lets the Service adapt to platforms weaker than Telegram, with a

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -101,6 +101,15 @@ type Config struct {
 	// always handled regardless. See plan §5.
 	RequireGroupMention bool `env:"REQUIRE_GROUP_MENTION" envDefault:"false"`
 
+	// EnableRichMessages toggles Bot API 10.1 rich rendering in the Telegram
+	// adapter (structured blocks + native rich draft). Default false: the adapter
+	// uses the legacy MarkdownToHTML/plain path and behaves exactly as before. When
+	// true it is surfaced via the Telegram Capabilities().CanSendRich flag; the rich
+	// path still falls back to MarkdownToHTML/plain on any error, so flipping this on
+	// can never break delivery. VK ignores it (no rich support). See
+	// docs/rich-messages-plan.md.
+	EnableRichMessages bool `env:"ENABLE_RICH_MESSAGES" envDefault:"false"`
+
 	// Team-loop knobs rendered into each workspace's CLAUDE.md (mirrors the
 	// values the Python entrypoint substituted). Kept as strings since they are
 	// substituted verbatim into the template.


### PR DESCRIPTION
**Stages 2 & 3 of `docs/rich-messages-plan.md`** (PR #22). Renders answers as Bot API 10.1 rich messages and streams live progress as a native rich draft with a dedicated reasoning block — all behind `ENABLE_RICH_MESSAGES` (off by default).

> **Stacked on #23 (Stage 0) + #24 (Stage 1).** This branch contains their commits (merged as its base). Merge **bottom-up**: #23 → #24 → this; or merge this alone (it includes them) and close #23/#24. Net behaviour with the flag off is byte-identical to `main`.

## ⚠️ Provisional wire schema (read first)
`go-telegram/bot v1.21.0` is the **latest** release and does **not** model the 10.1 rich types, and the published changelog gives class **names**, not field-level JSON. So the on-the-wire shape is **provisional**, isolated to **one marked file** (`adapters/telegram/richwire.go`): field names follow the published `RichBlock*`/`RichText*` class names + Telegram's invariant JSON conventions. This is safe because the path is **off by default** and **every call site falls back** to the legacy `MarkdownToHTML`/plain rendering on **any** error — a wrong field name degrades to today's output, never a failure. When the lib gains the types (or a live API verifies the schema), that one file is the only thing to correct.

## Stage 2 — rich Send/Edit
- `richwire.go` — provisional `InputRichMessage` types + IR→wire serializer (paragraph, section_heading, preformatted, list, block_quotation, **table**).
- `richtransport.go` — `httpRichTransport`: a raw-HTTP shim over `b.Token()` for `sendRichMessage` / `editMessageText(rich_message)` (the lib lacks the methods), behind a `richTransport` interface.
- `bot.go` — `Send`/`Edit` try rich first, fall back to the existing HTML/plain path on any error; gated by `enableRich && asMarkdown && non-empty`.

## Stage 3 — native rich draft + RichBlockThinking
- `core/chat/rich` — `Thinking` block (producer: `RichFrame`, so not an unconstructed type).
- `core/chat/progress.go` — `RichFrame()` separates the model's reasoning into one Thinking block; tool lines stay paragraphs.
- `core/chat/transport.go` — **`RichDrafter`**, an **optional** Transport extension. The Service uses it only when the transport implements it **and** reports `CanSendRich` → **VK (neither) is untouched** and keeps `StreamDraft`.
- `core/chat/service.go` — `sendDraft()` routes rich vs plain; same error contract (failure → edit fallback).
- `telegram` — `sendRichMessageDraft` shim + `botChat.StreamRichDraft`.

## VK-safety invariant (plan §6) — verified
- `git diff origin/main -- adapters/vk/{bot,api,longpoll}.go` → **empty** (VK production zero-diff).
- VK reports neither `CanSendRich` nor `RichDrafter` → both rich paths skip it; its tests assert `CanSendRich == false`.

## Acceptance — all green via the repo's runner (`dev-tools` container, mirrors CI)
- Serializer mapping + JSON shape; HTTP shim request/result/`ok:false`→error; `Send`/`Edit`/`StreamRichDraft` gating + fallback; `RichFrame` reasoning separation; capability-gated `sendDraft` routing.
- `go build`, `go vet`, `golangci-lint run` → **0 issues**; `go test -race ./...` green (incl. VK + all existing suites).
- Flag **off** → legacy path, byte-identical to `main`.

## Not included
- **Stage 4** (collapsible `Details` for long review logs) — optional polish; deferred because it has no live producer yet (adding the block without one would be dead abstraction).