### PR TITLE
feat: Bot API 10.1 Rich Messages on Telegram (default-on, verified schema)

### DIFF
--- a/adapters/telegram/.env.example
+++ b/adapters/telegram/.env.example
@@ -29,6 +29,10 @@ REQUIRE_GROUP_MENTION=false
 # Published-PR review/fix loop (Gitea poller + on-PR review). false (default) = off: build +
 # open a PR, then stop. true = react to PR comments and run the on-PR review loop.
 ENABLE_PR_REVIEW=false
+# Bot API 10.1 rich messages (structured blocks + native rich draft). false (default) = off:
+# the legacy Markdown→HTML rendering, unchanged. true = render rich (Telegram only; falls back
+# to Markdown→HTML/plain on any error). See docs/rich-messages-plan.md.
+ENABLE_RICH_MESSAGES=false
 BOT_MEM_LIMIT=3g                # consumed by docker-compose mem_limit, not the bot
 
 # ===== GIT (optional) — clone repos + open PRs from chat. Works with Gitea/GitHub/GitLab. =====

--- a/adapters/telegram/.env.example
+++ b/adapters/telegram/.env.example
@@ -29,10 +29,11 @@ REQUIRE_GROUP_MENTION=false
 # Published-PR review/fix loop (Gitea poller + on-PR review). false (default) = off: build +
 # open a PR, then stop. true = react to PR comments and run the on-PR review loop.
 ENABLE_PR_REVIEW=false
-# Bot API 10.1 rich messages (structured blocks + native rich draft). false (default) = off:
-# the legacy Markdown→HTML rendering, unchanged. true = render rich (Telegram only; falls back
-# to Markdown→HTML/plain on any error). See docs/rich-messages-plan.md.
-ENABLE_RICH_MESSAGES=false
+# Bot API 10.1 rich messages (Rich Markdown answers + native rich draft). true (default) = on:
+# render rich (Telegram only; falls back to Markdown→HTML/plain on any error, and self-disables
+# for the process after repeated failures). Set false to force the legacy Markdown→HTML path.
+# See docs/rich-messages-plan.md.
+ENABLE_RICH_MESSAGES=true
 BOT_MEM_LIMIT=3g                # consumed by docker-compose mem_limit, not the bot
 
 # ===== GIT (optional) — clone repos + open PRs from chat. Works with Gitea/GitHub/GitLab. =====

--- a/adapters/telegram/bot.go
+++ b/adapters/telegram/bot.go
@@ -41,20 +41,28 @@ type botChat struct {
 	// enableRich is set; every call site treats a rich error as "fall back to the
 	// legacy MarkdownToHTML/plain path", so the rich path is never load-bearing.
 	rich richTransport
-	// richFailures counts CONSECUTIVE rich failures (reset to 0 on any success), and
-	// richOff latches the rich path off for the rest of the process once they reach
-	// richFailureThreshold. This is the circuit breaker behind a default-on flag: if
-	// the live API does not (yet) serve the rich methods, the adapter stops paying a
-	// failed round-trip on every message after a short burst, instead of forever.
-	richFailures atomic.Int32
-	richOff      atomic.Bool
+	// richFailures counts CONSECUTIVE rich failures (reset to 0 on any success).
+	// richDisabledUntil holds a unix-nano deadline: while now < it, the rich path is
+	// suppressed (0 = enabled). Together they form a circuit breaker behind the
+	// default-on flag: after richFailureThreshold consecutive failures the rich path
+	// is suppressed for richCooldown, then a single probe is allowed — so an API that
+	// does not serve the rich methods stops costing a failed round-trip per message,
+	// while a transient blip self-heals instead of disabling rich until restart.
+	richFailures      atomic.Int32
+	richDisabledUntil atomic.Int64
+	// now is an injectable clock for the breaker cooldown (tests). nil means time.Now.
+	now func() time.Time
 }
 
-// richFailureThreshold is how many consecutive rich failures trip the breaker,
-// latching the rich path off for the process. Small enough to stop the wasted
-// round-trips quickly when the API lacks the methods, large enough to ride out a
-// transient blip (a single success resets the count).
-const richFailureThreshold = 5
+const (
+	// richFailureThreshold is how many consecutive rich failures trip the breaker.
+	// Small enough to stop wasted round-trips quickly when the API lacks the methods,
+	// large enough to ride out a transient blip (any success resets the count).
+	richFailureThreshold = 5
+	// richCooldown is how long the rich path stays suppressed after the breaker trips
+	// before a single probe is allowed.
+	richCooldown = time.Minute
+)
 
 // NewBotChat adapts a *bot.Bot to the core/chat.Transport interface used by the
 // Service. enableRich sets Capabilities().CanSendRich (from ENABLE_RICH_MESSAGES)
@@ -248,27 +256,45 @@ func draftIDToInt(draftID string) int64 {
 	return id
 }
 
-// richAttemptable reports whether a rich attempt should be made for this call:
-// rich is enabled and wired, the breaker has not latched it off, the text is
-// markdown-rendered, and it is non-empty (the empty-text draft clear stays on the
-// legacy path).
-func (c *botChat) richAttemptable(asMarkdown bool, text string) bool {
-	return c.enableRich && c.rich != nil && !c.richOff.Load() && asMarkdown && text != ""
+// nowTime reads the breaker clock, defaulting to time.Now when none is injected.
+func (c *botChat) nowTime() time.Time {
+	if c.now != nil {
+		return c.now()
+	}
+	return time.Now()
 }
 
-// recordRich feeds the circuit breaker: a success resets the consecutive-failure
-// count; a failure increments it and, on reaching richFailureThreshold, latches
-// the rich path off for the process (logged once, WARN). The error is already
-// token-redacted by the transport (see httpRichTransport.redactErr).
+// richAttemptable reports whether a rich attempt should be made for this call:
+// rich is enabled and wired, the breaker's cooldown is not currently active, the
+// text is markdown-rendered, and it is non-empty (the empty-text draft clear stays
+// on the legacy path).
+func (c *botChat) richAttemptable(asMarkdown bool, text string) bool {
+	if !c.enableRich || c.rich == nil || !asMarkdown || text == "" {
+		return false
+	}
+	until := c.richDisabledUntil.Load()
+	return until == 0 || c.nowTime().UnixNano() >= until
+}
+
+// recordRich feeds the circuit breaker: a success clears the failure count and any
+// cooldown; a failure increments the count and, on reaching richFailureThreshold,
+// suppresses the rich path for richCooldown (logged WARN only on the first trip,
+// not on each re-arm). The error is already token-redacted by the transport.
 func (c *botChat) recordRich(err error) {
 	if err == nil {
 		c.richFailures.Store(0)
+		c.richDisabledUntil.Store(0)
 		return
 	}
-	if n := c.richFailures.Add(1); n >= richFailureThreshold && c.richOff.CompareAndSwap(false, true) {
+	n := c.richFailures.Add(1)
+	if n < richFailureThreshold {
+		return
+	}
+	until := c.nowTime().Add(richCooldown).UnixNano()
+	if prev := c.richDisabledUntil.Swap(until); prev == 0 {
 		slog.Default().Warn(
-			"telegram: disabling rich rendering for this process after consecutive failures; using legacy",
-			"failures", n, "error", err,
+			"telegram: suppressing rich rendering after consecutive failures; using legacy",
+			"failures", n, "cooldown", richCooldown, "error", err,
 		)
 	}
 }

--- a/adapters/telegram/bot.go
+++ b/adapters/telegram/bot.go
@@ -11,8 +11,10 @@ import (
 	"context"
 	"errors"
 	"io"
+	"log/slog"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-telegram/bot"
@@ -33,16 +35,27 @@ const telegramMaxMessageRunes = 4096
 type botChat struct {
 	b *bot.Bot
 	// enableRich reports the Capabilities().CanSendRich flag, sourced from the
-	// ENABLE_RICH_MESSAGES config. Stage 0 only surfaces it; the rich render paths
-	// are wired in later stages (see docs/rich-messages-plan.md).
+	// ENABLE_RICH_MESSAGES config (see docs/rich-messages-plan.md).
 	enableRich bool
+	// rich serializes and sends Bot API 10.1 rich messages. It is non-nil only when
+	// enableRich is set; every call site treats a rich error as "fall back to the
+	// legacy MarkdownToHTML/plain path", so the rich path is never load-bearing.
+	rich richTransport
+	// richFallbackOnce logs the FIRST rich failure (once) so a systematically broken
+	// rich path is visible instead of silently degrading to legacy on every message.
+	richFallbackOnce sync.Once
 }
 
 // NewBotChat adapts a *bot.Bot to the core/chat.Transport interface used by the
-// Service. enableRich sets Capabilities().CanSendRich (from ENABLE_RICH_MESSAGES);
-// pass false to keep the legacy MarkdownToHTML/plain rendering.
+// Service. enableRich sets Capabilities().CanSendRich (from ENABLE_RICH_MESSAGES)
+// and, when set, wires the rich HTTP transport over the bot's token; pass false to
+// keep the legacy MarkdownToHTML/plain rendering.
 func NewBotChat(b *bot.Bot, enableRich bool) chat.Transport {
-	return &botChat{b: b, enableRich: enableRich}
+	c := &botChat{b: b, enableRich: enableRich}
+	if enableRich {
+		c.rich = newHTTPRichTransport(b.Token(), defaultTelegramAPIBase, nil)
+	}
+	return c
 }
 
 // Capabilities reports Telegram's full feature set: it can send documents, its
@@ -72,6 +85,12 @@ func parseMessageID(messageID chat.MessageID) int {
 }
 
 func (c *botChat) Send(ctx context.Context, chatID chat.ChatID, text, stopRunID string, asMarkdown bool) (chat.MessageID, error) {
+	// Rich path first (when enabled and the message is markdown-rendered). Any
+	// failure falls through to the legacy HTML/plain path below — the rich render
+	// never costs the user the answer.
+	if id, ok := c.trySendRich(ctx, parseChatID(chatID), text, stopRunID, asMarkdown); ok {
+		return id, nil
+	}
 	params := &bot.SendMessageParams{
 		ChatID:      parseChatID(chatID),
 		Text:        text,
@@ -98,6 +117,10 @@ func (c *botChat) Send(ctx context.Context, chatID chat.ChatID, text, stopRunID 
 func (c *botChat) Edit(
 	ctx context.Context, chatID chat.ChatID, messageID chat.MessageID, text, stopRunID string, asMarkdown bool,
 ) error {
+	// Rich path first; on any failure fall through to the legacy HTML/plain edit.
+	if c.tryEditRich(ctx, parseChatID(chatID), parseMessageID(messageID), text, stopRunID, asMarkdown) {
+		return nil
+	}
 	params := &bot.EditMessageTextParams{
 		ChatID:      parseChatID(chatID),
 		MessageID:   parseMessageID(messageID),
@@ -126,6 +149,17 @@ func (c *botChat) Edit(
 // error (not just a parse error) so enabling markup can never knock the preview off
 // the rate-limit-free draft path. asMarkdown is ignored when text is empty (clear).
 func (c *botChat) StreamDraft(ctx context.Context, chatID chat.ChatID, draftID, text string, asMarkdown bool) error {
+	// Rich path first: stream the frame as a native rich draft (sendRichMessageDraft),
+	// passing the Markdown straight through. On any failure fall through to the legacy
+	// HTML/plain draft below — identical contract, so the run loop's draft fallback is
+	// unaffected. Skipped for the empty-text clear (handled by the legacy path).
+	if c.enableRich && c.rich != nil && asMarkdown && text != "" {
+		err := c.rich.streamDraft(ctx, parseChatID(chatID), draftIDToInt(draftID), richMarkdown(text))
+		if err == nil {
+			return nil
+		}
+		c.noteRichFallback(err)
+	}
 	params := &bot.SendMessageDraftParams{
 		ChatID:  parseChatID(chatID),
 		DraftID: draftID,
@@ -149,6 +183,71 @@ func (c *botChat) StreamDraft(ctx context.Context, chatID chat.ChatID, draftID, 
 		_, err = c.b.SendMessageDraft(ctx, params)
 	}
 	return err
+}
+
+// trySendRich attempts to send text as a Bot API 10.1 rich message. It returns
+// (id, true) on success; ("", false) tells Send to fall back to the legacy
+// HTML/plain path. It is a no-op (false) unless rich is enabled, asMarkdown is
+// set, and the text is non-empty — so plain sends and the rich-off build keep
+// their exact previous behaviour.
+func (c *botChat) trySendRich(
+	ctx context.Context, chatID int64, text, stopRunID string, asMarkdown bool,
+) (chat.MessageID, bool) {
+	if !c.enableRich || c.rich == nil || !asMarkdown || text == "" {
+		return "", false
+	}
+	id, err := c.rich.send(ctx, chatID, richMarkdown(text), stopMarkup(stopRunID))
+	if err != nil {
+		c.noteRichFallback(err)
+		return "", false // any rich failure → legacy fallback
+	}
+	return strconv.Itoa(id), true
+}
+
+// tryEditRich is the Edit counterpart of trySendRich: it returns true when the
+// rich edit succeeded, false to fall back to the legacy HTML/plain edit.
+func (c *botChat) tryEditRich(
+	ctx context.Context, chatID int64, messageID int, text, stopRunID string, asMarkdown bool,
+) bool {
+	if !c.enableRich || c.rich == nil || !asMarkdown || text == "" {
+		return false
+	}
+	if err := c.rich.edit(ctx, chatID, messageID, richMarkdown(text), stopMarkup(stopRunID)); err != nil {
+		c.noteRichFallback(err)
+		return false
+	}
+	return true
+}
+
+// draftIDToInt maps the neutral string draft id (the run id) to the non-zero
+// int64 sendRichMessageDraft requires, stably: the same run id always yields the
+// same id (so Telegram animates updates to one draft), and a zero hash is bumped
+// to 1 since the API rejects draft_id 0.
+func draftIDToInt(draftID string) int64 {
+	const (
+		fnvOffset = 1469598103934665603
+		fnvPrime  = 1099511628211
+	)
+	var h uint64 = fnvOffset
+	for i := 0; i < len(draftID); i++ {
+		h ^= uint64(draftID[i])
+		h *= fnvPrime
+	}
+	id := int64(h >> 1) // shift out the sign bit so the id is always positive
+	if id == 0 {
+		id = 1
+	}
+	return id
+}
+
+// noteRichFallback logs the first rich-path failure at debug level (once), so a
+// systematically broken rich path is diagnosable instead of silently degrading to
+// the legacy renderer on every message. The error is already token-redacted by the
+// transport (see httpRichTransport.redactErr).
+func (c *botChat) noteRichFallback(err error) {
+	c.richFallbackOnce.Do(func() {
+		slog.Default().Debug("telegram: rich message failed, using legacy rendering", "error", err)
+	})
 }
 
 // isParseError reports whether err is Telegram rejecting our parse_mode markup

--- a/adapters/telegram/bot.go
+++ b/adapters/telegram/bot.go
@@ -14,7 +14,7 @@ import (
 	"log/slog"
 	"strconv"
 	"strings"
-	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-telegram/bot"
@@ -41,10 +41,20 @@ type botChat struct {
 	// enableRich is set; every call site treats a rich error as "fall back to the
 	// legacy MarkdownToHTML/plain path", so the rich path is never load-bearing.
 	rich richTransport
-	// richFallbackOnce logs the FIRST rich failure (once) so a systematically broken
-	// rich path is visible instead of silently degrading to legacy on every message.
-	richFallbackOnce sync.Once
+	// richFailures counts CONSECUTIVE rich failures (reset to 0 on any success), and
+	// richOff latches the rich path off for the rest of the process once they reach
+	// richFailureThreshold. This is the circuit breaker behind a default-on flag: if
+	// the live API does not (yet) serve the rich methods, the adapter stops paying a
+	// failed round-trip on every message after a short burst, instead of forever.
+	richFailures atomic.Int32
+	richOff      atomic.Bool
 }
+
+// richFailureThreshold is how many consecutive rich failures trip the breaker,
+// latching the rich path off for the process. Small enough to stop the wasted
+// round-trips quickly when the API lacks the methods, large enough to ride out a
+// transient blip (a single success resets the count).
+const richFailureThreshold = 5
 
 // NewBotChat adapts a *bot.Bot to the core/chat.Transport interface used by the
 // Service. enableRich sets Capabilities().CanSendRich (from ENABLE_RICH_MESSAGES)
@@ -153,12 +163,12 @@ func (c *botChat) StreamDraft(ctx context.Context, chatID chat.ChatID, draftID, 
 	// passing the Markdown straight through. On any failure fall through to the legacy
 	// HTML/plain draft below — identical contract, so the run loop's draft fallback is
 	// unaffected. Skipped for the empty-text clear (handled by the legacy path).
-	if c.enableRich && c.rich != nil && asMarkdown && text != "" {
+	if c.richAttemptable(asMarkdown, text) {
 		err := c.rich.streamDraft(ctx, parseChatID(chatID), draftIDToInt(draftID), richMarkdown(text))
+		c.recordRich(err)
 		if err == nil {
 			return nil
 		}
-		c.noteRichFallback(err)
 	}
 	params := &bot.SendMessageDraftParams{
 		ChatID:  parseChatID(chatID),
@@ -193,12 +203,12 @@ func (c *botChat) StreamDraft(ctx context.Context, chatID chat.ChatID, draftID, 
 func (c *botChat) trySendRich(
 	ctx context.Context, chatID int64, text, stopRunID string, asMarkdown bool,
 ) (chat.MessageID, bool) {
-	if !c.enableRich || c.rich == nil || !asMarkdown || text == "" {
+	if !c.richAttemptable(asMarkdown, text) {
 		return "", false
 	}
 	id, err := c.rich.send(ctx, chatID, richMarkdown(text), stopMarkup(stopRunID))
+	c.recordRich(err)
 	if err != nil {
-		c.noteRichFallback(err)
 		return "", false // any rich failure → legacy fallback
 	}
 	return strconv.Itoa(id), true
@@ -209,14 +219,12 @@ func (c *botChat) trySendRich(
 func (c *botChat) tryEditRich(
 	ctx context.Context, chatID int64, messageID int, text, stopRunID string, asMarkdown bool,
 ) bool {
-	if !c.enableRich || c.rich == nil || !asMarkdown || text == "" {
+	if !c.richAttemptable(asMarkdown, text) {
 		return false
 	}
-	if err := c.rich.edit(ctx, chatID, messageID, richMarkdown(text), stopMarkup(stopRunID)); err != nil {
-		c.noteRichFallback(err)
-		return false
-	}
-	return true
+	err := c.rich.edit(ctx, chatID, messageID, richMarkdown(text), stopMarkup(stopRunID))
+	c.recordRich(err)
+	return err == nil
 }
 
 // draftIDToInt maps the neutral string draft id (the run id) to the non-zero
@@ -240,14 +248,29 @@ func draftIDToInt(draftID string) int64 {
 	return id
 }
 
-// noteRichFallback logs the first rich-path failure at debug level (once), so a
-// systematically broken rich path is diagnosable instead of silently degrading to
-// the legacy renderer on every message. The error is already token-redacted by the
-// transport (see httpRichTransport.redactErr).
-func (c *botChat) noteRichFallback(err error) {
-	c.richFallbackOnce.Do(func() {
-		slog.Default().Debug("telegram: rich message failed, using legacy rendering", "error", err)
-	})
+// richAttemptable reports whether a rich attempt should be made for this call:
+// rich is enabled and wired, the breaker has not latched it off, the text is
+// markdown-rendered, and it is non-empty (the empty-text draft clear stays on the
+// legacy path).
+func (c *botChat) richAttemptable(asMarkdown bool, text string) bool {
+	return c.enableRich && c.rich != nil && !c.richOff.Load() && asMarkdown && text != ""
+}
+
+// recordRich feeds the circuit breaker: a success resets the consecutive-failure
+// count; a failure increments it and, on reaching richFailureThreshold, latches
+// the rich path off for the process (logged once, WARN). The error is already
+// token-redacted by the transport (see httpRichTransport.redactErr).
+func (c *botChat) recordRich(err error) {
+	if err == nil {
+		c.richFailures.Store(0)
+		return
+	}
+	if n := c.richFailures.Add(1); n >= richFailureThreshold && c.richOff.CompareAndSwap(false, true) {
+		slog.Default().Warn(
+			"telegram: disabling rich rendering for this process after consecutive failures; using legacy",
+			"failures", n, "error", err,
+		)
+	}
 }
 
 // isParseError reports whether err is Telegram rejecting our parse_mode markup

--- a/adapters/telegram/bot.go
+++ b/adapters/telegram/bot.go
@@ -32,21 +32,28 @@ const telegramMaxMessageRunes = 4096
 // botChat implements core/chat.Transport over a *bot.Bot.
 type botChat struct {
 	b *bot.Bot
+	// enableRich reports the Capabilities().CanSendRich flag, sourced from the
+	// ENABLE_RICH_MESSAGES config. Stage 0 only surfaces it; the rich render paths
+	// are wired in later stages (see docs/rich-messages-plan.md).
+	enableRich bool
 }
 
 // NewBotChat adapts a *bot.Bot to the core/chat.Transport interface used by the
-// Service.
-func NewBotChat(b *bot.Bot) chat.Transport {
-	return &botChat{b: b}
+// Service. enableRich sets Capabilities().CanSendRich (from ENABLE_RICH_MESSAGES);
+// pass false to keep the legacy MarkdownToHTML/plain rendering.
+func NewBotChat(b *bot.Bot, enableRich bool) chat.Transport {
+	return &botChat{b: b, enableRich: enableRich}
 }
 
-// Capabilities reports Telegram's full feature set: it can send documents and
-// its message cap is 4096 runes. With these flags the neutral Service behaves
-// exactly as before.
+// Capabilities reports Telegram's full feature set: it can send documents, its
+// message cap is 4096 runes, and it can render rich messages when enableRich is
+// set. With these flags the neutral Service behaves exactly as before when rich
+// is off.
 func (c *botChat) Capabilities() chat.Capabilities {
 	return chat.Capabilities{
 		CanSendDocument: true,
 		MaxMessageRunes: telegramMaxMessageRunes,
+		CanSendRich:     c.enableRich,
 	}
 }
 

--- a/adapters/telegram/bot_rich_test.go
+++ b/adapters/telegram/bot_rich_test.go
@@ -1,0 +1,239 @@
+//nolint:testpackage // whitebox: tests the unexported rich gating/fallback in Send/Edit/StreamDraft
+package telegram
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/go-telegram/bot"
+	"github.com/go-telegram/bot/models"
+)
+
+// fakeRich is a stub richTransport: it records calls and returns a configured id
+// or error so the gating/fallback decisions can be tested without HTTP.
+type fakeRich struct {
+	sendID    int
+	sendErr   error
+	editErr   error
+	draftErr  error
+	sendN     int32
+	editN     int32
+	draftN    int32
+	lastDraft inputRichMessage
+}
+
+func (f *fakeRich) send(_ context.Context, _ int64, _ inputRichMessage, _ models.ReplyMarkup) (int, error) {
+	atomic.AddInt32(&f.sendN, 1)
+	return f.sendID, f.sendErr
+}
+
+func (f *fakeRich) edit(_ context.Context, _ int64, _ int, _ inputRichMessage, _ models.ReplyMarkup) error {
+	atomic.AddInt32(&f.editN, 1)
+	return f.editErr
+}
+
+func (f *fakeRich) streamDraft(_ context.Context, _, _ int64, msg inputRichMessage) error {
+	atomic.AddInt32(&f.draftN, 1)
+	f.lastDraft = msg
+	return f.draftErr
+}
+
+// legacyBotServer builds a *bot.Bot pointed at a fake Bot API that counts the
+// legacy sendMessage/editMessageText/sendMessageDraft calls and always succeeds.
+func legacyBotServer(t *testing.T, sendHits, editHits, draftHits *int32) *bot.Bot {
+	t.Helper()
+	ok := func(w http.ResponseWriter, _ *http.Request) {
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"ok":     true,
+			"result": map[string]any{"message_id": 99, "chat": map[string]any{"id": 1}, "date": 0},
+		}); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/bot123:ABC/sendMessage", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(sendHits, 1)
+		ok(w, r)
+	})
+	mux.HandleFunc("/bot123:ABC/editMessageText", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(editHits, 1)
+		ok(w, r)
+	})
+	mux.HandleFunc("/bot123:ABC/sendMessageDraft", func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(draftHits, 1)
+		if err := json.NewEncoder(w).Encode(map[string]any{"ok": true, "result": true}); err != nil {
+			t.Errorf("encode draft response: %v", err)
+		}
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	b, err := bot.New("123:ABC", bot.WithSkipGetMe(), bot.WithServerURL(srv.URL))
+	if err != nil {
+		t.Fatalf("bot.New: %v", err)
+	}
+	return b
+}
+
+func TestTrySendRichGating(t *testing.T) {
+	fr := &fakeRich{sendID: 11}
+	tests := []struct {
+		name       string
+		enableRich bool
+		rich       richTransport
+		asMarkdown bool
+		text       string
+		wantOK     bool
+	}{
+		{"rich disabled", false, fr, true, "hi", false},
+		{"nil transport", true, nil, true, "hi", false},
+		{"not markdown", true, fr, false, "hi", false},
+		{"empty text", true, fr, true, "", false},
+		{"all set", true, fr, true, "hi", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &botChat{enableRich: tc.enableRich, rich: tc.rich}
+			id, ok := c.trySendRich(context.Background(), 1, tc.text, "", tc.asMarkdown)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if ok && id != "11" {
+				t.Errorf("id = %q, want 11", id)
+			}
+		})
+	}
+}
+
+// TestSendRichSuccessSkipsLegacy: a successful rich send returns the rich id and
+// never touches the legacy sendMessage endpoint.
+func TestSendRichSuccessSkipsLegacy(t *testing.T) {
+	var sendHits, editHits, draftHits int32
+	b := legacyBotServer(t, &sendHits, &editHits, &draftHits)
+	c := &botChat{b: b, enableRich: true, rich: &fakeRich{sendID: 4242}}
+
+	id, err := c.Send(context.Background(), "555", "# Hi\n\nbody", "", true)
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if id != "4242" {
+		t.Errorf("id = %q, want 4242 (rich id)", id)
+	}
+	if atomic.LoadInt32(&sendHits) != 0 {
+		t.Errorf("legacy sendMessage called %d times, want 0 (rich succeeded)", sendHits)
+	}
+}
+
+// TestSendRichErrorFallsBackToLegacy: a rich failure falls through to the legacy
+// sendMessage, which delivers the answer.
+func TestSendRichErrorFallsBackToLegacy(t *testing.T) {
+	var sendHits, editHits, draftHits int32
+	b := legacyBotServer(t, &sendHits, &editHits, &draftHits)
+	fr := &fakeRich{sendErr: errors.New("rich boom")}
+	c := &botChat{b: b, enableRich: true, rich: fr}
+
+	id, err := c.Send(context.Background(), "555", "hello", "", true)
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if id != "99" {
+		t.Errorf("id = %q, want 99 (legacy fallback)", id)
+	}
+	if atomic.LoadInt32(&fr.sendN) != 1 {
+		t.Errorf("rich send attempts = %d, want 1", fr.sendN)
+	}
+	if atomic.LoadInt32(&sendHits) != 1 {
+		t.Errorf("legacy sendMessage hits = %d, want 1 (fallback)", sendHits)
+	}
+}
+
+// TestEditRichErrorFallsBackToLegacy mirrors the Send fallback for Edit.
+func TestEditRichErrorFallsBackToLegacy(t *testing.T) {
+	var sendHits, editHits, draftHits int32
+	b := legacyBotServer(t, &sendHits, &editHits, &draftHits)
+	fr := &fakeRich{editErr: errors.New("rich boom")}
+	c := &botChat{b: b, enableRich: true, rich: fr}
+
+	if err := c.Edit(context.Background(), "555", "7", "progress", "run-1", true); err != nil {
+		t.Fatalf("Edit: %v", err)
+	}
+	if atomic.LoadInt32(&editHits) != 1 {
+		t.Errorf("legacy editMessageText hits = %d, want 1 (fallback)", editHits)
+	}
+}
+
+// TestStreamDraftRichSuccessSkipsLegacy: a successful rich draft never touches the
+// legacy sendMessageDraft endpoint and carries the Markdown frame.
+func TestStreamDraftRichSuccessSkipsLegacy(t *testing.T) {
+	var sendHits, editHits, draftHits int32
+	b := legacyBotServer(t, &sendHits, &editHits, &draftHits)
+	fr := &fakeRich{}
+	c := &botChat{b: b, enableRich: true, rich: fr}
+
+	if err := c.StreamDraft(context.Background(), "555", "run-1", "**frame**", true); err != nil {
+		t.Fatalf("StreamDraft: %v", err)
+	}
+	if atomic.LoadInt32(&fr.draftN) != 1 {
+		t.Errorf("rich streamDraft calls = %d, want 1", fr.draftN)
+	}
+	if fr.lastDraft.Markdown != "**frame**" {
+		t.Errorf("draft markdown = %q, want the frame text", fr.lastDraft.Markdown)
+	}
+	if atomic.LoadInt32(&draftHits) != 0 {
+		t.Errorf("legacy sendMessageDraft hits = %d, want 0 (rich succeeded)", draftHits)
+	}
+}
+
+// TestStreamDraftRichErrorFallsBackToLegacy: a rich draft failure falls through to
+// the legacy SendMessageDraft.
+func TestStreamDraftRichErrorFallsBackToLegacy(t *testing.T) {
+	var sendHits, editHits, draftHits int32
+	b := legacyBotServer(t, &sendHits, &editHits, &draftHits)
+	fr := &fakeRich{draftErr: errors.New("rich boom")}
+	c := &botChat{b: b, enableRich: true, rich: fr}
+
+	if err := c.StreamDraft(context.Background(), "555", "run-1", "frame", true); err != nil {
+		t.Fatalf("StreamDraft: %v", err)
+	}
+	if atomic.LoadInt32(&draftHits) != 1 {
+		t.Errorf("legacy sendMessageDraft hits = %d, want 1 (fallback)", draftHits)
+	}
+}
+
+// TestSendRichDisabledUsesLegacy: with the flag off, Send takes the legacy path
+// untouched (no rich transport configured).
+func TestSendRichDisabledUsesLegacy(t *testing.T) {
+	var sendHits, editHits, draftHits int32
+	b := legacyBotServer(t, &sendHits, &editHits, &draftHits)
+	c := &botChat{b: b, enableRich: false} // rich nil — exactly today's behaviour
+
+	if _, err := c.Send(context.Background(), "555", "hello", "", true); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if atomic.LoadInt32(&sendHits) != 1 {
+		t.Errorf("legacy sendMessage hits = %d, want 1", sendHits)
+	}
+}
+
+// TestDraftIDToInt asserts the run-id → non-zero int64 mapping is stable and
+// distinguishes different ids (sendRichMessageDraft requires a non-zero integer).
+func TestDraftIDToInt(t *testing.T) {
+	if a, b := draftIDToInt("run-1"), draftIDToInt("run-1"); a != b {
+		t.Errorf("not stable: %d != %d", a, b)
+	}
+	if draftIDToInt("run-1") == draftIDToInt("run-2") {
+		t.Error("distinct run ids collided")
+	}
+	for _, s := range []string{"", "0", "run-1", "duck/-5238983644/x"} {
+		if draftIDToInt(s) == 0 {
+			t.Errorf("draftIDToInt(%q) = 0, want non-zero", s)
+		}
+		if draftIDToInt(s) < 0 {
+			t.Errorf("draftIDToInt(%q) = %d, want positive", s, draftIDToInt(s))
+		}
+	}
+}

--- a/adapters/telegram/bot_rich_test.go
+++ b/adapters/telegram/bot_rich_test.go
@@ -204,6 +204,60 @@ func TestStreamDraftRichErrorFallsBackToLegacy(t *testing.T) {
 	}
 }
 
+// TestRecordRichBreaker exercises the circuit-breaker logic: threshold consecutive
+// failures latch rich off, and any success in between resets the count.
+func TestRecordRichBreaker(t *testing.T) {
+	c := &botChat{}
+	// One short of the threshold: not latched.
+	for range richFailureThreshold - 1 {
+		c.recordRich(errors.New("x"))
+	}
+	if c.richOff.Load() {
+		t.Fatal("breaker latched before reaching the threshold")
+	}
+	// A success resets the consecutive count.
+	c.recordRich(nil)
+	if c.richFailures.Load() != 0 {
+		t.Fatalf("failure count = %d after success, want 0", c.richFailures.Load())
+	}
+	// A full threshold of consecutive failures now latches it off.
+	for range richFailureThreshold {
+		c.recordRich(errors.New("x"))
+	}
+	if !c.richOff.Load() {
+		t.Error("breaker did not latch after threshold consecutive failures")
+	}
+}
+
+// TestRichBreakerStopsAttempts: once the breaker latches, Send stops attempting
+// the rich path entirely (no further calls to the rich transport).
+func TestRichBreakerStopsAttempts(t *testing.T) {
+	var sendHits, editHits, draftHits int32
+	b := legacyBotServer(t, &sendHits, &editHits, &draftHits)
+	fr := &fakeRich{sendErr: errors.New("unsupported")}
+	c := &botChat{b: b, enableRich: true, rich: fr}
+
+	for range richFailureThreshold {
+		if _, err := c.Send(context.Background(), "555", "hi", "", true); err != nil {
+			t.Fatalf("Send: %v", err)
+		}
+	}
+	tripped := atomic.LoadInt32(&fr.sendN)
+	if tripped != int32(richFailureThreshold) {
+		t.Fatalf("rich attempts before trip = %d, want %d", tripped, richFailureThreshold)
+	}
+	if !c.richOff.Load() {
+		t.Fatal("breaker not latched after threshold failures")
+	}
+	// Subsequent sends must not touch the rich transport, only legacy.
+	if _, err := c.Send(context.Background(), "555", "hi", "", true); err != nil {
+		t.Fatalf("Send after trip: %v", err)
+	}
+	if atomic.LoadInt32(&fr.sendN) != tripped {
+		t.Errorf("rich attempted after breaker tripped (%d > %d)", fr.sendN, tripped)
+	}
+}
+
 // TestSendRichDisabledUsesLegacy: with the flag off, Send takes the legacy path
 // untouched (no rich transport configured).
 func TestSendRichDisabledUsesLegacy(t *testing.T) {

--- a/adapters/telegram/bot_rich_test.go
+++ b/adapters/telegram/bot_rich_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/go-telegram/bot"
 	"github.com/go-telegram/bot/models"
@@ -205,32 +206,37 @@ func TestStreamDraftRichErrorFallsBackToLegacy(t *testing.T) {
 }
 
 // TestRecordRichBreaker exercises the circuit-breaker logic: threshold consecutive
-// failures latch rich off, and any success in between resets the count.
+// failures suppress rich, and any success in between resets the count + cooldown.
 func TestRecordRichBreaker(t *testing.T) {
 	c := &botChat{}
-	// One short of the threshold: not latched.
+	// One short of the threshold: not suppressed.
 	for range richFailureThreshold - 1 {
 		c.recordRich(errors.New("x"))
 	}
-	if c.richOff.Load() {
-		t.Fatal("breaker latched before reaching the threshold")
+	if c.richDisabledUntil.Load() != 0 {
+		t.Fatal("breaker suppressed rich before reaching the threshold")
 	}
 	// A success resets the consecutive count.
 	c.recordRich(nil)
 	if c.richFailures.Load() != 0 {
 		t.Fatalf("failure count = %d after success, want 0", c.richFailures.Load())
 	}
-	// A full threshold of consecutive failures now latches it off.
+	// A full threshold of consecutive failures now arms the cooldown.
 	for range richFailureThreshold {
 		c.recordRich(errors.New("x"))
 	}
-	if !c.richOff.Load() {
-		t.Error("breaker did not latch after threshold consecutive failures")
+	if c.richDisabledUntil.Load() == 0 {
+		t.Error("breaker did not suppress rich after threshold consecutive failures")
+	}
+	// A later success clears the cooldown again.
+	c.recordRich(nil)
+	if c.richDisabledUntil.Load() != 0 {
+		t.Error("success did not clear the cooldown")
 	}
 }
 
-// TestRichBreakerStopsAttempts: once the breaker latches, Send stops attempting
-// the rich path entirely (no further calls to the rich transport).
+// TestRichBreakerStopsAttempts: once the breaker trips, Send stops attempting the
+// rich path during the cooldown (no further calls to the rich transport).
 func TestRichBreakerStopsAttempts(t *testing.T) {
 	var sendHits, editHits, draftHits int32
 	b := legacyBotServer(t, &sendHits, &editHits, &draftHits)
@@ -246,15 +252,34 @@ func TestRichBreakerStopsAttempts(t *testing.T) {
 	if tripped != int32(richFailureThreshold) {
 		t.Fatalf("rich attempts before trip = %d, want %d", tripped, richFailureThreshold)
 	}
-	if !c.richOff.Load() {
-		t.Fatal("breaker not latched after threshold failures")
+	if c.richDisabledUntil.Load() == 0 {
+		t.Fatal("breaker not armed after threshold failures")
 	}
-	// Subsequent sends must not touch the rich transport, only legacy.
+	// Subsequent sends must not touch the rich transport during cooldown, only legacy.
 	if _, err := c.Send(context.Background(), "555", "hi", "", true); err != nil {
 		t.Fatalf("Send after trip: %v", err)
 	}
 	if atomic.LoadInt32(&fr.sendN) != tripped {
-		t.Errorf("rich attempted after breaker tripped (%d > %d)", fr.sendN, tripped)
+		t.Errorf("rich attempted during cooldown (%d > %d)", fr.sendN, tripped)
+	}
+}
+
+// TestRichBreakerCooldownProbe: after the cooldown elapses, a single rich probe is
+// allowed again (self-healing from a transient failure burst).
+func TestRichBreakerCooldownProbe(t *testing.T) {
+	now := time.Unix(1_000, 0)
+	c := &botChat{enableRich: true, rich: &fakeRich{}, now: func() time.Time { return now }}
+
+	for range richFailureThreshold {
+		c.recordRich(errors.New("x"))
+	}
+	if c.richAttemptable(true, "hi") {
+		t.Fatal("rich attempted during the cooldown window")
+	}
+	// Advance the clock past the cooldown → a probe is permitted again.
+	now = now.Add(richCooldown + time.Second)
+	if !c.richAttemptable(true, "hi") {
+		t.Error("rich not probed after the cooldown elapsed")
 	}
 }
 

--- a/adapters/telegram/capabilities_test.go
+++ b/adapters/telegram/capabilities_test.go
@@ -1,15 +1,22 @@
 //nolint:testpackage // whitebox: asserts the unexported botChat wiring of the rich-capability flag
 package telegram
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/go-telegram/bot"
+)
 
 // TestCapabilitiesRichFollowsFlag asserts the Bot API 10.1 rich capability is
 // surfaced from the ENABLE_RICH_MESSAGES flag threaded through NewBotChat, and
-// that the always-on Telegram capabilities are unaffected. Capabilities() does
-// not touch the *bot.Bot, so a nil bot is sufficient here.
+// that the always-on Telegram capabilities are unaffected.
 func TestCapabilitiesRichFollowsFlag(t *testing.T) {
+	b, err := bot.New("123:ABC", bot.WithSkipGetMe())
+	if err != nil {
+		t.Fatalf("bot.New: %v", err)
+	}
 	for _, enableRich := range []bool{false, true} {
-		caps := NewBotChat(nil, enableRich).Capabilities()
+		caps := NewBotChat(b, enableRich).Capabilities()
 		if caps.CanSendRich != enableRich {
 			t.Errorf("NewBotChat(_, %t).Capabilities().CanSendRich = %t, want %t",
 				enableRich, caps.CanSendRich, enableRich)

--- a/adapters/telegram/capabilities_test.go
+++ b/adapters/telegram/capabilities_test.go
@@ -1,0 +1,24 @@
+//nolint:testpackage // whitebox: asserts the unexported botChat wiring of the rich-capability flag
+package telegram
+
+import "testing"
+
+// TestCapabilitiesRichFollowsFlag asserts the Bot API 10.1 rich capability is
+// surfaced from the ENABLE_RICH_MESSAGES flag threaded through NewBotChat, and
+// that the always-on Telegram capabilities are unaffected. Capabilities() does
+// not touch the *bot.Bot, so a nil bot is sufficient here.
+func TestCapabilitiesRichFollowsFlag(t *testing.T) {
+	for _, enableRich := range []bool{false, true} {
+		caps := NewBotChat(nil, enableRich).Capabilities()
+		if caps.CanSendRich != enableRich {
+			t.Errorf("NewBotChat(_, %t).Capabilities().CanSendRich = %t, want %t",
+				enableRich, caps.CanSendRich, enableRich)
+		}
+		if !caps.CanSendDocument {
+			t.Errorf("CanSendDocument = false, want true (enableRich=%t)", enableRich)
+		}
+		if caps.MaxMessageRunes != telegramMaxMessageRunes {
+			t.Errorf("MaxMessageRunes = %d, want %d", caps.MaxMessageRunes, telegramMaxMessageRunes)
+		}
+	}
+}

--- a/adapters/telegram/deploy/roles/claude_tg_bot/templates/env.j2
+++ b/adapters/telegram/deploy/roles/claude_tg_bot/templates/env.j2
@@ -49,6 +49,9 @@ REQUIRE_GROUP_MENTION={{ require_group_mention | default(false) | string | lower
 # Published-PR review/fix loop (poller + CLAUDE.md Phase 2). false (default) = off:
 # build + open a PR, then stop; no on-PR review or comment reactions.
 ENABLE_PR_REVIEW={{ enable_pr_review | default(false) | string | lower }}
+# Bot API 10.1 rich messages (structured blocks + native rich draft). false (default) = off:
+# legacy Markdown→HTML rendering; true = render rich (Telegram only, falls back on any error).
+ENABLE_RICH_MESSAGES={{ enable_rich_messages | default(false) | string | lower }}
 {% if webhook_domain %}
 
 # === WEBHOOK SERVER (PR monitoring) ===

--- a/adapters/telegram/deploy/roles/claude_tg_bot/templates/env.j2
+++ b/adapters/telegram/deploy/roles/claude_tg_bot/templates/env.j2
@@ -49,9 +49,10 @@ REQUIRE_GROUP_MENTION={{ require_group_mention | default(false) | string | lower
 # Published-PR review/fix loop (poller + CLAUDE.md Phase 2). false (default) = off:
 # build + open a PR, then stop; no on-PR review or comment reactions.
 ENABLE_PR_REVIEW={{ enable_pr_review | default(false) | string | lower }}
-# Bot API 10.1 rich messages (structured blocks + native rich draft). false (default) = off:
-# legacy Markdown→HTML rendering; true = render rich (Telegram only, falls back on any error).
-ENABLE_RICH_MESSAGES={{ enable_rich_messages | default(false) | string | lower }}
+# Bot API 10.1 rich messages (Rich Markdown answers + native rich draft). true (default) = on
+# (Telegram only; falls back to Markdown→HTML/plain on any error, self-disables after repeated
+# failures). Set false to force the legacy path.
+ENABLE_RICH_MESSAGES={{ enable_rich_messages | default(true) | string | lower }}
 {% if webhook_domain %}
 
 # === WEBHOOK SERVER (PR monitoring) ===

--- a/adapters/telegram/richtransport.go
+++ b/adapters/telegram/richtransport.go
@@ -1,0 +1,153 @@
+package telegram
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/go-telegram/bot/models"
+)
+
+// defaultTelegramAPIBase is the Bot API origin the rich HTTP shim targets,
+// matching the go-telegram/bot default. The lib keeps its own server URL private
+// (no accessor), so the shim defaults to the same value; a deployment using a
+// custom Telegram server URL would need this overridden too (a known limitation
+// of the shim, removed once the lib models the rich methods natively).
+const defaultTelegramAPIBase = "https://api.telegram.org"
+
+// richTransport sends Bot API 10.1 rich messages. It is an interface so the
+// adapter's Send/Edit/StreamDraft can be unit-tested with a fake, and so the HTTP
+// shim is swappable when the upstream lib gains native rich support.
+type richTransport interface {
+	send(ctx context.Context, chatID int64, msg inputRichMessage, markup models.ReplyMarkup) (messageID int, err error)
+	edit(ctx context.Context, chatID int64, messageID int, msg inputRichMessage, markup models.ReplyMarkup) error
+	streamDraft(ctx context.Context, chatID, draftID int64, msg inputRichMessage) error
+}
+
+// httpRichTransport calls the rich methods directly over HTTP. It exists because
+// go-telegram/bot v1.21.0 (the latest) does not expose them; it reuses the bot's
+// token (b.Token()) and posts JSON to <base>/bot<token>/<method>, exactly the
+// endpoint shape the lib itself uses (see FileDownloadLink). The token rides the
+// path as the Bot API requires and is never logged here.
+type httpRichTransport struct {
+	token string
+	base  string
+	hc    *http.Client
+}
+
+func newHTTPRichTransport(token, base string, hc *http.Client) *httpRichTransport {
+	if base == "" {
+		base = defaultTelegramAPIBase
+	}
+	if hc == nil {
+		hc = http.DefaultClient
+	}
+	return &httpRichTransport{token: token, base: base, hc: hc}
+}
+
+// send posts sendRichMessage and returns the new message id. markup carries the
+// Stop inline keyboard (sendRichMessage accepts reply_markup); nil sends none.
+func (t *httpRichTransport) send(
+	ctx context.Context, chatID int64, msg inputRichMessage, markup models.ReplyMarkup,
+) (int, error) {
+	body := map[string]any{"chat_id": chatID, "rich_message": msg}
+	if markup != nil {
+		body["reply_markup"] = markup
+	}
+	raw, err := t.call(ctx, "sendRichMessage", body)
+	if err != nil {
+		return 0, err
+	}
+	var res struct {
+		MessageID int `json:"message_id"` //nolint:tagliatelle // Telegram Bot API uses snake_case.
+	}
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return 0, fmt.Errorf("decode sendRichMessage result: %w", err)
+	}
+	return res.MessageID, nil
+}
+
+// edit posts editMessageText with the rich_message parameter (Bot API 10.1).
+func (t *httpRichTransport) edit(
+	ctx context.Context, chatID int64, messageID int, msg inputRichMessage, markup models.ReplyMarkup,
+) error {
+	body := map[string]any{"chat_id": chatID, "message_id": messageID, "rich_message": msg}
+	if markup != nil {
+		body["reply_markup"] = markup
+	}
+	_, err := t.call(ctx, "editMessageText", body)
+	return err
+}
+
+// streamDraft posts sendRichMessageDraft: an ephemeral ~30s live preview keyed by
+// an INTEGER draft_id (non-zero; same id animates an update). A draft carries no
+// inline keyboard, so no markup is passed (the Stop button rides the separate
+// anchor message, as on the legacy draft path).
+func (t *httpRichTransport) streamDraft(
+	ctx context.Context, chatID, draftID int64, msg inputRichMessage,
+) error {
+	body := map[string]any{"chat_id": chatID, "draft_id": draftID, "rich_message": msg}
+	_, err := t.call(ctx, "sendRichMessageDraft", body)
+	return err
+}
+
+// apiEnvelope is the subset of the Bot API response envelope the shim reads.
+type apiEnvelope struct {
+	OK          bool            `json:"ok"`
+	Description string          `json:"description"`
+	Result      json.RawMessage `json:"result"`
+}
+
+// call POSTs a JSON body to a Bot API method and returns the raw "result" on
+// success, or an error (HTTP, transport, or ok:false) the caller turns into a
+// fallback to the legacy rendering.
+func (t *httpRichTransport) call(ctx context.Context, method string, body map[string]any) (json.RawMessage, error) {
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal %s body: %w", method, err)
+	}
+	url := fmt.Sprintf("%s/bot%s/%s", t.base, t.token, method)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(buf))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := t.hc.Do(req)
+	if err != nil {
+		// net/http embeds the request URL — which carries the bot token — in its
+		// error string. Redact it before the error escapes, so a caller that logs the
+		// rich fallback can never leak the token.
+		return nil, t.redactErr(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	var env apiEnvelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		return nil, fmt.Errorf("decode %s envelope: %w", method, err)
+	}
+	if !env.OK {
+		return nil, fmt.Errorf("telegram %s failed: %s", method, env.Description)
+	}
+	return env.Result, nil
+}
+
+// redactErr returns a copy of err with the bot token masked, so a token embedded
+// in a transport error (net/http puts the request URL in its message) never
+// reaches a log. The concrete error type is dropped, which is fine: rich errors
+// are only logged and used to trigger the legacy fallback, never type-inspected.
+func (t *httpRichTransport) redactErr(err error) error {
+	if t.token == "" {
+		return err
+	}
+	return errors.New(strings.ReplaceAll(err.Error(), t.token, "***"))
+}

--- a/adapters/telegram/richtransport_test.go
+++ b/adapters/telegram/richtransport_test.go
@@ -1,0 +1,138 @@
+//nolint:testpackage // whitebox: tests the unexported rich HTTP shim
+package telegram
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// richRecordingServer is a fake Bot API that records the last method path and
+// JSON body, and returns a canned envelope.
+type richRecordingServer struct {
+	srv      *httptest.Server
+	lastPath string
+	lastBody map[string]any
+}
+
+func newRichServer(t *testing.T, reply string) *richRecordingServer {
+	t.Helper()
+	rs := &richRecordingServer{}
+	rs.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rs.lastPath = r.URL.Path
+		data, _ := io.ReadAll(r.Body)
+		rs.lastBody = map[string]any{}
+		_ = json.Unmarshal(data, &rs.lastBody)
+		_, _ = io.WriteString(w, reply)
+	}))
+	t.Cleanup(rs.srv.Close)
+	return rs
+}
+
+// richMessageField returns the rich_message sub-object of the recorded body.
+func (rs *richRecordingServer) richMessageField(t *testing.T) map[string]any {
+	t.Helper()
+	rm, ok := rs.lastBody["rich_message"].(map[string]any)
+	if !ok {
+		t.Fatalf("body %v has no rich_message object", rs.lastBody)
+	}
+	return rm
+}
+
+func TestHTTPRichTransportSend(t *testing.T) {
+	rs := newRichServer(t, `{"ok":true,"result":{"message_id":4242}}`)
+	tr := newHTTPRichTransport("123:ABC", rs.srv.URL, rs.srv.Client())
+
+	id, err := tr.send(context.Background(), 555, richMarkdown("# Title\n\nhi"), stopMarkup("run-1"))
+	if err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if id != 4242 {
+		t.Errorf("message id = %d, want 4242", id)
+	}
+	if !strings.HasSuffix(rs.lastPath, "/bot123:ABC/sendRichMessage") {
+		t.Errorf("path = %q, want .../bot123:ABC/sendRichMessage", rs.lastPath)
+	}
+	if rs.richMessageField(t)["markdown"] != "# Title\n\nhi" {
+		t.Errorf("rich_message.markdown = %v, want the passed text", rs.richMessageField(t)["markdown"])
+	}
+	if rs.lastBody["chat_id"].(float64) != 555 {
+		t.Errorf("chat_id = %v, want 555", rs.lastBody["chat_id"])
+	}
+	if _, ok := rs.lastBody["reply_markup"]; !ok {
+		t.Errorf("body %v missing reply_markup (Stop button)", rs.lastBody)
+	}
+}
+
+func TestHTTPRichTransportEdit(t *testing.T) {
+	rs := newRichServer(t, `{"ok":true,"result":{"message_id":7}}`)
+	tr := newHTTPRichTransport("123:ABC", rs.srv.URL, rs.srv.Client())
+
+	if err := tr.edit(context.Background(), 555, 7, richMarkdown("updated"), nil); err != nil {
+		t.Fatalf("edit: %v", err)
+	}
+	if !strings.HasSuffix(rs.lastPath, "/editMessageText") {
+		t.Errorf("path = %q, want .../editMessageText", rs.lastPath)
+	}
+	if rs.lastBody["message_id"].(float64) != 7 {
+		t.Errorf("message_id = %v, want 7", rs.lastBody["message_id"])
+	}
+	if rs.richMessageField(t)["markdown"] != "updated" {
+		t.Errorf("rich_message.markdown = %v, want updated", rs.richMessageField(t)["markdown"])
+	}
+}
+
+func TestHTTPRichTransportStreamDraft(t *testing.T) {
+	rs := newRichServer(t, `{"ok":true,"result":true}`)
+	tr := newHTTPRichTransport("123:ABC", rs.srv.URL, rs.srv.Client())
+
+	if err := tr.streamDraft(context.Background(), 555, 99, richMarkdown("frame")); err != nil {
+		t.Fatalf("streamDraft: %v", err)
+	}
+	if !strings.HasSuffix(rs.lastPath, "/sendRichMessageDraft") {
+		t.Errorf("path = %q, want .../sendRichMessageDraft", rs.lastPath)
+	}
+	// draft_id is an integer per the verified schema.
+	if rs.lastBody["draft_id"].(float64) != 99 {
+		t.Errorf("draft_id = %v, want 99", rs.lastBody["draft_id"])
+	}
+	if rs.richMessageField(t)["markdown"] != "frame" {
+		t.Errorf("rich_message.markdown = %v, want frame", rs.richMessageField(t)["markdown"])
+	}
+}
+
+// TestHTTPRichTransportRedactsToken asserts a transport-level error (net/http
+// embeds the token-bearing request URL in its message) never leaks the token.
+func TestHTTPRichTransportRedactsToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	base := srv.URL
+	srv.Close() // now the base refuses connections → t.hc.Do returns an error
+
+	tr := newHTTPRichTransport("123:SECRETTOKEN", base, srv.Client())
+	_, err := tr.send(context.Background(), 1, richMarkdown("x"), nil)
+	if err == nil {
+		t.Fatal("send to a closed server returned nil error")
+	}
+	if strings.Contains(err.Error(), "SECRETTOKEN") {
+		t.Errorf("error leaks the bot token: %v", err)
+	}
+}
+
+// TestHTTPRichTransportAPIError asserts an ok:false envelope becomes an error
+// (which the adapter turns into a legacy fallback).
+func TestHTTPRichTransportAPIError(t *testing.T) {
+	rs := newRichServer(t, `{"ok":false,"description":"RICH_MESSAGE_INVALID"}`)
+	tr := newHTTPRichTransport("123:ABC", rs.srv.URL, rs.srv.Client())
+
+	_, err := tr.send(context.Background(), 1, richMarkdown("x"), nil)
+	if err == nil {
+		t.Fatal("send with ok:false returned nil error, want failure")
+	}
+	if !strings.Contains(err.Error(), "RICH_MESSAGE_INVALID") {
+		t.Errorf("error %v missing API description", err)
+	}
+}

--- a/adapters/telegram/richwire.go
+++ b/adapters/telegram/richwire.go
@@ -1,0 +1,38 @@
+package telegram
+
+// Bot API 10.1 rich-message wire types, VERIFIED against the official reference
+// (core.telegram.org/bots/api — InputRichMessage / sendRichMessage / the "Rich
+// Markdown style" section).
+//
+// Sending a rich message does NOT use the RichBlock*/RichText* tree — those
+// describe a RECEIVED RichMessage. To SEND, InputRichMessage carries exactly one
+// of `markdown` or `html`: a single string in Telegram's "Rich Markdown style"
+// (an extended GitHub-flavoured Markdown — headings, tables, task lists,
+// blockquotes, ~~strikethrough~~, ==marked==, ||spoiler||, <details>, footnotes,
+// $math$, …). The assistant already emits this dialect, so the rich path passes
+// its Markdown straight through and lets Telegram parse it — no IR, no serializer.
+type inputRichMessage struct {
+	// Markdown is the message content in Telegram's Rich Markdown style. Exactly one
+	// of Markdown or HTML must be set; the adapter always uses Markdown.
+	Markdown string `json:"markdown,omitempty"`
+	// HTML is the alternative content form (unused by this adapter, kept for
+	// completeness of the documented type).
+	HTML string `json:"html,omitempty"`
+	// IsRTL requests right-to-left rendering. Left false (default LTR).
+	IsRTL bool `json:"is_rtl,omitempty"` //nolint:tagliatelle // Telegram Bot API uses snake_case.
+	// SkipEntityDetection disables Telegram's automatic detection of URLs, e-mails,
+	// @mentions, #hashtags, $cashtags, phone numbers, /commands and bank-card-like
+	// digit runs in the text. We set it true for the rich path: the legacy
+	// MarkdownToHTML path only ever linked EXPLICIT [text](url) markdown, so leaving
+	// auto-detection on would silently turn ordinary dev output (identifiers like
+	// @scope/pkg, issue refs #4242, $ENV vars, long numeric ids) into surprise
+	// entities — a behaviour change, not parity. Explicit Markdown links still work.
+	SkipEntityDetection bool `json:"skip_entity_detection,omitempty"` //nolint:tagliatelle // Telegram Bot API uses snake_case.
+}
+
+// richMarkdown builds an InputRichMessage from the assistant's Markdown text. It
+// disables automatic entity detection so the rich path matches the legacy path's
+// "explicit links only" behaviour (see SkipEntityDetection).
+func richMarkdown(text string) inputRichMessage {
+	return inputRichMessage{Markdown: text, SkipEntityDetection: true}
+}

--- a/adapters/telegram/richwire_test.go
+++ b/adapters/telegram/richwire_test.go
@@ -1,0 +1,45 @@
+//nolint:testpackage // whitebox: tests the unexported rich wire type
+package telegram
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestRichMarkdownCarriesText asserts the assistant's Markdown is passed straight
+// through into InputRichMessage.markdown.
+func TestRichMarkdownCarriesText(t *testing.T) {
+	const md = "# Title\n\nhello **world**\n\n| a | b |\n|---|---|\n| 1 | 2 |"
+	got := richMarkdown(md)
+	if got.Markdown != md {
+		t.Errorf("Markdown = %q, want the input verbatim", got.Markdown)
+	}
+	if got.HTML != "" {
+		t.Errorf("HTML = %q, want empty (exactly one of markdown/html)", got.HTML)
+	}
+	if !got.SkipEntityDetection {
+		t.Error("SkipEntityDetection = false, want true (parity with legacy: explicit links only)")
+	}
+}
+
+// TestInputRichMessageJSONShape asserts the wire payload carries "markdown" plus
+// skip_entity_detection (true), and omits the empty alternative fields.
+func TestInputRichMessageJSONShape(t *testing.T) {
+	b, err := json.Marshal(richMarkdown("hi **there**"))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	js := string(b)
+	if !strings.Contains(js, `"markdown":"hi **there**"`) {
+		t.Errorf("payload %s missing markdown field", js)
+	}
+	if !strings.Contains(js, `"skip_entity_detection":true`) {
+		t.Errorf("payload %s missing skip_entity_detection:true", js)
+	}
+	for _, absent := range []string{`"html"`, `"is_rtl"`} {
+		if strings.Contains(js, absent) {
+			t.Errorf("payload %s should omit empty %s", js, absent)
+		}
+	}
+}

--- a/adapters/vk/bot_test.go
+++ b/adapters/vk/bot_test.go
@@ -23,6 +23,12 @@ func TestCapabilities(t *testing.T) {
 	if caps.MaxMessageRunes != vkMaxMessageRunes {
 		t.Errorf("MaxMessageRunes = %d, want %d", caps.MaxMessageRunes, vkMaxMessageRunes)
 	}
+	// VK has no Bot API 10.1 rich support: the additive CanSendRich field must stay
+	// at its zero value so the VK adapter keeps the legacy rendering with no change
+	// (docs/rich-messages-plan.md §6).
+	if caps.CanSendRich {
+		t.Errorf("capabilities = %+v, want CanSendRich false (VK has no rich support)", caps)
+	}
 }
 
 func TestSendRendersStopKeyboardAndUniqueRandomID(t *testing.T) {

--- a/cmd/flock-telegram/main.go
+++ b/cmd/flock-telegram/main.go
@@ -231,7 +231,7 @@ func run() int {
 
 	svc = chat.New(chat.Config{
 		Runner:     runner,
-		Transport:  telegram.NewBotChat(b),
+		Transport:  telegram.NewBotChat(b, cfg.EnableRichMessages),
 		Dispatcher: disp,
 		Workspace:  ws,
 		Sessions:   sessions,

--- a/cmd/flock-telegram/media_routing_test.go
+++ b/cmd/flock-telegram/media_routing_test.go
@@ -127,7 +127,7 @@ func newMediaHarness(t *testing.T, maxUpload int64) *mediaTestHarness {
 	disp := dispatch.New(2)
 	svc := chat.New(chat.Config{
 		Runner:     runner,
-		Transport:  telegram.NewBotChat(b),
+		Transport:  telegram.NewBotChat(b, false),
 		Dispatcher: disp,
 		Workspace:  &fakeWorkspace{dir: t.TempDir()},
 		Logger:     logger,

--- a/core/chat/chunk.go
+++ b/core/chat/chunk.go
@@ -48,6 +48,99 @@ func ChunkSize(s string, limit int) []string {
 	return chunks
 }
 
+// fenceMarker is the Markdown code-fence delimiter.
+const fenceMarker = "```"
+
+// fenceInfoCap bounds the info-string length carried onto a reopened fence, so the
+// per-chunk markers a split adds stay within fenceReserve.
+const fenceInfoCap = 32
+
+// fenceReserve is the rune budget held back per chunk so the close/reopen fence
+// markers a mid-block split adds can never push a balanced chunk over the limit:
+// a worst-case chunk gets BOTH a reopen ("```" + info + "\n") and a close
+// ("\n" + "```"), i.e. <= fenceInfoCap + 8 runes. The reserve clears that.
+const fenceReserve = fenceInfoCap + 16
+
+// ChunkFenced splits s into Telegram-safe pieces like Chunk, but keeps fenced code
+// blocks renderable across a split: when a break lands INSIDE a ``` block, the
+// chunk that ends open is given a closing fence and the continuation a reopening
+// ```<info>. Without this a split code block renders as one runaway code block on
+// the rich (Markdown) path and loses its fencing on the legacy path. With no
+// fenced block present the output equals Chunk's.
+func ChunkFenced(s string) []string { return ChunkFencedSize(s, TelegramMaxMessage) }
+
+// ChunkFencedSize is ChunkFenced with an explicit per-chunk rune limit.
+func ChunkFencedSize(s string, limit int) []string {
+	if limit <= 0 {
+		limit = TelegramMaxMessage
+	}
+	// No fences anywhere → nothing to balance, and no need to reserve budget; behave
+	// exactly like ChunkSize.
+	if !strings.Contains(s, fenceMarker) {
+		return ChunkSize(s, limit)
+	}
+	// Split with headroom so the added fence markers can't exceed the real limit.
+	split := limit - fenceReserve
+	if split < 1 {
+		split = limit
+	}
+	return balanceFences(ChunkSize(s, split))
+}
+
+// balanceFences rewrites chunk seams so no chunk ends inside an open ``` fence,
+// carrying the open fence's info string across the boundary.
+func balanceFences(chunks []string) []string {
+	out := make([]string, len(chunks))
+	openInfo := "" // info string of the fence open at the current seam
+	open := false  // whether a fence is open at the current seam
+	for i, c := range chunks {
+		var b strings.Builder
+		if open {
+			// Reopen the fence carried in from the previous chunk. strings.Builder
+			// writes never return an error, so the results are deliberately discarded.
+			_, _ = b.WriteString(fenceMarker)
+			_, _ = b.WriteString(openInfo)
+			_ = b.WriteByte('\n')
+		}
+		_, _ = b.WriteString(c)
+		endOpen, endInfo := scanFences(c, open, openInfo)
+		if endOpen {
+			// Close the fence at the chunk boundary so this chunk renders cleanly.
+			if !strings.HasSuffix(c, "\n") {
+				_ = b.WriteByte('\n')
+			}
+			_, _ = b.WriteString(fenceMarker)
+		}
+		out[i] = b.String()
+		open, openInfo = endOpen, endInfo
+	}
+	return out
+}
+
+// scanFences walks chunk line by line from the (startOpen, startInfo) fence state
+// and returns the state at its end. A line whose trimmed text begins with ```
+// toggles the fence: opening captures the (capped) info string after the marker,
+// closing clears it.
+func scanFences(chunk string, startOpen bool, startInfo string) (open bool, info string) {
+	open, info = startOpen, startInfo
+	for _, line := range strings.Split(chunk, "\n") {
+		t := strings.TrimSpace(line)
+		if !strings.HasPrefix(t, fenceMarker) {
+			continue
+		}
+		if open {
+			open, info = false, ""
+			continue
+		}
+		open = true
+		info = strings.TrimSpace(t[len(fenceMarker):])
+		if len(info) > fenceInfoCap {
+			info = info[:fenceInfoCap]
+		}
+	}
+	return open, info
+}
+
 // splitAt returns the largest prefix of s that is at most limit runes, broken on
 // a newline or space boundary when one exists within the budget, plus the
 // remainder with any single boundary separator consumed. When no boundary fits,

--- a/core/chat/chunk_fenced_test.go
+++ b/core/chat/chunk_fenced_test.go
@@ -1,0 +1,85 @@
+//nolint:testpackage // intentionally whitebox to test unexported fenced-chunk internals
+package chat
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// TestChunkFencedNoFenceEqualsChunk: input without any ``` is chunked exactly like
+// ChunkSize (no markers added, no budget reserved).
+func TestChunkFencedNoFenceEqualsChunk(t *testing.T) {
+	s := strings.Repeat("word ", 5000) // well over the limit, no fences
+	got := ChunkFencedSize(s, 100)
+	want := ChunkSize(s, 100)
+	if len(got) != len(want) {
+		t.Fatalf("chunk count = %d, want %d (must match ChunkSize when no fence)", len(got), len(want))
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("chunk %d differs from ChunkSize", i)
+		}
+	}
+}
+
+// TestChunkFencedBalancesSplitBlock: a code block that crosses a chunk boundary is
+// closed at the seam and reopened (with its info string) on the next chunk.
+func TestChunkFencedBalancesSplitBlock(t *testing.T) {
+	body := strings.Repeat("x = 1\n", 60) // long code body that forces a split
+	s := "intro\n```go\n" + body + "```\ndone"
+
+	chunks := ChunkFencedSize(s, 80)
+	if len(chunks) < 2 {
+		t.Fatalf("expected the block to split into >=2 chunks, got %d", len(chunks))
+	}
+	for i, c := range chunks {
+		// Each chunk must have balanced fences (an even number of ``` lines).
+		if n := countFenceLines(c); n%2 != 0 {
+			t.Errorf("chunk %d has unbalanced fences (%d markers):\n%s", i, n, c)
+		}
+		if utf8.RuneCountInString(c) > 80 {
+			t.Errorf("chunk %d exceeds the limit: %d runes", i, utf8.RuneCountInString(c))
+		}
+	}
+	// The continuation chunk must reopen the go fence so its code keeps rendering.
+	if !strings.Contains(chunks[1], "```go") {
+		t.Errorf("continuation chunk did not reopen the ```go fence:\n%s", chunks[1])
+	}
+}
+
+// TestChunkFencedWholeBlockUntouched: a complete fenced block under the limit is
+// returned as a single, unchanged chunk.
+func TestChunkFencedWholeBlockUntouched(t *testing.T) {
+	s := "```go\nx := 1\n```"
+	chunks := ChunkFencedSize(s, 4096)
+	if len(chunks) != 1 || chunks[0] != s {
+		t.Errorf("a whole fenced block was altered: %q", chunks)
+	}
+}
+
+// TestScanFencesState walks fence toggles from a starting state.
+func TestScanFencesState(t *testing.T) {
+	// Opens a fence, captures the info string.
+	if open, info := scanFences("```python\nprint(1)", false, ""); !open || info != "python" {
+		t.Errorf("open/info = %v/%q, want true/python", open, info)
+	}
+	// Continues an already-open fence and closes it.
+	if open, _ := scanFences("more code\n```", true, "go"); open {
+		t.Error("fence should be closed after the closing ```")
+	}
+	// A line with no fence marker preserves the incoming state.
+	if open, info := scanFences("just text", true, "go"); !open || info != "go" {
+		t.Errorf("state changed by a non-fence line: %v/%q", open, info)
+	}
+}
+
+func countFenceLines(s string) int {
+	n := 0
+	for _, line := range strings.Split(s, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "```") {
+			n++
+		}
+	}
+	return n
+}

--- a/core/chat/service.go
+++ b/core/chat/service.go
@@ -552,7 +552,9 @@ func (s *Service) finish(
 		text = Final(res)
 	}
 
-	chunks := ChunkSize(text, s.maxRunes)
+	// Fence-aware chunking so a code block that crosses a chunk boundary stays
+	// renderable (balanced ``` per chunk) on both the rich and legacy paths.
+	chunks := ChunkFencedSize(text, s.maxRunes)
 
 	// Replace the progress message with the first chunk (clearing Stop markup);
 	// send any further chunks as new messages.

--- a/core/chat/transport.go
+++ b/core/chat/transport.go
@@ -66,4 +66,12 @@ type Capabilities struct {
 	// MaxMessageRunes is the platform's max message length in runes, fed to the
 	// chunker (Telegram 4096). A non-positive value selects a safe default.
 	MaxMessageRunes int
+	// CanSendRich: the platform can render Bot API 10.1 rich messages (structured
+	// blocks + a native rich draft) instead of the legacy MarkdownToHTML/plain
+	// path. It is purely additive — false (the zero value) keeps a transport on the
+	// exact pre-rich behaviour, so a platform that does not set it (VK) needs no
+	// change. Telegram sets it from the ENABLE_RICH_MESSAGES flag; even there the
+	// rich path always falls back to MarkdownToHTML/plain on any error, so the flag
+	// is a feature toggle, never a hard dependency.
+	CanSendRich bool
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -101,14 +101,15 @@ type Config struct {
 	// always handled regardless. See plan §5.
 	RequireGroupMention bool `env:"REQUIRE_GROUP_MENTION" envDefault:"false"`
 
-	// EnableRichMessages toggles Bot API 10.1 rich rendering in the Telegram
-	// adapter (structured blocks + native rich draft). Default false: the adapter
-	// uses the legacy MarkdownToHTML/plain path and behaves exactly as before. When
-	// true it is surfaced via the Telegram Capabilities().CanSendRich flag; the rich
-	// path still falls back to MarkdownToHTML/plain on any error, so flipping this on
-	// can never break delivery. VK ignores it (no rich support). See
-	// docs/rich-messages-plan.md.
-	EnableRichMessages bool `env:"ENABLE_RICH_MESSAGES" envDefault:"false"`
+	// EnableRichMessages toggles Bot API 10.1 rich rendering in the Telegram adapter
+	// (Rich Markdown answers + native rich draft). Default true: answers/progress are
+	// sent via sendRichMessage/sendRichMessageDraft. It can never break delivery — the
+	// rich path falls back to the legacy MarkdownToHTML/plain rendering on any error,
+	// and the adapter latches rich OFF for the process after repeated failures (so a
+	// deployment where the live API does not yet serve these methods stops paying the
+	// failed round-trip). Set ENABLE_RICH_MESSAGES=false to force the legacy path. VK
+	// ignores it (no rich support). See docs/rich-messages-plan.md.
+	EnableRichMessages bool `env:"ENABLE_RICH_MESSAGES" envDefault:"true"`
 
 	// Team-loop knobs rendered into each workspace's CLAUDE.md (mirrors the
 	// values the Python entrypoint substituted). Kept as strings since they are

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -101,6 +101,15 @@ type Config struct {
 	// always handled regardless. See plan §5.
 	RequireGroupMention bool `env:"REQUIRE_GROUP_MENTION" envDefault:"false"`
 
+	// EnableRichMessages toggles Bot API 10.1 rich rendering in the Telegram
+	// adapter (structured blocks + native rich draft). Default false: the adapter
+	// uses the legacy MarkdownToHTML/plain path and behaves exactly as before. When
+	// true it is surfaced via the Telegram Capabilities().CanSendRich flag; the rich
+	// path still falls back to MarkdownToHTML/plain on any error, so flipping this on
+	// can never break delivery. VK ignores it (no rich support). See
+	// docs/rich-messages-plan.md.
+	EnableRichMessages bool `env:"ENABLE_RICH_MESSAGES" envDefault:"false"`
+
 	// Team-loop knobs rendered into each workspace's CLAUDE.md (mirrors the
 	// values the Python entrypoint substituted). Kept as strings since they are
 	// substituted verbatim into the template.


### PR DESCRIPTION
Implements **Bot API 10.1 "Rich Messages"** in the Telegram adapter, **on by default** (`ENABLE_RICH_MESSAGES=true`; set `false` to force the legacy path). Single independently-reviewable PR (4 commits off `main`). Design doc: #22.

## ✅ Schema VERIFIED (official reference)
Sending does NOT use a `RichBlock*`/`RichText*` tree — those describe a *received* `RichMessage`. `InputRichMessage` carries exactly one of **`markdown`** or **`html`**: a single string in Telegram's **"Rich Markdown style"** (extended GitHub-flavoured Markdown). The assistant already emits this dialect, so the adapter passes its Markdown straight through — **no IR, no serializer, no core run-loop changes**.

## Commits
1. **Stage 0** — `ENABLE_RICH_MESSAGES` flag + additive `Capabilities.CanSendRich`.
2. **Rich rendering** — `Send`/`Edit`/`StreamDraft` send `InputRichMessage{markdown}` via `sendRichMessage` / `editMessageText(rich_message)` / `sendRichMessageDraft`, full fallback ladder.
3. **Default-on + circuit breaker**.
4. **Review fixes** — fence-aware chunking + breaker cooldown.

## Delivery is never at risk
Every call site tries rich first and falls back to the existing `MarkdownToHTML`/plain (and legacy draft) path on **any** error — no legacy line removed.

## Circuit breaker (default-on safety)
A default-on flag means every message attempts rich first; if a deployment's live API doesn't serve the methods yet, that would be a wasted round-trip per message. The breaker bounds it: `richFailures` counts **consecutive** failures (reset on any success); after `richFailureThreshold` (5) the rich path is **suppressed for `richCooldown` (1m)**, then a single probe is allowed — so an unsupported API costs ~5 messages + an occasional probe, and a **transient blip self-heals** (no permanent latch). Logged once (WARN) on the first trip.

## Other hardening
- **`skip_entity_detection=true`** — parity with legacy ("explicit `[text](url)` only"); avoids auto-linking `@scope/pkg`, `#4242`, `$ENV`, numeric ids into surprise entities.
- **Token redaction** — transport errors (net/http embeds the token-bearing URL) are masked before they can reach a log; covered by a test.
- **Fence-aware chunking** (`ChunkFencedSize`) — a fenced code block crossing the 4096-rune chunk boundary is closed at the seam and reopened on the next chunk, so it stays renderable on **both** the rich and legacy paths. No-fence input is unchanged.

## VK-safety invariant — verified
- `git diff origin/main -- adapters/vk/{bot,api,longpoll}.go` → **empty** (VK production zero-diff).
- Additive only: one `Capabilities.CanSendRich` field (false by zero value on VK); no `Transport` method added/changed.

## Acceptance — green via the repo's runner (`dev-tools`, mirrors CI)
- Wire type + JSON shape; HTTP shim (request shape, result parse, `ok:false`→error, token redaction); `Send`/`Edit`/`StreamDraft` gating + fallback; `draftIDToInt`; **circuit-breaker suppress/probe/reset**; **fenced-chunk balancing + budget + scanFences**.
- `go build`, `go vet`, `golangci-lint run` → **0 issues**; `go test -race ./...` green (incl. VK + every existing suite).

## Known issues (tracked — not blockers, delivery always falls back)
- **Tables crossing a chunk boundary** still lose their header row on the continuation chunk (code fences are now handled; the table-header-repeat case is rarer and left as a follow-up).
- **`sendRichMessageDraft` is private-chat-only** per schema; in groups the rich draft errors → legacy `SendMessageDraft` (group behaviour unchanged).
- **plain→rich edit, unverified live.** The anchor is sent plain and the first answer chunk edits it via `editMessageText(rich_message)`; if Telegram disallows plain→rich, that first edit falls back to legacy HTML (self-healing). Needs a live-bot eyeball.

Supersedes the earlier stacked #23/#24/#25.