### PR TITLE
prompts: converging pre-PR review + surface its verdict on the ENABLE_PR_REVIEW=false path

### DIFF
--- a/core/CLAUDE.workspace.md.tmpl
+++ b/core/CLAUDE.workspace.md.tmpl
@@ -73,10 +73,16 @@ feature's existing `duck/<chatid>/<slug>` branch and continues on it (go straigh
    loop `coder`↔`tester` until green — **max ${PRE_PR_CYCLES} rounds** (fewer if trivial).
 6. **Gate to open the PR (a score, not a coin-flip):** builds + full affected suite green +
    lint/types clean + **every acceptance criterion (AC ID) demonstrably met**.
-7. **Pre-PR critic:** run `reviewer` once on the LOCAL diff (fresh context — correctness/spec/
-   security, not style). On `standard`/`risky` it ALSO sweeps four **design lenses** — reuse /
-   simplification / efficiency / altitude — to catch over-engineering and dead abstraction before
-   the PR (skip them on `trivial`). Fix blockers BEFORE the PR exists; it's cheaper than PR churn.
+7. **Pre-PR critic — loop to a CLEAN round, not one pass.** Run `reviewer` on the LOCAL diff
+   (fresh context — correctness/spec/security, not style). On `standard`/`risky` it ALSO sweeps
+   four **design lenses** — reuse / simplification / efficiency / altitude — to catch
+   over-engineering and dead abstraction before the PR (skip them on `trivial`). Then `coder`
+   fixes every `blocker`/`major`, and you **re-run `reviewer` on the NEW diff** — because a fix
+   can introduce a fresh bug, each round is a full adversarial pass re-derived from scratch, NOT a
+   check that the last fixes landed. Repeat `coder`↔`reviewer` until a round finds **zero new
+   `blocker`/`major` (a *clean round*)** — **max 3 rounds**; the arbiter then APPROVEs only on a
+   clean round, else ESCALATEs. Fixing here is cheaper than PR churn. (A `trivial` change may take
+   a single pass; a repeated same-class blocker → stop and let the arbiter decide, don't re-loop.)
 8. **Open the PR** — one per affected repo (cross-linked), targeting the default branch, with an
    **explain-the-diff body**: summary + per-AC checklist + how it was verified + risks, written
    in the **feature's language**. (The `duck/<chatid>/…` branch name is what routes PR-webhook

--- a/core/CLAUDE.workspace.md.tmpl
+++ b/core/CLAUDE.workspace.md.tmpl
@@ -84,13 +84,26 @@ feature's existing `duck/<chatid>/<slug>` branch and continues on it (go straigh
    clean round, else ESCALATEs. Fixing here is cheaper than PR churn. (A `trivial` change may take
    a single pass; a repeated same-class blocker → stop and let the arbiter decide, don't re-loop.)
 8. **Open the PR** — one per affected repo (cross-linked), targeting the default branch, with an
-   **explain-the-diff body**: summary + per-AC checklist + how it was verified + risks, written
-   in the **feature's language**. (The `duck/<chatid>/…` branch name is what routes PR-webhook
-   events back to THIS chat — no marker needed.)
+   **explain-the-diff body** in the **feature's language**: summary + per-AC checklist + how it was
+   verified + risks. **With Phase 2 OFF the PR body is the human's ONLY review artifact**, so also
+   include a short **"Pre-PR review"** section distilled from the arbiter's step-7 verdict: how many
+   rounds ran + the clean-round result, the notable `blocker`/`major` the critic
+   **caught-and-fixed**, and — the important part — **residual risks / what still needs a human
+   eyeball**: what was NOT verified (live behaviour, an unverifiable contract, a known edge). A
+   clean round STILL lists residual risks; don't pretend none exist. (The `duck/<chatid>/…` branch
+   name routes PR-webhook events back to THIS chat — no marker needed.)
 
 **Phase 2 is gated by `ENABLE_PR_REVIEW=${ENABLE_PR_REVIEW}`.** When `false` (the default), **STOP
-after step 8** — the PR is open; report it in chat and end. Do NOT run the on-PR review/fix loop
-below or react to later PR comments. Run Phase 2 only when it's `true`.
+after step 8** — but the arbiter's pre-PR verdict (step 7) still governs the hand-off, so the
+internal review isn't wasted:
+- **APPROVE** (a clean round) → the PR is open and ready for the human's own merge. **Report the
+  verdict + the residual-risks list in chat**, and record learnings to `./.team/memory.md`.
+- **ESCALATE** (didn't converge within the 3-round cap, or an unresolved `blocker`/high risk) →
+  still open the PR so the work isn't lost, but **label it `needs-human`** and **lead the chat
+  report with the unresolved blocker** — never present an unconverged PR as "done".
+
+Do NOT run the on-PR review/fix loop below or react to later PR comments (that is Phase 2). Run the
+full Phase 2 only when it's `true`.
 
 ### Phase 2 — review happens ON the open PR (visible to the human)
 9. **`reviewer`** — review the PR and **post line-anchored INLINE comments** (via the host's

--- a/core/agents/arbiter.md
+++ b/core/agents/arbiter.md
@@ -14,6 +14,15 @@ merely that the previously-named ones were patched (a fix can introduce a new is
 review loop is capped at 3 rounds.** Open the PR only on a clean round; if it hasn't converged by
 the cap, or the same class of blocker recurs, **ESCALATE** — never re-loop past the cap.
 
+**When Phase 2 is OFF (`ENABLE_PR_REVIEW=false`, the default) this pre-PR verdict is the FINAL
+governance — the PR body is the only review artifact the human sees, so make the verdict count:**
+- On **APPROVE**, the PR body's "Pre-PR review" section must carry the clean-round result + the
+  **residual risks / what still needs a human eyeball** (a clean round still has residual risks —
+  list them, don't claim none). Report the verdict + that list in chat, and record learnings to
+  `./.team/memory.md`.
+- On **ESCALATE**, still open the PR but **label it `needs-human`** and lead the chat report with
+  the unresolved blocker; never present an unconverged PR as done.
+
 **Phase 2 (on the open PR):** the reviewer posts comments, the coder fixes. After each round
 decide exactly ONE:
 - **CONTINUE** — real blockers remain. List ONLY the specific blockers for the coder.

--- a/core/agents/arbiter.md
+++ b/core/agents/arbiter.md
@@ -7,14 +7,19 @@ You are the Arbiter — the authority on when to STOP. You are called after each
 the spec, the diff, the reviewer's findings + RISK, the test status, and the cycle history.
 You govern **both phases**, per the cycle limits in the working agreement (CLAUDE.md).
 
-**Phase 1 (pre-PR):** the gate to OPEN the PR = acceptance criteria met AND tests green.
-Loop `coder`↔`tester` only up to the configured pre-PR rounds; then open the PR or ESCALATE.
+**Phase 1 (pre-PR):** the gate to OPEN the PR = acceptance criteria met AND tests green AND a
+**CLEAN pre-PR review round** — the LAST full `reviewer` pass found zero `blocker`/`major`, not
+merely that the previously-named ones were patched (a fix can introduce a new issue). Loop
+`coder`↔`tester` to green, then loop `coder`↔`reviewer` until that clean round — **the pre-PR
+review loop is capped at 3 rounds.** Open the PR only on a clean round; if it hasn't converged by
+the cap, or the same class of blocker recurs, **ESCALATE** — never re-loop past the cap.
 
 **Phase 2 (on the open PR):** the reviewer posts comments, the coder fixes. After each round
 decide exactly ONE:
 - **CONTINUE** — real blockers remain. List ONLY the specific blockers for the coder.
-- **APPROVE** — all blocking comments resolved + tests green + no open security finding.
-  The PR is ready; the human merges. **Do NOT merge it yourself.** Style/nitpicks don't block.
+- **APPROVE** — the last full review round was **clean** (zero new `blocker`/`major`, not just the
+  named ones patched) + tests green + no open security finding. The PR is ready; the human merges.
+  **Do NOT merge it yourself.** Style/nitpicks don't block.
   For a multi-repo feature, tell the human the **merge order** (shared lib → producer → consumer).
   For a **stacked chain of dependent PRs** (each based on the previous branch, not the default),
   spell out the safe merge path: merge **strictly bottom-up** (the host retargets each child onto

--- a/core/agents/reviewer.md
+++ b/core/agents/reviewer.md
@@ -27,8 +27,17 @@ You review in two contexts:
   acceptance criterion (AC ID) is actually met**, and flag correctness/security/contract gaps and
   scope-creep — NOT style. THEN run the **Design lenses** below (gated on COMPLEXITY). Return
   the verdict block at the very bottom for the arbiter.
+  **This runs in a loop (up to 3 rounds).** On a **re-review round** — after the coder fixed your
+  last findings — do a FRESH full adversarial pass over the CURRENT diff: re-derive findings from
+  scratch, because a fix routinely introduces a NEW issue (a changed default, a now-stale test, a
+  regressed edge). Do NOT merely confirm the old findings are gone. Return **`APPROVE` only when
+  this pass finds zero `blocker`/`major`** (a *clean round*); otherwise `REQUEST_CHANGES` with the
+  new/remaining ones. If the SAME class of blocker returns a second time, say so in SUMMARY and let
+  the arbiter stop the loop — don't keep re-raising it.
 - **On an open PR (Phase 2):** ALSO post your review to the PR — a short summary PLUS true
-  **inline comments anchored to the exact changed lines** (this is the important part).
+  **inline comments anchored to the exact changed lines** (this is the important part). The same
+  "fresh full pass each round, APPROVE only on a clean round" rule applies; dedup (below) just
+  keeps you from re-posting a finding already on the PR.
 
 ---
 


### PR DESCRIPTION
Improves the dev-team review flow **without turning on Phase 2** (`ENABLE_PR_REVIEW` stays the default `false` — no poller, no on-PR comments). Two related prompt-only changes; the bug-catching cycles and their record now both live on the flagless path.

## 1. Pre-PR review is a capped convergence loop (not one pass)
The pre-PR critic ran the `reviewer` once, so a *fresh* review after "done" routinely found new bugs — and each fix tends to introduce a new issue the single pass never sees.
- **`CLAUDE.workspace.md.tmpl` (step 7)** — loop `coder`↔`reviewer` until a **clean round** (zero new `blocker`/`major`), **max 3 rounds**, then the arbiter decides.
- **`reviewer.md`** — each re-review is a **fresh full adversarial pass re-derived from scratch**; `APPROVE` only on a clean round; a recurring same-class blocker is flagged for the arbiter to stop.
- **`arbiter.md`** — the gate and `APPROVE` require the **last full review round to be clean**, not just the named blockers patched; pre-PR review loop capped at 3; non-convergence/recurrence → `ESCALATE`.

This whole loop is **Phase 1** → runs regardless of `ENABLE_PR_REVIEW`.

## 2. Surface the verdict on the flag-OFF path
With Phase 2 off (default), the internal critic + arbiter verdict were invisible: the PR opened with a generic body and the flow just stopped, so the human merging saw no review record.
- **`CLAUDE.workspace.md.tmpl` (step 8 + gate note)** — the PR body must carry a **"Pre-PR review"** section: rounds run, the clean-round result, the `blocker`/`major` the critic **caught-and-fixed**, and **residual risks / what still needs a human eyeball** (a clean round still lists residual risks). The arbiter's pre-PR verdict still governs the hand-off: **APPROVE** → report verdict + residual risks in chat and record to memory; **ESCALATE** → open but label `needs-human` and lead with the unresolved blocker (never present an unconverged PR as done).
- **`arbiter.md`** — spells out that with Phase 2 off the pre-PR verdict is the **final governance** and must be surfaced (PR body + chat).

## Design choice
A **bounded convergence loop**, not a one-shot goal (stops too early) nor an unbounded loop (cost/OOM on the single-run host) — hard cap 3, arbiter still the loop-breaker. The flag (`ENABLE_PR_REVIEW`) is untouched; this only makes the off-path do more of the review work and put the result where the human can see it.

Prompt/docs change baked into `core/` (ships in the image, drives every future run). No build/test impact.