### PR TITLE
Show file-path tool details relative to the run workdir in progress frame

### DIFF
--- a/core/chat/progress.go
+++ b/core/chat/progress.go
@@ -8,6 +8,7 @@ package chat
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -136,6 +137,11 @@ type Progress struct {
 	elapsed  func() time.Duration
 	ring     []string
 	ringSize int
+	// baseDir is the run's working directory. File-path tool details are shown
+	// relative to it (see repoRelPath) so the progress frame reads
+	// "📖 Read · roost/web/…" instead of the noisy absolute "/workspace/chat_…/…".
+	// An empty baseDir disables relativization (paths are shown unchanged).
+	baseDir string
 	// total counts every activity line ever pushed (not no-op/ignored events), so
 	// Frame can show how many lines have scrolled off above the visible window.
 	total int
@@ -144,14 +150,16 @@ type Progress struct {
 // NewProgress returns a Progress whose header counter reads from elapsed, the
 // time since the run started. Injecting elapsed (rather than calling time.Now
 // internally) keeps Frame deterministic for tests. ringSize <= 0 selects the
-// default.
-func NewProgress(elapsed func() time.Duration, ringSize int) *Progress {
+// default. baseDir is the run's working directory used to shorten file-path tool
+// details to repo-relative form (empty disables it; see repoRelPath).
+func NewProgress(elapsed func() time.Duration, ringSize int, baseDir string) *Progress {
 	if ringSize <= 0 {
 		ringSize = defaultRingSize
 	}
 	return &Progress{
 		elapsed:  elapsed,
 		ringSize: ringSize,
+		baseDir:  baseDir,
 		ring:     make([]string, 0, ringSize),
 	}
 }
@@ -161,7 +169,7 @@ func NewProgress(elapsed func() time.Duration, ringSize int) *Progress {
 // Final / FinalError to render the terminal message. It reports whether the
 // activity ring changed, so callers can skip a redundant edit.
 func (p *Progress) Observe(e claude.Event) bool {
-	line, ok := activityLine(e)
+	line, ok := activityLine(e, p.baseDir)
 	if !ok {
 		return false
 	}
@@ -174,7 +182,7 @@ func (p *Progress) Observe(e claude.Event) bool {
 // upper bound (recentSnippetMax) when stored — enough for any ring position — and
 // Frame() re-caps it tighter per recency. The emoji prefix is added on top of the
 // text budget, so it is never split or counted against the cap.
-func activityLine(e claude.Event) (string, bool) {
+func activityLine(e claude.Event, baseDir string) (string, bool) {
 	switch e.Type {
 	case claude.ToolUse:
 		tool := e.Tool
@@ -182,7 +190,7 @@ func activityLine(e claude.Event) (string, bool) {
 			tool = "tool"
 		}
 		line := tool
-		if detail := toolDetail(tool, e.ToolInput); detail != "" {
+		if detail := toolDetail(tool, e.ToolInput, baseDir); detail != "" {
 			line += toolDetailSeparator + detail
 		}
 		return toolLinePrefix(tool) + truncateRunes(line, recentSnippetMax), true
@@ -209,8 +217,9 @@ func activityLine(e claude.Event) (string, bool) {
 // best-effort and purely cosmetic: any empty, malformed, or unrecognized input
 // yields "" so the caller falls back to the bare tool name. The chosen value is
 // whitespace-collapsed and truncated to toolDetailMax runes so one long command or
-// path can't dominate the line.
-func toolDetail(tool string, input json.RawMessage) string {
+// path can't dominate the line. baseDir (the run's working dir) shortens file-path
+// details to repo-relative form; see repoRelPath.
+func toolDetail(tool string, input json.RawMessage, baseDir string) string {
 	if len(input) == 0 {
 		return ""
 	}
@@ -256,6 +265,13 @@ func toolDetail(tool string, input json.RawMessage) string {
 		raw = strField("subagent_type")
 	}
 
+	// For the file-path tools, shorten the absolute path to repo-relative BEFORE
+	// whitespace-collapse and truncation, so the budget is spent on the meaningful
+	// tail (repo/dir/file) rather than the constant "/workspace/chat_…" prefix.
+	if key == "file_path" {
+		raw = repoRelPath(raw, baseDir)
+	}
+
 	detail := collapseWhitespace(raw)
 	// Redact obvious secret-bearing fragments BEFORE truncation, but ONLY for the
 	// CLI-shaped fields that can actually carry a credential: a shell command or a
@@ -270,6 +286,33 @@ func toolDetail(tool string, input json.RawMessage) string {
 		return ""
 	}
 	return truncateRunes(detail, toolDetailMax)
+}
+
+// repoRelPath shortens an absolute file path to one relative to baseDir (the run's
+// working directory) for the cosmetic progress line, turning the noisy
+// "/workspace/chat_123/roost/web/src/App.tsx" into "roost/web/src/App.tsx" — the
+// repo segment is kept since baseDir is the workspace root, not the repo root. It
+// is deliberately conservative and never fabricates "../.." noise: when the path
+// can't be cleanly expressed under baseDir it returns the input unchanged. The
+// fallbacks (all return path as-is): an empty baseDir (relativization disabled), a
+// filepath.Rel error, or a result that escapes baseDir (starts with ".."). Paths in
+// this codebase are POSIX, so filepath.Rel on linux already yields '/' separators.
+func repoRelPath(path, baseDir string) string {
+	if baseDir == "" {
+		return path
+	}
+	rel, err := filepath.Rel(baseDir, path)
+	if err != nil {
+		return path
+	}
+	// A leading ".." means the path is outside baseDir (e.g. a sibling dir or an
+	// absolute path that doesn't share the prefix); keep the original full path
+	// rather than show "../../something". A bare "." means the path IS baseDir (no
+	// real file_path is the workspace root, but guard it so we never render "·  .").
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return path
+	}
+	return rel
 }
 
 // secretRedactions masks common secret-bearing fragments in a tool detail before

--- a/core/chat/progress_test.go
+++ b/core/chat/progress_test.go
@@ -20,7 +20,7 @@ func fakeClock(d *time.Duration) func() time.Duration {
 
 func TestFrameCounterDrivenByClockNotEvents(t *testing.T) {
 	var elapsed time.Duration
-	p := NewProgress(fakeClock(&elapsed), 5)
+	p := NewProgress(fakeClock(&elapsed), 5, "")
 
 	// No events observed yet: the counter still advances purely from the clock,
 	// proving it is wall-clock driven (the §7.2 frozen-counter fix).
@@ -48,7 +48,7 @@ func TestFrameCounterDrivenByClockNotEvents(t *testing.T) {
 
 func TestActivityRingBounded(t *testing.T) {
 	var elapsed time.Duration
-	p := NewProgress(fakeClock(&elapsed), 3)
+	p := NewProgress(fakeClock(&elapsed), 3, "")
 
 	for _, tool := range []string{"Read", "Grep", "Edit", "Bash", "Write"} {
 		p.Observe(claude.Event{Type: claude.ToolUse, Tool: tool})
@@ -74,7 +74,7 @@ func TestActivityRingBounded(t *testing.T) {
 
 func TestObserveTextAndIgnoredEvents(t *testing.T) {
 	var elapsed time.Duration
-	p := NewProgress(fakeClock(&elapsed), 5)
+	p := NewProgress(fakeClock(&elapsed), 5, "")
 
 	if p.Observe(claude.Event{Type: claude.SystemInit, SessionID: "s1"}) {
 		t.Fatal("SystemInit should not change the ring")
@@ -160,7 +160,7 @@ func TestToolUseDetailEnrichment(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			var elapsed time.Duration
-			p := NewProgress(fakeClock(&elapsed), 5)
+			p := NewProgress(fakeClock(&elapsed), 5, "")
 			p.Observe(claude.Event{Type: claude.ToolUse, Tool: tc.tool, ToolInput: []byte(tc.input)})
 			frame := p.Frame()
 			if !strings.Contains(frame, tc.wantSub) {
@@ -207,7 +207,7 @@ func TestToolLinePrefixPerTool(t *testing.T) {
 
 func TestToolUseDetailCollapsesMultilineCommand(t *testing.T) {
 	var elapsed time.Duration
-	p := NewProgress(fakeClock(&elapsed), 5)
+	p := NewProgress(fakeClock(&elapsed), 5, "")
 	p.Observe(claude.Event{
 		Type:      claude.ToolUse,
 		Tool:      "Bash",
@@ -225,7 +225,7 @@ func TestToolUseDetailTruncatedToBudget(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	detail := toolDetail("Bash", input)
+	detail := toolDetail("Bash", input, "")
 	if got := utf8.RuneCountInString(detail); got != toolDetailMax {
 		t.Fatalf("detail rune count = %d, want %d (truncated with ellipsis)", got, toolDetailMax)
 	}
@@ -353,7 +353,7 @@ func TestToolDetailRedactsSecrets(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			detail := toolDetail(tc.tool, []byte(tc.input))
+			detail := toolDetail(tc.tool, []byte(tc.input), "")
 			if !strings.Contains(detail, tc.wantSub) {
 				t.Fatalf("detail %q does not contain %q", detail, tc.wantSub)
 			}
@@ -396,7 +396,7 @@ func TestToolDetailRedactsQuotedKeySecret(t *testing.T) {
 			if err != nil {
 				t.Fatalf("marshal: %v", err)
 			}
-			detail := toolDetail("Bash", input)
+			detail := toolDetail("Bash", input, "")
 			if strings.Contains(detail, tc.miss) {
 				t.Fatalf("detail leaked JSON-body secret %q: %q", tc.miss, detail)
 			}
@@ -411,15 +411,98 @@ func TestToolDetailNonObjectJSON(t *testing.T) {
 	// Valid JSON that is not an object unmarshals into map[string]any with an
 	// error, so the detail falls back to "" (bare tool name).
 	for _, in := range []string{`"just a string"`, `[1,2,3]`, `42`} {
-		if got := toolDetail("Read", []byte(in)); got != "" {
+		if got := toolDetail("Read", []byte(in), ""); got != "" {
 			t.Fatalf("toolDetail(%q) = %q, want empty", in, got)
 		}
 	}
 }
 
+func TestRepoRelPath(t *testing.T) {
+	cases := []struct {
+		name    string
+		path    string
+		baseDir string
+		want    string
+	}{
+		{
+			name:    "under workdir relativized with repo segment kept",
+			path:    "/workspace/chat_123/roost/web/src/components/SettingsForm.tsx",
+			baseDir: "/workspace/chat_123",
+			want:    "roost/web/src/components/SettingsForm.tsx",
+		},
+		{
+			name:    "outside workdir unchanged",
+			path:    "/etc/passwd",
+			baseDir: "/workspace/chat_123",
+			want:    "/etc/passwd",
+		},
+		{
+			name:    "sibling dir would need leading dotdot so unchanged",
+			path:    "/workspace/chat_999/roost/main.go",
+			baseDir: "/workspace/chat_123",
+			want:    "/workspace/chat_999/roost/main.go",
+		},
+		{
+			name:    "empty baseDir unchanged",
+			path:    "/workspace/chat_123/roost/web/App.tsx",
+			baseDir: "",
+			want:    "/workspace/chat_123/roost/web/App.tsx",
+		},
+		{
+			name:    "non-absolute path under baseDir unchanged",
+			path:    "relative/path.go",
+			baseDir: "/workspace/chat_123",
+			want:    "relative/path.go",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := repoRelPath(tc.path, tc.baseDir); got != tc.want {
+				t.Fatalf("repoRelPath(%q, %q) = %q, want %q", tc.path, tc.baseDir, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestToolDetailFilePathRelativized(t *testing.T) {
+	input, err := json.Marshal(map[string]string{
+		"file_path": "/workspace/chat_123/roost/web/src/components/SettingsForm.tsx",
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	// Under the workdir → repo-relative (repo segment kept).
+	if got := toolDetail("Read", input, "/workspace/chat_123"); got != "roost/web/src/components/SettingsForm.tsx" {
+		t.Fatalf("toolDetail relativized = %q, want repo-relative path", got)
+	}
+	// Empty baseDir → unchanged absolute path.
+	if got := toolDetail("Read", input, ""); got != "/workspace/chat_123/roost/web/src/components/SettingsForm.tsx" {
+		t.Fatalf("toolDetail with empty baseDir = %q, want unchanged absolute path", got)
+	}
+}
+
+func TestFrameRendersFilePathRelative(t *testing.T) {
+	var elapsed time.Duration
+	p := NewProgress(fakeClock(&elapsed), 5, "/workspace/chat_123")
+	input, err := json.Marshal(map[string]string{
+		"file_path": "/workspace/chat_123/roost/web/src/components/SettingsForm.tsx",
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	p.Observe(claude.Event{Type: claude.ToolUse, Tool: "Read", ToolInput: input})
+	frame := p.Frame()
+	if !strings.Contains(frame, "📖 Read · roost/web/src/components/SettingsForm.tsx") {
+		t.Fatalf("frame should render repo-relative Read line, got: %q", frame)
+	}
+	if strings.Contains(frame, "/workspace/chat_123/") {
+		t.Fatalf("frame should not contain the absolute workdir prefix, got: %q", frame)
+	}
+}
+
 func TestActivitySnippetTruncated(t *testing.T) {
 	var elapsed time.Duration
-	p := NewProgress(fakeClock(&elapsed), 5)
+	p := NewProgress(fakeClock(&elapsed), 5, "")
 	// A single (hence most-recent) line longer than recentSnippetMax is capped at
 	// recentSnippetMax; the emoji prefix rides on top of that text budget.
 	long := strings.Repeat("a", recentSnippetMax+200)
@@ -450,7 +533,7 @@ func TestActivitySnippetTruncated(t *testing.T) {
 // same length is truncated to olderSnippetMax.
 func TestPositionalSnippetCaps(t *testing.T) {
 	var elapsed time.Duration
-	p := NewProgress(fakeClock(&elapsed), 5)
+	p := NewProgress(fakeClock(&elapsed), 5, "")
 
 	// Length is longer than olderSnippetMax but shorter than recentSnippetMax, so
 	// it is untruncated only while it is the most-recent line.
@@ -494,7 +577,7 @@ func TestPositionalSnippetCaps(t *testing.T) {
 // assembled frame stays within frameBudgetMax (and therefore below TelegramMaxMessage).
 func TestFrameBudgetNeverExceedsLimit(t *testing.T) {
 	var elapsed time.Duration
-	p := NewProgress(fakeClock(&elapsed), 5)
+	p := NewProgress(fakeClock(&elapsed), 5, "")
 	for i := 0; i < 5; i++ {
 		p.Observe(claude.Event{Type: claude.Text, Text: strings.Repeat("x", recentSnippetMax+500)})
 	}
@@ -514,7 +597,7 @@ func TestFrameBudgetNeverExceedsLimit(t *testing.T) {
 // stored text at recentSnippetMax, which is below the frame budget by design.
 func TestSingleOversizedLineHardTruncated(t *testing.T) {
 	var elapsed time.Duration
-	p := NewProgress(fakeClock(&elapsed), 5)
+	p := NewProgress(fakeClock(&elapsed), 5, "")
 	p.push(thoughtPrefix + strings.Repeat("z", frameBudgetMax+2000))
 	frame := p.Frame()
 	if frame == "" {
@@ -542,7 +625,7 @@ func TestSingleOversizedLineHardTruncated(t *testing.T) {
 func TestFrameBudgetDropsOldestLines(t *testing.T) {
 	var elapsed time.Duration
 	const ring = 20
-	p := NewProgress(fakeClock(&elapsed), ring)
+	p := NewProgress(fakeClock(&elapsed), ring, "")
 	// Each line is a max-length older snippet tagged with its index at the FRONT, so
 	// the tag survives end-truncation and lets us tell which lines were kept.
 	for i := 0; i < ring; i++ {
@@ -593,7 +676,7 @@ func TestFormatElapsed(t *testing.T) {
 // TestFormatElapsedInHeader confirms the humanized form reaches the rendered header.
 func TestFormatElapsedInHeader(t *testing.T) {
 	var elapsed time.Duration
-	p := NewProgress(fakeClock(&elapsed), 5)
+	p := NewProgress(fakeClock(&elapsed), 5, "")
 	elapsed = 1281 * time.Second
 	if got := p.Frame(); !strings.Contains(got, "Working… (21m 21s)") {
 		t.Fatalf("header not humanized: %q", got)
@@ -605,7 +688,7 @@ func TestFormatElapsedInHeader(t *testing.T) {
 func TestElidedIndicatorHiddenWhenAllShown(t *testing.T) {
 	var elapsed time.Duration
 	const ring = 5
-	p := NewProgress(fakeClock(&elapsed), ring)
+	p := NewProgress(fakeClock(&elapsed), ring, "")
 	for i := 0; i < ring; i++ {
 		p.Observe(claude.Event{Type: claude.ToolUse, Tool: "Bash"})
 	}
@@ -620,7 +703,7 @@ func TestElidedIndicatorShownWhenEvicted(t *testing.T) {
 	var elapsed time.Duration
 	const ring = 5
 	const extra = 37
-	p := NewProgress(fakeClock(&elapsed), ring)
+	p := NewProgress(fakeClock(&elapsed), ring, "")
 	for i := 0; i < ring+extra; i++ {
 		p.Observe(claude.Event{Type: claude.ToolUse, Tool: "Bash"})
 	}
@@ -646,7 +729,7 @@ func TestElidedIndicatorShownWhenEvicted(t *testing.T) {
 func TestElidedIndicatorCountsBudgetDrops(t *testing.T) {
 	var elapsed time.Duration
 	const ring = 20
-	p := NewProgress(fakeClock(&elapsed), ring)
+	p := NewProgress(fakeClock(&elapsed), ring, "")
 	for i := 0; i < ring; i++ {
 		p.push(thoughtPrefix + "L" + strconv.Itoa(i) + " " + strings.Repeat("x", olderSnippetMax))
 	}

--- a/core/chat/service.go
+++ b/core/chat/service.go
@@ -345,7 +345,7 @@ func (s *Service) run(ctx context.Context, chatID ChatID, userID int64, prompt s
 	}
 
 	start := s.nowFunc()
-	prog := NewProgress(func() time.Duration { return s.nowFunc().Sub(start) }, 0)
+	prog := NewProgress(func() time.Duration { return s.nowFunc().Sub(start) }, 0, workdir)
 
 	// The anchor: a persistent message that carries the Stop button (a draft can't)
 	// and is later edited into the final answer. It stays static while live progress


### PR DESCRIPTION
## Summary
The live "Working…" progress frame printed file-path tool lines as absolute paths, e.g.
`📖 Read · /workspace/chat_-5214520757/roost/web/src/components/SettingsForm.tsx`. On a phone these
wrap into multi-line walls of `/workspace/chat_<id>/…` noise.

This renders file-path tool details **relative to the run's working directory** instead:

`📖 Read · roost/web/src/components/SettingsForm.tsx`

The working directory is the per-chat workspace root (`/workspace/chat_<id>`), so the repo segment
(`roost`) is retained — paths stay unambiguous across services while shedding the constant prefix.

## Scope
- Affected only the file-path tools: `Read`, `Edit`, `Write`, `NotebookEdit`.
- `Bash` commands, `Grep`/`Glob` patterns, URLs and queries are **unchanged** (the path there lives
  inside a command string, not a standalone field).
- No hardcoded `/workspace` — relativization is computed against the run's actual `Workdir`.

## How it works
- New pure helper `repoRelPath(path, baseDir)` in `core/chat/progress.go`.
- `baseDir` is threaded honestly through `NewProgress → activityLine → toolDetail`; the production
  call site in `core/chat/service.go` passes the run's `workdir`.
- Conservative fallbacks — all return the path **unchanged**, never emitting `../..` noise:
  empty `baseDir`, a `filepath.Rel` error, a result that escapes `baseDir` (`.` / `..` / `../…`),
  or a path outside the workdir.

## Acceptance criteria
- [x] **AC1** — file-path tools render workdir-relative with the repo segment kept
  (`roost/web/src/...`).
- [x] **AC2** — fallbacks return the path unchanged (empty baseDir, `Rel` error, escape-`..`,
  non-absolute); no `../..` noise. Sibling-prefix collision (`/workspace/chat_1` vs
  `/workspace/chat_12/x`) is correctly **not** relativized.
- [x] **AC3** — only file-path tools affected; secret redaction (scoped to `command`/`url`) is
  untouched; no hardcoded paths.

## Verification
- `golangci-lint run ./...` → **0 issues**; `go vet` clean.
- `go test -race ./...` → full suite green (regression guard included).
- New tests: `TestRepoRelPath` (under-workdir, outside, sibling/escape, empty baseDir, non-absolute),
  `TestToolDetailFilePathRelativized`, `TestFrameRendersFilePathRelative` (asserts
  `📖 Read · roost/web/...` and the absence of any absolute prefix in the rendered frame).

## Risks
Low — cosmetic, progress-rendering-only change with conservative fallbacks. No effect on the final
answer, secret redaction, or non-file-path tools.
