### PR TITLE
Graceful drain on deploy + auto-resume of interrupted runs

### DIFF
--- a/adapters/telegram/.env.example
+++ b/adapters/telegram/.env.example
@@ -25,6 +25,8 @@ MAX_CONCURRENT_CHAT_RUNS=4
 # on their own (a run that completes in time delivers its real answer) before
 # cancelling survivors. Must stay below the compose stop_grace_period (75s) so the
 # process self-exits before SIGKILL. Survivors are auto-resumed on the next startup.
+# Capped at 60s (60 + the dispatcher's 10s post-cancel grace = 70 < 75); a higher
+# value is clamped down to 60s at startup with a logged warning.
 SHUTDOWN_DRAIN_SECONDS=45
 # Dev-team loop limits (rendered into the workspace CLAUDE.md at start).
 PRE_PR_CYCLES=5

--- a/adapters/telegram/.env.example
+++ b/adapters/telegram/.env.example
@@ -21,6 +21,11 @@ RATE_LIMIT_REQUESTS=30          # per-user; 0 (or window 0) disables the rate li
 RATE_LIMIT_WINDOW=60            # seconds
 # Chats answered in PARALLEL (each chat stays serial). Caps memory — 1 = fully serial.
 MAX_CONCURRENT_CHAT_RUNS=4
+# Graceful drain on deploy: on SIGTERM, WAIT this long for in-flight runs to finish
+# on their own (a run that completes in time delivers its real answer) before
+# cancelling survivors. Must stay below the compose stop_grace_period (75s) so the
+# process self-exits before SIGKILL. Survivors are auto-resumed on the next startup.
+SHUTDOWN_DRAIN_SECONDS=45
 # Dev-team loop limits (rendered into the workspace CLAUDE.md at start).
 PRE_PR_CYCLES=5
 PR_REVIEW_CYCLES=10

--- a/adapters/telegram/deploy/roles/claude_tg_bot/templates/docker-compose.yml.j2
+++ b/adapters/telegram/deploy/roles/claude_tg_bot/templates/docker-compose.yml.j2
@@ -5,6 +5,10 @@ services:
     pull_policy: always
     container_name: {{ container_prefix }}-bot
     restart: unless-stopped
+    # Graceful drain on deploy: give the bot up to 75s after SIGTERM to drain
+    # in-flight runs before SIGKILL. Must stay strictly above SHUTDOWN_DRAIN_SECONDS
+    # (default 45s) so the process self-exits first. An idle bot still exits at once.
+    stop_grace_period: 75s
     env_file:
       - .env
 {% if gitea_host_ip is defined and gitea_host_ip %}

--- a/adapters/telegram/docker-compose.yml
+++ b/adapters/telegram/docker-compose.yml
@@ -9,6 +9,10 @@ services:
     image: ghcr.io/duckbugio/flock-telegram:latest
     container_name: duck-bot
     restart: unless-stopped
+    # Graceful drain on deploy: give the bot up to 75s after SIGTERM to drain
+    # in-flight runs before SIGKILL. Must stay strictly above SHUTDOWN_DRAIN_SECONDS
+    # (default 45s) so the process self-exits first. An idle bot still exits at once.
+    stop_grace_period: 75s
     env_file: .env
     volumes:
       - claude_home:/home/claude/.claude   # Claude sessions + auth state

--- a/cmd/flock-telegram/main.go
+++ b/cmd/flock-telegram/main.go
@@ -857,43 +857,56 @@ func sendCommandReply(ctx context.Context, b *bot.Bot, chatID int64, text string
 // on startup so the user sees the bot picking the run back up after a restart.
 const resumeNotice = "🔄 Resuming after a restart…"
 
-// resumePending re-injects every interrupted run recorded in the pending store so
-// a run killed mid-flight on a deploy/restart continues WITHOUT the user re-sending
-// their message. For each marker it best-effort edits the dangling anchor into a
-// short resume notice (non-fatal on failure), then re-injects the prompt through
-// the Service (Inject -> Submit), letting the dispatcher's concurrency cap throttle
-// the replay. Markers are intentionally left in place: only a clean terminal clears
-// them, so a crash mid-replay re-resumes on the next boot (idempotent). A nil store
-// (open failed) yields an empty set, so this is a safe no-op.
+// resumePending re-submits every interrupted run recorded in the pending store so
+// a run killed mid-flight (or merely queued behind a running run) on a
+// deploy/restart continues WITHOUT the user re-sending their message. The store
+// holds a per-chat FIFO queue; for each chat its markers are replayed IN ORDER.
+// For each marker it best-effort edits the dangling anchor into a short resume
+// notice (only when an anchor id was captured; non-fatal on failure), then
+// re-submits via ResumePending, which REUSES the marker's id so the resumed run
+// clears the SAME on-disk marker on its clean terminal — never a duplicate. The
+// dispatcher's concurrency cap throttles the replay. Order is best-effort: a
+// concurrent same-chat submit may interleave enqueue vs dispatch order — the
+// guarantee is no-loss, not strict order. Markers are intentionally left in place
+// (cleared by id only on a clean terminal), so a crash mid-replay re-resumes only
+// the not-yet-cleared markers on the next boot, and never double-runs a marker
+// within one boot (each is resumed once). A nil store (open failed) yields an
+// empty set, so this is a safe no-op.
 func resumePending(
 	ctx context.Context, b *bot.Bot, svc *chat.Service, store *pending.FileStore, logger *slog.Logger,
 ) {
 	markers := store.All()
-	if len(markers) == 0 {
+	total := 0
+	for _, q := range markers {
+		total += len(q)
+	}
+	if total == 0 {
 		return
 	}
-	logger.Info("resuming interrupted runs after restart", "count", len(markers))
-	for chatID, m := range markers {
+	logger.Info("resuming interrupted runs after restart", "count", total)
+	for chatID, queue := range markers {
 		id, err := strconv.ParseInt(chatID, 10, 64)
 		if err != nil {
 			logger.Warn("pending: bad chat id; skipping resume", "chat_id", chatID)
 			continue
 		}
-		// Best-effort: turn the frozen "Working…" anchor into a resume notice so the
-		// user knows the run was picked back up. A failed/absent edit never blocks the
-		// resume.
-		if m.AnchorMsgID != "" {
-			if anchor, perr := strconv.Atoi(m.AnchorMsgID); perr == nil {
-				if _, eerr := b.EditMessageText(ctx, &bot.EditMessageTextParams{
-					ChatID:    id,
-					MessageID: anchor,
-					Text:      resumeNotice,
-				}); eerr != nil {
-					logger.Debug("edit dangling anchor on resume", "chat_id", chatID, "error", eerr)
+		for _, m := range queue {
+			// Best-effort: turn the frozen "Working…" anchor into a resume notice so the
+			// user knows the run was picked back up. A failed/absent edit never blocks the
+			// resume.
+			if m.AnchorMsgID != "" {
+				if anchor, perr := strconv.Atoi(m.AnchorMsgID); perr == nil {
+					if _, eerr := b.EditMessageText(ctx, &bot.EditMessageTextParams{
+						ChatID:    id,
+						MessageID: anchor,
+						Text:      resumeNotice,
+					}); eerr != nil {
+						logger.Debug("edit dangling anchor on resume", "chat_id", chatID, "error", eerr)
+					}
 				}
 			}
+			svc.ResumePending(chatID, m)
 		}
-		svc.Inject(chatID, m.Prompt)
 	}
 }
 

--- a/cmd/flock-telegram/main.go
+++ b/cmd/flock-telegram/main.go
@@ -882,13 +882,15 @@ func resumePending(
 		// Best-effort: turn the frozen "Working…" anchor into a resume notice so the
 		// user knows the run was picked back up. A failed/absent edit never blocks the
 		// resume.
-		if anchor, perr := strconv.Atoi(m.AnchorMsgID); perr == nil && m.AnchorMsgID != "" {
-			if _, eerr := b.EditMessageText(ctx, &bot.EditMessageTextParams{
-				ChatID:    id,
-				MessageID: anchor,
-				Text:      resumeNotice,
-			}); eerr != nil {
-				logger.Debug("edit dangling anchor on resume", "chat_id", chatID, "error", eerr)
+		if m.AnchorMsgID != "" {
+			if anchor, perr := strconv.Atoi(m.AnchorMsgID); perr == nil {
+				if _, eerr := b.EditMessageText(ctx, &bot.EditMessageTextParams{
+					ChatID:    id,
+					MessageID: anchor,
+					Text:      resumeNotice,
+				}); eerr != nil {
+					logger.Debug("edit dangling anchor on resume", "chat_id", chatID, "error", eerr)
+				}
 			}
 		}
 		svc.Inject(chatID, m.Prompt)

--- a/cmd/flock-telegram/main.go
+++ b/cmd/flock-telegram/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/duckbugio/flock/core/ghstar"
 	"github.com/duckbugio/flock/core/gitsetup"
 	"github.com/duckbugio/flock/core/nudge"
+	"github.com/duckbugio/flock/core/pending"
 	"github.com/duckbugio/flock/core/poller"
 	"github.com/duckbugio/flock/core/ratelimit"
 	"github.com/duckbugio/flock/core/session"
@@ -37,10 +38,6 @@ import (
 	"github.com/duckbugio/flock/core/workspace"
 	"github.com/duckbugio/flock/internal/config"
 )
-
-// shutdownDrainTimeout bounds how long Shutdown waits for in-flight runs to
-// deliver their final message during graceful drain.
-const shutdownDrainTimeout = 5 * time.Second
 
 // voiceClientTimeout is the shared budget for the voice file download plus the
 // transcription provider call.
@@ -129,6 +126,17 @@ func run() int {
 		logger.Error("open cost store; cost cap disabled", "path", cfg.CostStoreFile(), "error", err)
 		costs = nil
 	}
+
+	// Durable per-chat interrupted-run store (auto-resume after a deploy/restart):
+	// the run path marks a chat at run start and clears it on every clean terminal,
+	// and startup re-injects any marker left by a killed run. Like the cost store, a
+	// store-open failure is non-fatal — log and continue with a nil/no-op store
+	// (auto-resume off) rather than crash-loop the bot.
+	pendings, err := pending.Open(cfg.PendingStoreFile())
+	if err != nil {
+		logger.Error("open pending store; auto-resume disabled", "path", cfg.PendingStoreFile(), "error", err)
+		pendings = nil
+	}
 	logger.Info("guardrails configured",
 		"rate_limit_enabled", cfg.RateLimitEnabled(),
 		"rate_limit_requests", cfg.RateLimitRequests,
@@ -138,14 +146,17 @@ func run() int {
 	)
 
 	disp := dispatch.New(cfg.MaxConcurrentChatRuns)
-	// On shutdown, give in-flight runs a bounded chance to deliver their final
-	// message before exit (graceful drain) rather than dropping them with the
-	// non-waiting Close(). Close() remains available for callers that don't drain.
+	// On shutdown (SIGTERM during a deploy), gracefully drain: WAIT for in-flight
+	// runs to finish on their own up to the configured drain window (so a run that
+	// completes in time delivers its real answer), cancelling only the survivors at
+	// the deadline. The drain window is strictly below the Docker stop_grace_period
+	// (75s) so the process self-exits before SIGKILL; a survivor's marker, written
+	// at run start, drives auto-resume on the next startup.
 	defer func() {
-		drainCtx, cancelDrain := context.WithTimeout(context.Background(), shutdownDrainTimeout)
+		drainCtx, cancelDrain := context.WithTimeout(context.Background(), cfg.ShutdownDrain())
 		defer cancelDrain()
 		if err := disp.Shutdown(drainCtx); err != nil {
-			logger.Warn("dispatcher drain timed out", "error", err)
+			logger.Warn("dispatcher drain deadline reached; survivors cancelled", "error", err)
 		}
 	}()
 
@@ -235,6 +246,7 @@ func run() int {
 		Dispatcher: disp,
 		Workspace:  ws,
 		Sessions:   sessions,
+		Pending:    pendings,
 		Costs:      costs,
 		Outbox:     outbox,
 		StarNudge:  starNudge,
@@ -293,6 +305,15 @@ func run() int {
 			}
 		}()
 	}
+
+	// Auto-resume after restart: re-inject any run that was still in flight when the
+	// process was killed (e.g. SIGKILL after the drain window on a deploy). Each
+	// marker's prompt is replayed through the dispatcher (Inject -> Submit), so the
+	// MaxConcurrentChatRuns cap throttles a resume storm just like live traffic. The
+	// dangling "Working…" anchor is best-effort edited into a brief resume notice
+	// (non-fatal if the edit fails). Markers are NOT cleared here — only a clean
+	// terminal clears them, so a crash mid-replay just re-resumes next boot.
+	resumePending(ctx, b, svc, pendings, logger)
 
 	logger.Info("starting telegram adapter", "username", cfg.TelegramBotUsername)
 	b.Start(ctx)
@@ -829,6 +850,48 @@ func stopCommandHandler(cfg config.Config, svc *chat.Service) bot.HandlerFunc {
 func sendCommandReply(ctx context.Context, b *bot.Bot, chatID int64, text string) {
 	if _, err := b.SendMessage(ctx, &bot.SendMessageParams{ChatID: chatID, Text: text}); err != nil {
 		slog.Debug("send command reply", "error", err)
+	}
+}
+
+// resumeNotice is the brief message the dangling "Working…" anchor is edited into
+// on startup so the user sees the bot picking the run back up after a restart.
+const resumeNotice = "🔄 Resuming after a restart…"
+
+// resumePending re-injects every interrupted run recorded in the pending store so
+// a run killed mid-flight on a deploy/restart continues WITHOUT the user re-sending
+// their message. For each marker it best-effort edits the dangling anchor into a
+// short resume notice (non-fatal on failure), then re-injects the prompt through
+// the Service (Inject -> Submit), letting the dispatcher's concurrency cap throttle
+// the replay. Markers are intentionally left in place: only a clean terminal clears
+// them, so a crash mid-replay re-resumes on the next boot (idempotent). A nil store
+// (open failed) yields an empty set, so this is a safe no-op.
+func resumePending(
+	ctx context.Context, b *bot.Bot, svc *chat.Service, store *pending.FileStore, logger *slog.Logger,
+) {
+	markers := store.All()
+	if len(markers) == 0 {
+		return
+	}
+	logger.Info("resuming interrupted runs after restart", "count", len(markers))
+	for chatID, m := range markers {
+		id, err := strconv.ParseInt(chatID, 10, 64)
+		if err != nil {
+			logger.Warn("pending: bad chat id; skipping resume", "chat_id", chatID)
+			continue
+		}
+		// Best-effort: turn the frozen "Working…" anchor into a resume notice so the
+		// user knows the run was picked back up. A failed/absent edit never blocks the
+		// resume.
+		if anchor, perr := strconv.Atoi(m.AnchorMsgID); perr == nil && m.AnchorMsgID != "" {
+			if _, eerr := b.EditMessageText(ctx, &bot.EditMessageTextParams{
+				ChatID:    id,
+				MessageID: anchor,
+				Text:      resumeNotice,
+			}); eerr != nil {
+				logger.Debug("edit dangling anchor on resume", "chat_id", chatID, "error", eerr)
+			}
+		}
+		svc.Inject(chatID, m.Prompt)
 	}
 }
 

--- a/cmd/flock-telegram/main.go
+++ b/cmd/flock-telegram/main.go
@@ -152,6 +152,12 @@ func run() int {
 	// the deadline. The drain window is strictly below the Docker stop_grace_period
 	// (75s) so the process self-exits before SIGKILL; a survivor's marker, written
 	// at run start, drives auto-resume on the next startup.
+	if cfg.ShutdownDrainClamped() {
+		logger.Warn("SHUTDOWN_DRAIN_SECONDS above cap; clamped",
+			"configured_seconds", cfg.ShutdownDrainSeconds,
+			"effective", cfg.ShutdownDrain(),
+		)
+	}
 	defer func() {
 		drainCtx, cancelDrain := context.WithTimeout(context.Background(), cfg.ShutdownDrain())
 		defer cancelDrain()
@@ -310,9 +316,11 @@ func run() int {
 	// process was killed (e.g. SIGKILL after the drain window on a deploy). Each
 	// marker's prompt is replayed through the dispatcher (Inject -> Submit), so the
 	// MaxConcurrentChatRuns cap throttles a resume storm just like live traffic. The
-	// dangling "Working…" anchor is best-effort edited into a brief resume notice
-	// (non-fatal if the edit fails). Markers are NOT cleared here — only a clean
-	// terminal clears them, so a crash mid-replay just re-resumes next boot.
+	// dangling "Working…" anchor is best-effort deleted (non-fatal); the resumed run
+	// posts its own fresh anchor. Markers are NOT cleared here — only a clean
+	// terminal clears them, so a crash mid-replay just re-resumes next boot. Run
+	// SYNCHRONOUSLY before b.Start so resumed work is queued ahead of new live
+	// messages; this ordering is intentional.
 	resumePending(ctx, b, svc, pendings, logger)
 
 	logger.Info("starting telegram adapter", "username", cfg.TelegramBotUsername)
@@ -853,18 +861,16 @@ func sendCommandReply(ctx context.Context, b *bot.Bot, chatID int64, text string
 	}
 }
 
-// resumeNotice is the brief message the dangling "Working…" anchor is edited into
-// on startup so the user sees the bot picking the run back up after a restart.
-const resumeNotice = "🔄 Resuming after a restart…"
-
 // resumePending re-submits every interrupted run recorded in the pending store so
 // a run killed mid-flight (or merely queued behind a running run) on a
 // deploy/restart continues WITHOUT the user re-sending their message. The store
 // holds a per-chat FIFO queue; for each chat its markers are replayed IN ORDER.
-// For each marker it best-effort edits the dangling anchor into a short resume
-// notice (only when an anchor id was captured; non-fatal on failure), then
-// re-submits via ResumePending, which REUSES the marker's id so the resumed run
-// clears the SAME on-disk marker on its clean terminal — never a duplicate. The
+// For each marker it best-effort DELETES the dangling "Working…" anchor (only
+// when an anchor id was captured; non-fatal on failure) so the frozen progress
+// message disappears, then re-submits via ResumePending, which REUSES the
+// marker's id so the resumed run clears the SAME on-disk marker on its clean
+// terminal — never a duplicate. The resumed run posts its own fresh "Working…"
+// anchor as usual, so the user immediately sees live activity. The
 // dispatcher's concurrency cap throttles the replay. Order is best-effort: a
 // concurrent same-chat submit may interleave enqueue vs dispatch order — the
 // guarantee is no-loss, not strict order. Markers are intentionally left in place
@@ -891,17 +897,16 @@ func resumePending(
 			continue
 		}
 		for _, m := range queue {
-			// Best-effort: turn the frozen "Working…" anchor into a resume notice so the
-			// user knows the run was picked back up. A failed/absent edit never blocks the
-			// resume.
+			// Best-effort: delete the frozen "Working…" anchor so the stale progress
+			// message disappears; the resumed run posts its own fresh anchor below. A
+			// failed/absent delete never blocks the resume.
 			if m.AnchorMsgID != "" {
 				if anchor, perr := strconv.Atoi(m.AnchorMsgID); perr == nil {
-					if _, eerr := b.EditMessageText(ctx, &bot.EditMessageTextParams{
+					if _, derr := b.DeleteMessage(ctx, &bot.DeleteMessageParams{
 						ChatID:    id,
 						MessageID: anchor,
-						Text:      resumeNotice,
-					}); eerr != nil {
-						logger.Debug("edit dangling anchor on resume", "chat_id", chatID, "error", eerr)
+					}); derr != nil {
+						logger.Debug("delete dangling anchor on resume", "chat_id", chatID, "error", derr)
 					}
 				}
 			}

--- a/core/chat/commands.go
+++ b/core/chat/commands.go
@@ -28,5 +28,8 @@ func (s *Service) StopChat(chatID ChatID) bool {
 	}
 	s.mu.Unlock()
 	s.dispatch.Cancel(chatID)
+	// Purge the lane's markers too: /stop drops the running run AND any queued jobs,
+	// none of which the user wants resumed (there is no resubmit to preserve).
+	s.clearLanePending(chatID)
 	return running
 }

--- a/core/chat/service.go
+++ b/core/chat/service.go
@@ -10,6 +10,7 @@ package chat
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"strconv"
 	"sync"
@@ -18,6 +19,8 @@ import (
 
 	"github.com/duckbugio/flock/core/claude"
 	"github.com/duckbugio/flock/core/cost"
+	"github.com/duckbugio/flock/core/dispatch"
+	"github.com/duckbugio/flock/core/pending"
 )
 
 // tickInterval is how often the wall-clock ticker refreshes the progress frame
@@ -69,6 +72,17 @@ type sessionStore interface {
 	Delete(chatID ChatID) error
 }
 
+// pendingStore persists each chat's "interrupted run" marker so a run killed
+// mid-flight (e.g. SIGKILL after the drain window on a deploy) is auto-resumed on
+// the next startup. *pending.FileStore satisfies it. The marker is written at run
+// START (as early as possible) and cleared in finish on EVERY terminal path, so a
+// stopped or finished run is never resumed and the run-start write is the only
+// writer. A nil store disables the feature (all three calls are safe no-ops).
+type pendingStore interface {
+	Set(chatID ChatID, marker pending.Marker) error
+	Delete(chatID ChatID) error
+}
+
 // retryAfterFunc classifies a transport delivery error as a rate-limit back-off:
 // it returns the duration to wait and true when the error is a "too many
 // requests" signal the Service should honor before retrying, or false otherwise.
@@ -89,6 +103,7 @@ type Service struct {
 	dispatch   dispatcher
 	workspace  workspaceEnsurer
 	sessions   sessionStore
+	pending    pendingStore
 	costs      *cost.Store
 	outbox     *Sweeper
 	nudge      *starNudge
@@ -113,6 +128,10 @@ type Config struct {
 	// Sessions persists chatID -> session_id for --resume continuity. May be nil
 	// (continuity disabled: every run starts fresh and nothing is stored).
 	Sessions sessionStore
+	// Pending persists each chat's interrupted-run marker so a run killed
+	// mid-flight on a deploy is auto-resumed on the next startup. May be nil
+	// (auto-resume disabled: nothing is marked or cleared).
+	Pending pendingStore
 	// Costs accumulates each run's USD cost per user for the cumulative cost cap.
 	// May be nil (cost tracking disabled: runs record nothing). A nil *cost.Store
 	// is itself a no-op, so either a nil interface value or a nil store is safe.
@@ -163,6 +182,7 @@ func New(cfg Config) *Service {
 		dispatch:   cfg.Dispatcher,
 		workspace:  cfg.Workspace,
 		sessions:   cfg.Sessions,
+		pending:    cfg.Pending,
 		costs:      cfg.Costs,
 		outbox:     cfg.Outbox,
 		nudge:      newStarNudge(cfg.StarNudge, cfg.Transport, log),
@@ -312,6 +332,15 @@ func (s *Service) run(ctx context.Context, chatID ChatID, userID int64, prompt s
 	}
 	opts.Workdir = workdir
 
+	// Persist the interrupted-run marker as early as possible — right after the
+	// workspace resolves and BEFORE the run can be torn down — so a run killed at
+	// the drain deadline (or even before SystemInit) always leaves a resumable
+	// prompt behind. The anchor id is not known yet (the anchor is sent below); it
+	// is filled in once available. finish clears the marker on every terminal path,
+	// and run-start is the ONLY writer, so a finished/stopped run is never resumed.
+	startedAt := s.nowFunc()
+	s.markPending(chatID, pending.Marker{Prompt: prompt, StartedAt: startedAt.UnixMilli()})
+
 	// Resume this chat's stored Claude session so the run continues its context
 	// (empty = a fresh session). Continuity survives restarts because the store is
 	// durable and reloaded on startup. resuming records whether THIS run carried a
@@ -356,6 +385,14 @@ func (s *Service) run(ctx context.Context, chatID ChatID, userID int64, prompt s
 		// Without an anchor we can still deliver the result; keep going.
 		s.log.Error("send anchor message", "error", err)
 		progressMsgID = ""
+	}
+	// Record the anchor id on the marker now that it is known, so a restart can
+	// best-effort edit the dangling "Working…" message into a resume notice. The
+	// prompt was already persisted before runner.Run; this only enriches it.
+	if progressMsgID != "" {
+		s.markPending(chatID, pending.Marker{
+			Prompt: prompt, AnchorMsgID: progressMsgID, StartedAt: startedAt.UnixMilli(),
+		})
 	}
 
 	ticker := time.NewTicker(s.tick)
@@ -531,6 +568,30 @@ func (s *Service) storeSession(chatID ChatID, sessionID string) {
 	}
 }
 
+// markPending records (or refreshes) chatID's interrupted-run marker. A nil
+// store is a no-op. A write failure is logged but never aborts the run — a lost
+// marker only costs this run its auto-resume, it does not break delivery.
+func (s *Service) markPending(chatID ChatID, marker pending.Marker) {
+	if s.pending == nil {
+		return
+	}
+	if err := s.pending.Set(chatID, marker); err != nil {
+		s.log.Error("persist pending marker", "chat_id", chatID, "error", err)
+	}
+}
+
+// clearPending removes chatID's interrupted-run marker on a terminal so a
+// finished or stopped run is NOT auto-resumed after a later restart. A nil store
+// is a no-op; a delete failure is logged but never aborts terminal delivery.
+func (s *Service) clearPending(chatID ChatID) {
+	if s.pending == nil {
+		return
+	}
+	if err := s.pending.Delete(chatID); err != nil {
+		s.log.Error("clear pending marker", "chat_id", chatID, "error", err)
+	}
+}
+
 // finish renders the terminal message and replaces the progress message with it
 // (chunked when the answer exceeds the platform's message size limit).
 func (s *Service) finish(
@@ -539,6 +600,19 @@ func (s *Service) finish(
 	// Use a background context for delivery: the run ctx may be cancelled by Stop
 	// or shutdown, but the final message should still reach the user.
 	deliverCtx := context.WithoutCancel(ctx)
+	// Clear the interrupted-run marker on every CLEAN terminal (normal Result,
+	// RunError, timeout, user Stop / /stop / edit-supersede) so a finished or
+	// deliberately stopped run is NOT auto-resumed after a later restart. The ONE
+	// exception is a terminal caused by the dispatcher SHUTTING DOWN the process
+	// (drain-deadline cancel / Close): that run was killed by a deploy/restart, so
+	// its marker must SURVIVE to drive the auto-resume — we keep it and let the next
+	// startup re-inject. The two are told apart by the cancellation cause: a
+	// per-chat Stop/supersede cancels with context.Canceled, a shutdown with
+	// dispatch.ErrShutdown. Run-start is the only writer, so a cleared run stays
+	// cleared.
+	if !errors.Is(context.Cause(ctx), dispatch.ErrShutdown) {
+		s.clearPending(chatID)
+	}
 	// Clear the live draft preview (empty text) so it doesn't linger beside the
 	// persisted answer. Best-effort; harmless if no draft was ever streamed.
 	_ = s.chat.StreamDraft(deliverCtx, chatID, runID, "", false)

--- a/core/chat/service.go
+++ b/core/chat/service.go
@@ -72,15 +72,21 @@ type sessionStore interface {
 	Delete(chatID ChatID) error
 }
 
-// pendingStore persists each chat's "interrupted run" marker so a run killed
-// mid-flight (e.g. SIGKILL after the drain window on a deploy) is auto-resumed on
-// the next startup. *pending.FileStore satisfies it. The marker is written at run
-// START (as early as possible) and cleared in finish on EVERY terminal path, so a
-// stopped or finished run is never resumed and the run-start write is the only
-// writer. A nil store disables the feature (all three calls are safe no-ops).
+// pendingStore persists each chat's "interrupted run" marker QUEUE so a run
+// killed mid-flight (e.g. SIGKILL after the drain window on a deploy) OR merely
+// queued behind a running run is auto-resumed on the next startup.
+// *pending.FileStore satisfies it. A marker is enqueued at SUBMIT time (so a
+// queued-but-never-started run is captured), enriched with its anchor id once
+// known, and cleared BY ID on every clean terminal (so a stale run can't remove a
+// newer queued run's marker). The whole lane is cleared at once when the user
+// intentionally purges it (Stop / edit-supersede). A nil store disables the
+// feature (every call is a safe no-op).
 type pendingStore interface {
-	Set(chatID ChatID, marker pending.Marker) error
-	Delete(chatID ChatID) error
+	Enqueue(chatID ChatID, marker pending.Marker) (string, error)
+	SetAnchor(chatID ChatID, id, anchorMsgID string) error
+	Remove(chatID ChatID, id string) error
+	Clear(chatID ChatID) error
+	All() map[ChatID][]pending.Marker
 }
 
 // retryAfterFunc classifies a transport delivery error as a rate-limit back-off:
@@ -224,8 +230,13 @@ func (s *Service) HandleMedia(
 	s.mu.Lock()
 	s.lastMsg[chatID] = msgID
 	s.mu.Unlock()
+	// Enqueue the interrupted-run marker BEFORE Submit so a run that is only queued
+	// (behind a still-running run in the same chat) when the process is killed on a
+	// deploy is captured too — a queued job never reaches run-start to mark itself.
+	// The run clears this exact marker by id on its clean terminal.
+	id := s.enqueuePending(chatID, prompt)
 	s.dispatch.Submit(chatID, func(ctx context.Context) {
-		s.run(ctx, chatID, userID, prompt, images)
+		s.run(ctx, chatID, userID, prompt, images, id)
 	})
 }
 
@@ -237,8 +248,24 @@ func (s *Service) HandleMedia(
 // allow-listed user holds); these synthetic relays are rare and are not rate-/
 // cost-gated on the inbound path.
 func (s *Service) Inject(chatID ChatID, prompt string) {
+	// Enqueue before Submit so a poller-injected run is captured for auto-resume
+	// too (it should resume if killed mid-flight, same as a user message).
+	id := s.enqueuePending(chatID, prompt)
 	s.dispatch.Submit(chatID, func(ctx context.Context) {
-		s.run(ctx, chatID, 0, prompt, nil)
+		s.run(ctx, chatID, 0, prompt, nil, id)
+	})
+}
+
+// ResumePending re-submits an interrupted run recorded in the pending store,
+// REUSING the marker's existing id rather than enqueuing a new one. This is what
+// makes startup replay idempotent: the resumed run clears the SAME on-disk marker
+// (Remove by id) on its clean terminal instead of creating a duplicate, so a
+// crash mid-replay only re-resumes the markers a finished run has not yet cleared.
+// It deliberately does not touch edit-tracking state (like Inject), so replay
+// never interferes with a real user's supersede logic.
+func (s *Service) ResumePending(chatID ChatID, m pending.Marker) {
+	s.dispatch.Submit(chatID, func(ctx context.Context) {
+		s.run(ctx, chatID, 0, m.Prompt, nil, m.ID)
 	})
 }
 
@@ -277,9 +304,17 @@ func (s *Service) HandleEditMedia(
 		// jobs) so the stale message can't run as a duplicate; the in-flight run
 		// unwinds with a "Stopped" terminal, then the resubmitted job runs.
 		s.dispatch.Cancel(chatID)
+		// Cancel purges the whole lane, so its enqueued markers must go too —
+		// otherwise the dropped queued runs would auto-resume on a later restart. The
+		// cancelled run's async finish clears its own marker BY ID, so it cannot touch
+		// the new successor enqueued below.
+		s.clearLanePending(chatID)
 	}
+	// Enqueue the new marker after any lane purge so the resubmitted run is captured
+	// for auto-resume; the run clears this exact id on its clean terminal.
+	id := s.enqueuePending(chatID, prompt)
 	s.dispatch.Submit(chatID, func(ctx context.Context) {
-		s.run(ctx, chatID, userID, prompt, images)
+		s.run(ctx, chatID, userID, prompt, images, id)
 	})
 }
 
@@ -295,6 +330,10 @@ func (s *Service) Stop(runID string) bool {
 		return false
 	}
 	s.dispatch.Cancel(chatID)
+	// Purge the whole lane's markers: Stop cancels the running run AND drops any
+	// still-queued jobs, and the user does not want any of them resumed (there is
+	// no resubmit to preserve).
+	s.clearLanePending(chatID)
 	return true
 }
 
@@ -305,7 +344,9 @@ func (s *Service) Stop(runID string) bool {
 // shutdown.
 //
 //nolint:gocyclo // orchestrates the single-run lifecycle with best-effort fallbacks.
-func (s *Service) run(ctx context.Context, chatID ChatID, userID int64, prompt string, images []claude.ImageInput) {
+func (s *Service) run(
+	ctx context.Context, chatID ChatID, userID int64, prompt string, images []claude.ImageInput, markerID string,
+) {
 	runID := strconv.FormatUint(s.runSeq.Add(1), 10)
 	s.mu.Lock()
 	s.runChat[runID] = chatID
@@ -325,6 +366,9 @@ func (s *Service) run(ctx context.Context, chatID ChatID, userID int64, prompt s
 	workdir, err := s.workspace.Ensure(chatID)
 	if err != nil {
 		s.log.Error("ensure workspace", "chat_id", chatID, "error", err)
+		// A marker was enqueued at submit, but this run never starts — clear it (by
+		// id, gated on shutdown like finish) so a workspace failure is not resumed.
+		s.removePendingUnlessShutdown(ctx, chatID, markerID)
 		if _, sErr := s.chat.Send(ctx, chatID, FinalError(err), "", true); sErr != nil {
 			s.log.Error("send workspace error", "error", sErr)
 		}
@@ -332,15 +376,11 @@ func (s *Service) run(ctx context.Context, chatID ChatID, userID int64, prompt s
 	}
 	opts.Workdir = workdir
 
-	// Persist the interrupted-run marker as early as possible — right after the
-	// workspace resolves and BEFORE the run can be torn down — so a run killed at
-	// the drain deadline (or even before SystemInit) always leaves a resumable
-	// prompt behind. The anchor id is not known yet (the anchor is sent below); it
-	// is filled in once available. Every terminal that wrote a marker clears it on a
-	// clean terminal (finish, or clearPendingUnlessShutdown on an early return), and
-	// run-start is the ONLY writer, so a finished/stopped run is never resumed.
-	startedAt := s.nowFunc()
-	s.markPending(chatID, pending.Marker{Prompt: prompt, StartedAt: startedAt.UnixMilli()})
+	// The interrupted-run marker already exists: it was enqueued at SUBMIT time (so
+	// a still-queued run is captured too), not at run start. This run clears that
+	// exact marker by id on its clean terminal, and enriches it with the anchor id
+	// once the anchor is sent below. A shutdown-caused terminal keeps the marker so
+	// the next startup auto-resumes it.
 
 	// Resume this chat's stored Claude session so the run continues its context
 	// (empty = a fresh session). Continuity survives restarts because the store is
@@ -369,9 +409,9 @@ func (s *Service) run(ctx context.Context, chatID ChatID, userID int64, prompt s
 	if err != nil {
 		s.log.Error("start run", "error", err)
 		// A spawn failure is a clean (non-shutdown) terminal that never reaches
-		// finish, so clear the marker we wrote above — gated exactly like finish so a
+		// finish, so clear this run's marker by id — gated exactly like finish so a
 		// shutdown-caused start failure still keeps its marker and auto-resumes.
-		s.clearPendingUnlessShutdown(ctx, chatID)
+		s.removePendingUnlessShutdown(ctx, chatID, markerID)
 		if _, sErr := s.chat.Send(ctx, chatID, FinalError(err), "", true); sErr != nil {
 			s.log.Error("send start error", "error", sErr)
 		}
@@ -393,11 +433,10 @@ func (s *Service) run(ctx context.Context, chatID ChatID, userID int64, prompt s
 	}
 	// Record the anchor id on the marker now that it is known, so a restart can
 	// best-effort edit the dangling "Working…" message into a resume notice. The
-	// prompt was already persisted before runner.Run; this only enriches it.
+	// prompt was already persisted at submit; this only enriches the same entry by
+	// id (a no-op if the marker was already cleared).
 	if progressMsgID != "" {
-		s.markPending(chatID, pending.Marker{
-			Prompt: prompt, AnchorMsgID: progressMsgID, StartedAt: startedAt.UnixMilli(),
-		})
+		s.setAnchorPending(chatID, markerID, progressMsgID)
 	}
 
 	ticker := time.NewTicker(s.tick)
@@ -516,7 +555,7 @@ loop:
 	// case their NEXT request is denied (the crossing request still ran).
 	s.recordCost(userID, finalResult)
 
-	s.finish(ctx, chatID, progressMsgID, runID, finalResult, finalErr, ctx.Err())
+	s.finish(ctx, chatID, progressMsgID, runID, markerID, finalResult, finalErr, ctx.Err())
 
 	// Self-heal a stale/poisoned resume id: when a run that USED a resume session
 	// id terminates with an is_error Result, drop the stored session for this chat
@@ -573,59 +612,85 @@ func (s *Service) storeSession(chatID ChatID, sessionID string) {
 	}
 }
 
-// markPending records (or refreshes) chatID's interrupted-run marker. A nil
-// store is a no-op. A write failure is logged but never aborts the run — a lost
-// marker only costs this run its auto-resume, it does not break delivery.
-func (s *Service) markPending(chatID ChatID, marker pending.Marker) {
+// enqueuePending appends a fresh interrupted-run marker for chatID at submit time
+// and returns its process-unique id (used to clear the exact entry on a
+// terminal). A nil store or a write failure yields "" (the run still proceeds; a
+// lost marker only costs it its auto-resume, it does not break delivery).
+func (s *Service) enqueuePending(chatID ChatID, prompt string) string {
 	if s.pending == nil {
+		return ""
+	}
+	id, err := s.pending.Enqueue(chatID, pending.Marker{Prompt: prompt, StartedAt: s.nowFunc().UnixMilli()})
+	if err != nil {
+		s.log.Error("enqueue pending marker", "chat_id", chatID, "error", err)
+		return ""
+	}
+	return id
+}
+
+// setAnchorPending records the anchor message id on the marker with the given id
+// so a restart can edit the dangling "Working…" message into a resume notice. A
+// nil store, an empty id, or a missing marker is a harmless no-op; a write
+// failure is logged but never aborts the run.
+func (s *Service) setAnchorPending(chatID ChatID, id, anchorMsgID string) {
+	if s.pending == nil || id == "" {
 		return
 	}
-	if err := s.pending.Set(chatID, marker); err != nil {
-		s.log.Error("persist pending marker", "chat_id", chatID, "error", err)
+	if err := s.pending.SetAnchor(chatID, id, anchorMsgID); err != nil {
+		s.log.Error("set pending anchor", "chat_id", chatID, "error", err)
 	}
 }
 
-// clearPending removes chatID's interrupted-run marker on a terminal so a
-// finished or stopped run is NOT auto-resumed after a later restart. A nil store
-// is a no-op; a delete failure is logged but never aborts terminal delivery.
-func (s *Service) clearPending(chatID ChatID) {
-	if s.pending == nil {
+// removePendingUnlessShutdown clears this run's marker BY ID on a CLEAN terminal
+// but keeps it when the terminal was caused by the dispatcher SHUTTING DOWN the
+// process (drain-deadline cancel / Close): such a run was killed by a
+// deploy/restart, so its marker must SURVIVE to drive the auto-resume. The two
+// are told apart by the cancellation cause — a per-chat Stop/supersede cancels
+// with context.Canceled, a shutdown with dispatch.ErrShutdown. Clearing by id
+// means a stale/cancelled run can never remove a newer queued run's marker. A nil
+// store or an empty id is a no-op; a remove failure is logged but never aborts
+// terminal delivery.
+func (s *Service) removePendingUnlessShutdown(ctx context.Context, chatID ChatID, id string) {
+	if s.pending == nil || id == "" {
 		return
 	}
-	if err := s.pending.Delete(chatID); err != nil {
+	if errors.Is(context.Cause(ctx), dispatch.ErrShutdown) {
+		return
+	}
+	if err := s.pending.Remove(chatID, id); err != nil {
 		s.log.Error("clear pending marker", "chat_id", chatID, "error", err)
 	}
 }
 
-// clearPendingUnlessShutdown clears chatID's marker on a CLEAN terminal but
-// keeps it when the terminal was caused by the dispatcher SHUTTING DOWN the
-// process (drain-deadline cancel / Close): such a run was killed by a
-// deploy/restart, so its marker must SURVIVE to drive the auto-resume. The two
-// are told apart by the cancellation cause — a per-chat Stop/supersede cancels
-// with context.Canceled, a shutdown with dispatch.ErrShutdown. Every terminal
-// that wrote a marker and does NOT route through finish must call this so a
-// finished/stopped/spawn-failed run is never resumed.
-func (s *Service) clearPendingUnlessShutdown(ctx context.Context, chatID ChatID) {
-	if !errors.Is(context.Cause(ctx), dispatch.ErrShutdown) {
-		s.clearPending(chatID)
+// clearLanePending purges ALL of chatID's interrupted-run markers (the whole
+// lane) unconditionally. Used by Stop/StopChat/edit-supersede, where the user
+// intentionally drops every queued+running job for the chat and there is no
+// resubmit to preserve. A nil store is a no-op; a failure is logged but never
+// aborts the caller.
+func (s *Service) clearLanePending(chatID ChatID) {
+	if s.pending == nil {
+		return
+	}
+	if err := s.pending.Clear(chatID); err != nil {
+		s.log.Error("clear pending lane", "chat_id", chatID, "error", err)
 	}
 }
 
 // finish renders the terminal message and replaces the progress message with it
 // (chunked when the answer exceeds the platform's message size limit).
 func (s *Service) finish(
-	ctx context.Context, chatID ChatID, progressMsgID MessageID, runID string, res *claude.RunResult, runErr, ctxErr error,
+	ctx context.Context, chatID ChatID, progressMsgID MessageID, runID, markerID string,
+	res *claude.RunResult, runErr, ctxErr error,
 ) {
 	// Use a background context for delivery: the run ctx may be cancelled by Stop
 	// or shutdown, but the final message should still reach the user.
 	deliverCtx := context.WithoutCancel(ctx)
-	// Clear the interrupted-run marker on this CLEAN terminal (normal Result,
-	// RunError, timeout, user Stop / /stop / edit-supersede) so a finished or
-	// deliberately stopped run is NOT auto-resumed after a later restart, while a
-	// shutdown-caused terminal keeps its marker to drive the auto-resume. See
-	// clearPendingUnlessShutdown. Run-start is the only writer, so a cleared run
-	// stays cleared.
-	s.clearPendingUnlessShutdown(ctx, chatID)
+	// Clear this run's interrupted-run marker by id on this CLEAN terminal (normal
+	// Result, RunError, timeout) so a finished run is NOT auto-resumed after a later
+	// restart, while a shutdown-caused terminal keeps its marker to drive the
+	// auto-resume. See removePendingUnlessShutdown. Clearing by id means this run
+	// can never remove a newer queued run's marker.
+	s.removePendingUnlessShutdown(ctx, chatID, markerID)
 	// Clear the live draft preview (empty text) so it doesn't linger beside the
 	// persisted answer. Best-effort; harmless if no draft was ever streamed.
 	_ = s.chat.StreamDraft(deliverCtx, chatID, runID, "", false)

--- a/core/chat/service.go
+++ b/core/chat/service.go
@@ -336,8 +336,9 @@ func (s *Service) run(ctx context.Context, chatID ChatID, userID int64, prompt s
 	// workspace resolves and BEFORE the run can be torn down — so a run killed at
 	// the drain deadline (or even before SystemInit) always leaves a resumable
 	// prompt behind. The anchor id is not known yet (the anchor is sent below); it
-	// is filled in once available. finish clears the marker on every terminal path,
-	// and run-start is the ONLY writer, so a finished/stopped run is never resumed.
+	// is filled in once available. Every terminal that wrote a marker clears it on a
+	// clean terminal (finish, or clearPendingUnlessShutdown on an early return), and
+	// run-start is the ONLY writer, so a finished/stopped run is never resumed.
 	startedAt := s.nowFunc()
 	s.markPending(chatID, pending.Marker{Prompt: prompt, StartedAt: startedAt.UnixMilli()})
 
@@ -367,6 +368,10 @@ func (s *Service) run(ctx context.Context, chatID ChatID, userID int64, prompt s
 	events, err := s.runner.Run(ctx, prompt, opts)
 	if err != nil {
 		s.log.Error("start run", "error", err)
+		// A spawn failure is a clean (non-shutdown) terminal that never reaches
+		// finish, so clear the marker we wrote above — gated exactly like finish so a
+		// shutdown-caused start failure still keeps its marker and auto-resumes.
+		s.clearPendingUnlessShutdown(ctx, chatID)
 		if _, sErr := s.chat.Send(ctx, chatID, FinalError(err), "", true); sErr != nil {
 			s.log.Error("send start error", "error", sErr)
 		}
@@ -592,6 +597,20 @@ func (s *Service) clearPending(chatID ChatID) {
 	}
 }
 
+// clearPendingUnlessShutdown clears chatID's marker on a CLEAN terminal but
+// keeps it when the terminal was caused by the dispatcher SHUTTING DOWN the
+// process (drain-deadline cancel / Close): such a run was killed by a
+// deploy/restart, so its marker must SURVIVE to drive the auto-resume. The two
+// are told apart by the cancellation cause — a per-chat Stop/supersede cancels
+// with context.Canceled, a shutdown with dispatch.ErrShutdown. Every terminal
+// that wrote a marker and does NOT route through finish must call this so a
+// finished/stopped/spawn-failed run is never resumed.
+func (s *Service) clearPendingUnlessShutdown(ctx context.Context, chatID ChatID) {
+	if !errors.Is(context.Cause(ctx), dispatch.ErrShutdown) {
+		s.clearPending(chatID)
+	}
+}
+
 // finish renders the terminal message and replaces the progress message with it
 // (chunked when the answer exceeds the platform's message size limit).
 func (s *Service) finish(
@@ -600,19 +619,13 @@ func (s *Service) finish(
 	// Use a background context for delivery: the run ctx may be cancelled by Stop
 	// or shutdown, but the final message should still reach the user.
 	deliverCtx := context.WithoutCancel(ctx)
-	// Clear the interrupted-run marker on every CLEAN terminal (normal Result,
+	// Clear the interrupted-run marker on this CLEAN terminal (normal Result,
 	// RunError, timeout, user Stop / /stop / edit-supersede) so a finished or
-	// deliberately stopped run is NOT auto-resumed after a later restart. The ONE
-	// exception is a terminal caused by the dispatcher SHUTTING DOWN the process
-	// (drain-deadline cancel / Close): that run was killed by a deploy/restart, so
-	// its marker must SURVIVE to drive the auto-resume — we keep it and let the next
-	// startup re-inject. The two are told apart by the cancellation cause: a
-	// per-chat Stop/supersede cancels with context.Canceled, a shutdown with
-	// dispatch.ErrShutdown. Run-start is the only writer, so a cleared run stays
-	// cleared.
-	if !errors.Is(context.Cause(ctx), dispatch.ErrShutdown) {
-		s.clearPending(chatID)
-	}
+	// deliberately stopped run is NOT auto-resumed after a later restart, while a
+	// shutdown-caused terminal keeps its marker to drive the auto-resume. See
+	// clearPendingUnlessShutdown. Run-start is the only writer, so a cleared run
+	// stays cleared.
+	s.clearPendingUnlessShutdown(ctx, chatID)
 	// Clear the live draft preview (empty text) so it doesn't linger beside the
 	// persisted answer. Best-effort; harmless if no draft was ever streamed.
 	_ = s.chat.StreamDraft(deliverCtx, chatID, runID, "", false)

--- a/core/chat/service.go
+++ b/core/chat/service.go
@@ -662,6 +662,22 @@ func (s *Service) removePendingUnlessShutdown(ctx context.Context, chatID ChatID
 	}
 }
 
+// removePending clears this run's marker BY ID unconditionally (regardless of the
+// cancellation cause). Used by finish for a run that REACHED a terminal — it
+// produced a Result or errored — so its marker must NOT survive even when the ctx
+// was shutdown-cancelled in the microsecond window at the drain deadline;
+// otherwise the already-finished run would be phantom-resumed (a duplicate run
+// that can re-trigger side effects). A nil store or an empty id is a no-op; a
+// remove failure is logged but never aborts terminal delivery.
+func (s *Service) removePending(chatID ChatID, id string) {
+	if s.pending == nil || id == "" {
+		return
+	}
+	if err := s.pending.Remove(chatID, id); err != nil {
+		s.log.Error("clear pending marker", "chat_id", chatID, "error", err)
+	}
+}
+
 // clearLanePending purges ALL of chatID's interrupted-run markers (the whole
 // lane) unconditionally. Used by Stop/StopChat/edit-supersede, where the user
 // intentionally drops every queued+running job for the chat and there is no
@@ -685,12 +701,22 @@ func (s *Service) finish(
 	// Use a background context for delivery: the run ctx may be cancelled by Stop
 	// or shutdown, but the final message should still reach the user.
 	deliverCtx := context.WithoutCancel(ctx)
-	// Clear this run's interrupted-run marker by id on this CLEAN terminal (normal
-	// Result, RunError, timeout) so a finished run is NOT auto-resumed after a later
-	// restart, while a shutdown-caused terminal keeps its marker to drive the
-	// auto-resume. See removePendingUnlessShutdown. Clearing by id means this run
-	// can never remove a newer queued run's marker.
-	s.removePendingUnlessShutdown(ctx, chatID, markerID)
+	// Clear this run's interrupted-run marker by id whenever the run REACHED a
+	// terminal — it delivered a Result or errored — so a finished run is never
+	// auto-resumed after a later restart. The marker is KEPT only for a run that
+	// produced NOTHING (no Result, no error) and was shutdown-cancelled: that run
+	// was genuinely interrupted mid-flight by a deploy/restart, so its marker must
+	// survive to drive the auto-resume. Gating on the cancellation cause alone is
+	// not enough — a run that reached a clean terminal and then had its ctx
+	// shutdown-cancelled in the microsecond window at the drain deadline would
+	// otherwise keep its marker and be phantom-resumed (a duplicate run that can
+	// re-trigger side effects). Clearing by id means this run can never remove a
+	// newer queued run's marker.
+	genuinelyInterrupted := res == nil && runErr == nil &&
+		errors.Is(context.Cause(ctx), dispatch.ErrShutdown)
+	if !genuinelyInterrupted {
+		s.removePending(chatID, markerID)
+	}
 	// Clear the live draft preview (empty text) so it doesn't linger beside the
 	// persisted answer. Best-effort; harmless if no draft was ever streamed.
 	_ = s.chat.StreamDraft(deliverCtx, chatID, runID, "", false)

--- a/core/chat/service_test.go
+++ b/core/chat/service_test.go
@@ -263,56 +263,116 @@ func (f *fakeSessions) sets() []string {
 	return append([]string(nil), f.setLog...)
 }
 
-// fakePending is an in-memory pendingStore for the marker tests. It records the
-// current markers plus a log of Set/Delete calls so a test can assert what was
-// written and when.
+// fakePending is an in-memory pendingStore for the marker tests, modelling the
+// real per-chat FIFO queue + by-id clearing. It records the current queues plus a
+// log of mutating calls so a test can assert what was written and when.
 type fakePending struct {
-	mu     sync.Mutex
-	store  map[ChatID]pending.Marker
-	setLog []ChatID
-	delLog []ChatID
+	mu      sync.Mutex
+	store   map[ChatID][]pending.Marker
+	nextID  int
+	enqLog  []ChatID // chat ids that had a marker enqueued, in order
+	remLog  []ChatID // chat ids whose marker was Remove'd (by id), in order
+	clearLg []ChatID // chat ids whose whole lane was Clear'd, in order
 }
 
 func newFakePending() *fakePending {
-	return &fakePending{store: map[ChatID]pending.Marker{}}
+	return &fakePending{store: map[ChatID][]pending.Marker{}, nextID: 1}
 }
 
-func (f *fakePending) Set(chatID ChatID, marker pending.Marker) error {
+func (f *fakePending) Enqueue(chatID ChatID, marker pending.Marker) (string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.store[chatID] = marker
-	f.setLog = append(f.setLog, chatID)
+	id := strconv.Itoa(f.nextID)
+	f.nextID++
+	marker.ID = id
+	f.store[chatID] = append(f.store[chatID], marker)
+	f.enqLog = append(f.enqLog, chatID)
+	return id, nil
+}
+
+func (f *fakePending) SetAnchor(chatID ChatID, id, anchorMsgID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for i := range f.store[chatID] {
+		if f.store[chatID][i].ID == id {
+			f.store[chatID][i].AnchorMsgID = anchorMsgID
+			return nil
+		}
+	}
 	return nil
 }
 
-func (f *fakePending) Delete(chatID ChatID) error {
+func (f *fakePending) Remove(chatID ChatID, id string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	q := f.store[chatID]
+	for i := range q {
+		if q[i].ID == id {
+			q = append(q[:i], q[i+1:]...)
+			if len(q) == 0 {
+				delete(f.store, chatID)
+			} else {
+				f.store[chatID] = q
+			}
+			f.remLog = append(f.remLog, chatID)
+			return nil
+		}
+	}
+	return nil
+}
+
+func (f *fakePending) Clear(chatID ChatID) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	delete(f.store, chatID)
-	f.delLog = append(f.delLog, chatID)
+	f.clearLg = append(f.clearLg, chatID)
 	return nil
 }
 
-// has reports whether a marker is stored for testChatID (the id every marker test
-// submits under), mirroring fakeSessions.get's param-free style.
+func (f *fakePending) All() map[ChatID][]pending.Marker {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := map[ChatID][]pending.Marker{}
+	for k, v := range f.store {
+		out[k] = append([]pending.Marker(nil), v...)
+	}
+	return out
+}
+
+// count reports how many markers are queued for testChatID (the id every marker
+// test submits under).
+func (f *fakePending) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.store[testChatID])
+}
+
+// has reports whether any marker is stored for testChatID (the id every marker
+// test submits under), mirroring fakeSessions.get's param-free style.
 func (f *fakePending) has() bool {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	_, ok := f.store[testChatID]
-	return ok
+	return len(f.store[testChatID]) > 0
 }
 
+// get returns the first queued marker for testChatID.
 func (f *fakePending) get() (pending.Marker, bool) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	m, ok := f.store[testChatID]
-	return m, ok
+	q := f.store[testChatID]
+	if len(q) == 0 {
+		return pending.Marker{}, false
+	}
+	return q[0], true
 }
 
-func (f *fakePending) deletes() []ChatID {
+// removes returns the chat ids whose marker was cleared by id (Remove) or whose
+// lane was cleared (Clear), in call order — every path that drops a marker.
+func (f *fakePending) removes() []ChatID {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	return append([]ChatID(nil), f.delLog...)
+	out := append([]ChatID(nil), f.remLog...)
+	return append(out, f.clearLg...)
 }
 
 // newTestServiceWithPending builds a Service wired to a pending store (and a fake
@@ -996,10 +1056,11 @@ func TestSessionPreservedOnShutdown(t *testing.T) {
 	}
 }
 
-// TestPendingMarkerSetAtStart asserts the interrupted-run marker is written at run
-// START (before the run can be torn down), capturing the prompt and the anchor id,
-// and is present while the run is still in flight.
-func TestPendingMarkerSetAtStart(t *testing.T) {
+// TestPendingMarkerSetAtSubmit asserts the interrupted-run marker is enqueued at
+// SUBMIT (so a queued run is captured too), carries the prompt and a process id,
+// gains the anchor message id once the anchor is sent, and is present while the
+// run is still in flight.
+func TestPendingMarkerSetAtSubmit(t *testing.T) {
 	fc := newFakeChat()
 	pend := newFakePending()
 	// gate is never closed: the run blocks after SystemInit so we can inspect the
@@ -1037,8 +1098,8 @@ func TestPendingMarkerClearedOnNormalFinish(t *testing.T) {
 		return text == finalAnswer && !stop
 	})
 	waitUntil(t, func() bool { return !pend.has() })
-	if dels := pend.deletes(); len(dels) == 0 || dels[len(dels)-1] != testChatID {
-		t.Fatalf("marker not cleared on normal finish; deletes=%v", dels)
+	if dels := pend.removes(); len(dels) == 0 || dels[len(dels)-1] != testChatID {
+		t.Fatalf("marker not cleared on normal finish; removes=%v", dels)
 	}
 }
 
@@ -1085,7 +1146,7 @@ func TestPendingMarkerSurvivesShutdown(t *testing.T) {
 
 	// The marker must SURVIVE the shutdown so the run is auto-resumed on restart.
 	if !pend.has() {
-		t.Fatalf("marker was cleared on shutdown; deletes=%v — a killed run must stay resumable", pend.deletes())
+		t.Fatalf("marker was cleared on shutdown; removes=%v — a killed run must stay resumable", pend.removes())
 	}
 }
 
@@ -1128,7 +1189,7 @@ func TestPendingMarkerClearedOnTimeout(t *testing.T) {
 
 	svc.Handle(context.Background(), testChatID, 100, "1", "long task")
 
-	// The marker is written at run start while the run is in flight.
+	// The marker is enqueued at submit while the run is in flight.
 	waitUntil(t, func() bool { return pend.has() })
 
 	// The per-run timeout cancels the run (non-shutdown cause), the user sees the
@@ -1141,8 +1202,8 @@ func TestPendingMarkerClearedOnTimeout(t *testing.T) {
 	// ...and the timeout terminal clears the marker (cause is DeadlineExceeded, not
 	// ErrShutdown), so the run is not auto-resumed.
 	waitUntil(t, func() bool { return !pend.has() })
-	if dels := pend.deletes(); len(dels) == 0 || dels[len(dels)-1] != testChatID {
-		t.Fatalf("marker not cleared on timeout; deletes=%v", dels)
+	if dels := pend.removes(); len(dels) == 0 || dels[len(dels)-1] != testChatID {
+		t.Fatalf("marker not cleared on timeout; removes=%v", dels)
 	}
 }
 
@@ -1179,11 +1240,11 @@ func TestPendingMarkerClearedOnSpawnError(t *testing.T) {
 
 	svc.Handle(context.Background(), testChatID, 100, "1", "hello")
 
-	// The spawn-error terminal must clear the marker the run wrote at start. The
-	// marker is set and cleared within the same dispatched run, so assert on the
-	// Delete log (the transient marker may never be observable mid-flight).
+	// The spawn-error terminal must clear the marker enqueued at submit. The marker
+	// is enqueued and cleared around the same dispatched run, so assert on the
+	// remove log (the transient marker may never be observable mid-flight).
 	waitUntil(t, func() bool {
-		dels := pend.deletes()
+		dels := pend.removes()
 		return len(dels) > 0 && dels[len(dels)-1] == testChatID
 	})
 	if pend.has() {
@@ -1213,7 +1274,133 @@ func TestPendingMarkerSurvivesSpawnErrorOnShutdown(t *testing.T) {
 
 	// The marker must SURVIVE so the run is auto-resumed on restart.
 	if !pend.has() {
-		t.Fatalf("marker cleared on shutdown-caused spawn error; deletes=%v — a killed run must stay resumable", pend.deletes())
+		t.Fatalf("marker cleared on shutdown-caused spawn error; removes=%v — a killed run must stay resumable", pend.removes())
+	}
+}
+
+// TestPendingQueuedAndRunningBothSurviveShutdown is the finding-#1 regression: a
+// chat with one RUNNING run (A) and one QUEUED-but-never-started run (B) on the
+// same serial lane must keep BOTH markers when the process is shut down, so BOTH
+// resume on restart. The old per-chat single marker could hold only one of them
+// and a queued job never reached run-start to mark itself, silently losing B.
+func TestPendingQueuedAndRunningBothSurviveShutdown(t *testing.T) {
+	fc := newFakeChat()
+	pend := newFakePending()
+	// gate never closes: A blocks after SystemInit (in flight), so B stays queued
+	// behind it on the serial per-chat lane and never starts.
+	fr := &sessionRunner{emitInit: "s1", emitFinal: "s1", gate: make(chan struct{})}
+	svc, d := newTestServiceWithPending(t, fr, fc, pend)
+
+	// Two submissions on the SAME chat: A runs (and blocks), B queues behind it.
+	svc.Handle(context.Background(), testChatID, 100, "1", "run A")
+	svc.Handle(context.Background(), testChatID, 100, "2", "queue B")
+
+	// Both markers must be enqueued at submit (A in flight, B still queued).
+	waitUntil(t, func() bool { return pend.count() == 2 })
+
+	// Short drain window: the gated A never finishes (cause ErrShutdown), B never
+	// starts, so neither reaches a clean terminal.
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	_ = d.Shutdown(shutdownCtx)
+
+	// BOTH markers must survive so BOTH runs auto-resume on restart.
+	if got := pend.count(); got != 2 {
+		t.Fatalf("after shutdown queue len = %d, want 2 (both queued+running must survive); removes=%v", got, pend.removes())
+	}
+	prompts := map[string]bool{}
+	for _, m := range pend.All()[testChatID] {
+		prompts[m.Prompt] = true
+	}
+	if !prompts["run A"] || !prompts["queue B"] {
+		t.Fatalf("surviving markers = %v, want both 'run A' and 'queue B'", prompts)
+	}
+}
+
+// TestPendingSupersedeDoesNotLoseSuccessor asserts an edit-supersede (Cancel +
+// clear-lane + enqueue the new run) leaves exactly the NEW run's marker, and the
+// cancelled run's by-id clear cannot remove that successor. This is the
+// concurrency property: clear-by-id means a stale run never drops a newer marker.
+func TestPendingSupersedeDoesNotLoseSuccessor(t *testing.T) {
+	fc := newFakeChat()
+	pend := newFakePending()
+	// The first run blocks after SystemInit so it is genuinely in flight when the
+	// edit supersedes it.
+	fr := &sessionRunner{emitInit: "s1", emitFinal: "s1", gate: make(chan struct{})}
+	svc, d := newTestServiceWithPending(t, fr, fc, pend)
+	defer d.Close()
+
+	// Original message (msg id 1) starts a run and is recorded as the chat's latest.
+	svc.Handle(context.Background(), testChatID, 100, "1", "original")
+	waitUntil(t, func() bool { return pend.has() })
+
+	// Edit that same message: supersede cancels the in-flight run, clears the lane,
+	// and enqueues the new run.
+	svc.HandleEdit(context.Background(), testChatID, 100, "1", "edited")
+
+	// The new run's marker must be the one that survives; the cancelled run's by-id
+	// clear must not remove it. Eventually the queue holds exactly the edited run.
+	waitUntil(t, func() bool {
+		q := pend.All()[testChatID]
+		return len(q) == 1 && q[0].Prompt == "edited"
+	})
+}
+
+// TestPendingStopClearsLane asserts /stop (via svc.Stop) purges the WHOLE lane's
+// markers — both the running run and any queued successors — so nothing the user
+// deliberately stopped is auto-resumed.
+func TestPendingStopClearsLane(t *testing.T) {
+	fc := newFakeChat()
+	pend := newFakePending()
+	fr := &sessionRunner{emitInit: "s1", emitFinal: "s1", gate: make(chan struct{})}
+	svc, d := newTestServiceWithPending(t, fr, fc, pend)
+	defer d.Close()
+
+	// A runs (blocks), B queues behind it — two markers on the lane.
+	svc.Handle(context.Background(), testChatID, 100, "1", "run A")
+	svc.Handle(context.Background(), testChatID, 100, "2", "queue B")
+	waitUntil(t, func() bool { return pend.count() == 2 })
+
+	// Stop the running run: it cancels the lane AND clears every marker.
+	waitUntil(t, func() bool { return svc.Stop("1") })
+
+	waitUntil(t, func() bool { return pend.count() == 0 })
+}
+
+// TestResumePendingReusesIDNoDuplicate asserts ResumePending replays a marker by
+// REUSING its existing id (not enqueuing a fresh one), so the resumed run clears
+// the SAME on-disk marker on its clean terminal and never leaves a duplicate. It
+// mirrors the startup replay: the store already holds the persisted markers.
+func TestResumePendingReusesIDNoDuplicate(t *testing.T) {
+	fc := newFakeChat()
+	pend := newFakePending()
+	fr := &fakeRunner{events: []claude.Event{
+		{Type: claude.SystemInit, SessionID: "s1"},
+		{Type: claude.Result, Result: &claude.RunResult{Text: finalAnswer, SessionID: "s1"}},
+	}}
+	svc, d := newTestServiceWithPending(t, fr, fc, pend)
+	defer d.Close()
+
+	// Seed two persisted markers (as if left behind by a deploy), in order.
+	idA, _ := pend.Enqueue(testChatID, pending.Marker{Prompt: "A", StartedAt: 1})
+	idB, _ := pend.Enqueue(testChatID, pending.Marker{Prompt: "B", StartedAt: 2})
+
+	// Replay both in order, exactly as resumePending does — reusing their ids.
+	for _, m := range pend.All()[testChatID] {
+		svc.ResumePending(testChatID, m)
+	}
+
+	// Each resumed run clears its OWN marker by id on its clean terminal; no fresh
+	// marker is enqueued, so the lane drains to empty (no duplicate left behind).
+	waitUntil(t, func() bool { return pend.count() == 0 })
+
+	// The runs reused the seeded ids — no fresh ids were minted at replay (Enqueue
+	// was called exactly twice, by the seed above).
+	if got := len(pend.enqLog); got != 2 {
+		t.Fatalf("Enqueue called %d times, want 2 (replay must reuse ids, not enqueue)", got)
+	}
+	if idA == idB {
+		t.Fatalf("seeded ids collided: %q", idA)
 	}
 }
 

--- a/core/chat/service_test.go
+++ b/core/chat/service_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/duckbugio/flock/core/claude"
 	"github.com/duckbugio/flock/core/dispatch"
+	"github.com/duckbugio/flock/core/pending"
 	"github.com/duckbugio/flock/core/session"
 )
 
@@ -260,6 +261,77 @@ func (f *fakeSessions) sets() []string {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return append([]string(nil), f.setLog...)
+}
+
+// fakePending is an in-memory pendingStore for the marker tests. It records the
+// current markers plus a log of Set/Delete calls so a test can assert what was
+// written and when.
+type fakePending struct {
+	mu     sync.Mutex
+	store  map[ChatID]pending.Marker
+	setLog []ChatID
+	delLog []ChatID
+}
+
+func newFakePending() *fakePending {
+	return &fakePending{store: map[ChatID]pending.Marker{}}
+}
+
+func (f *fakePending) Set(chatID ChatID, marker pending.Marker) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.store[chatID] = marker
+	f.setLog = append(f.setLog, chatID)
+	return nil
+}
+
+func (f *fakePending) Delete(chatID ChatID) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.store, chatID)
+	f.delLog = append(f.delLog, chatID)
+	return nil
+}
+
+// has reports whether a marker is stored for testChatID (the id every marker test
+// submits under), mirroring fakeSessions.get's param-free style.
+func (f *fakePending) has() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	_, ok := f.store[testChatID]
+	return ok
+}
+
+func (f *fakePending) get() (pending.Marker, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	m, ok := f.store[testChatID]
+	return m, ok
+}
+
+func (f *fakePending) deletes() []ChatID {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]ChatID(nil), f.delLog...)
+}
+
+// newTestServiceWithPending builds a Service wired to a pending store (and a fake
+// session store) over a real Dispatcher, for the interrupted-run marker tests.
+func newTestServiceWithPending(
+	t *testing.T, r claude.Runner, c Transport, p pendingStore,
+) (*Service, *dispatch.Dispatcher) {
+	t.Helper()
+	d := dispatch.New(4)
+	s := New(Config{
+		Runner:     r,
+		Transport:  c,
+		Dispatcher: d,
+		Workspace:  &fakeWorkspace{},
+		Pending:    p,
+		Logger:     slog.New(slog.DiscardHandler),
+	})
+	s.tick = 5 * time.Millisecond
+	return s, d
 }
 
 // newTestService builds a Service over a real Dispatcher and a fake workspace.
@@ -902,12 +974,15 @@ func TestSessionPreservedOnShutdown(t *testing.T) {
 		return ok && id == sessShutdown
 	})
 
-	// Drain: cancel in-flight runs within a bounded budget (as main does on
-	// SIGINT/SIGTERM). The run is gated, so it unwinds via ctx cancellation.
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	// Drain: WAIT for in-flight runs up to a bounded budget, then cancel the
+	// survivors (as main does on SIGINT/SIGTERM). The run is gated and never
+	// finishes on its own, so it survives the (short) window and is cancelled at the
+	// deadline — Shutdown then reports the deadline. We assert the session id
+	// survived that cancel, which is the point of this regression.
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
-	if err := d.Shutdown(shutdownCtx); err != nil {
-		t.Fatalf("Shutdown drain: %v", err)
+	if err := d.Shutdown(shutdownCtx); err == nil {
+		t.Fatal("Shutdown returned nil; the gated run should survive the window and be cancelled at the deadline")
 	}
 
 	// The session id captured at SystemInit must survive the shutdown intact.
@@ -918,6 +993,99 @@ func TestSessionPreservedOnShutdown(t *testing.T) {
 	// exactly the init id is recorded.
 	if log := sess.sets(); len(log) == 0 || log[0] != sessShutdown {
 		t.Fatalf("setLog = %v, want first = sess-shutdown", log)
+	}
+}
+
+// TestPendingMarkerSetAtStart asserts the interrupted-run marker is written at run
+// START (before the run can be torn down), capturing the prompt and the anchor id,
+// and is present while the run is still in flight.
+func TestPendingMarkerSetAtStart(t *testing.T) {
+	fc := newFakeChat()
+	pend := newFakePending()
+	// gate is never closed: the run blocks after SystemInit so we can inspect the
+	// marker mid-run.
+	fr := &sessionRunner{emitInit: "s1", emitFinal: "s1", gate: make(chan struct{})}
+	svc, d := newTestServiceWithPending(t, fr, fc, pend)
+	defer d.Close()
+
+	svc.Handle(context.Background(), testChatID, 100, "1", "resume me")
+
+	// The marker must appear with the prompt and the anchor message id while the run
+	// is still in flight (before any terminal).
+	waitUntil(t, func() bool {
+		m, ok := pend.get()
+		return ok && m.Prompt == "resume me" && m.AnchorMsgID == anchorMsgID && m.StartedAt != 0
+	})
+}
+
+// TestPendingMarkerClearedOnNormalFinish asserts a normally-finished run clears its
+// marker, so it is NOT auto-resumed after a later restart.
+func TestPendingMarkerClearedOnNormalFinish(t *testing.T) {
+	fc := newFakeChat()
+	pend := newFakePending()
+	fr := &fakeRunner{events: []claude.Event{
+		{Type: claude.SystemInit, SessionID: "s1"},
+		{Type: claude.Result, Result: &claude.RunResult{Text: finalAnswer, SessionID: "s1"}},
+	}}
+	svc, d := newTestServiceWithPending(t, fr, fc, pend)
+	defer d.Close()
+
+	svc.Handle(context.Background(), testChatID, 100, "1", "hello")
+
+	waitUntil(t, func() bool {
+		text, stop := fc.snapshot()
+		return text == finalAnswer && !stop
+	})
+	waitUntil(t, func() bool { return !pend.has() })
+	if dels := pend.deletes(); len(dels) == 0 || dels[len(dels)-1] != testChatID {
+		t.Fatalf("marker not cleared on normal finish; deletes=%v", dels)
+	}
+}
+
+// TestPendingMarkerClearedOnStop asserts a user-Stopped run clears its marker (the
+// terminal is a per-chat cancel, not a shutdown), so a deliberately stopped run is
+// NOT auto-resumed.
+func TestPendingMarkerClearedOnStop(t *testing.T) {
+	fc := newFakeChat()
+	pend := newFakePending()
+	// gate never closes: the run blocks until Stop cancels its context.
+	fr := &sessionRunner{emitInit: "s1", emitFinal: "s1", gate: make(chan struct{})}
+	svc, d := newTestServiceWithPending(t, fr, fc, pend)
+	defer d.Close()
+
+	svc.Handle(context.Background(), testChatID, 100, "1", "stop me")
+
+	// Wait until the run is in flight (marker present), then Stop it.
+	waitUntil(t, func() bool { return pend.has() })
+	waitUntil(t, func() bool { return svc.Stop("1") })
+
+	// The Stop terminal must clear the marker.
+	waitUntil(t, func() bool { return !pend.has() })
+}
+
+// TestPendingMarkerSurvivesShutdown asserts a run cancelled by the dispatcher
+// SHUTTING DOWN (drain-deadline cancel) keeps its marker so the next startup can
+// auto-resume it — the one terminal that must NOT clear the marker.
+func TestPendingMarkerSurvivesShutdown(t *testing.T) {
+	fc := newFakeChat()
+	pend := newFakePending()
+	// gate never closes: the run blocks until Shutdown cancels its context at the
+	// (short) drain deadline.
+	fr := &sessionRunner{emitInit: "s1", emitFinal: "s1", gate: make(chan struct{})}
+	svc, d := newTestServiceWithPending(t, fr, fc, pend)
+
+	svc.Handle(context.Background(), testChatID, 100, "1", "resume me")
+	waitUntil(t, func() bool { return pend.has() })
+
+	// Short drain window: the gated run never finishes, so Shutdown cancels it with
+	// the ErrShutdown cause after the deadline.
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	_ = d.Shutdown(shutdownCtx)
+
+	// The marker must SURVIVE the shutdown so the run is auto-resumed on restart.
+	if !pend.has() {
+		t.Fatalf("marker was cleared on shutdown; deletes=%v — a killed run must stay resumable", pend.deletes())
 	}
 }
 

--- a/core/chat/service_test.go
+++ b/core/chat/service_test.go
@@ -1089,6 +1089,63 @@ func TestPendingMarkerSurvivesShutdown(t *testing.T) {
 	}
 }
 
+// newTestServiceWithPendingTimeout builds a Service wired to a pending store with
+// a per-run timeout, for the timeout marker-clear test. It mirrors
+// newTestServiceWithPending but injects a Timeout so a gated run hits the per-run
+// deadline (cause context.DeadlineExceeded, NOT dispatch.ErrShutdown).
+func newTestServiceWithPendingTimeout(
+	t *testing.T, r claude.Runner, c Transport, p pendingStore, timeout time.Duration,
+) (*Service, *dispatch.Dispatcher) {
+	t.Helper()
+	d := dispatch.New(4)
+	s := New(Config{
+		Runner:     r,
+		Transport:  c,
+		Dispatcher: d,
+		Workspace:  &fakeWorkspace{},
+		Pending:    p,
+		Timeout:    timeout,
+		Logger:     slog.New(slog.DiscardHandler),
+	})
+	s.tick = 5 * time.Millisecond
+	return s, d
+}
+
+// TestPendingMarkerClearedOnTimeout asserts a run that hits its per-run timeout
+// (ctx deadline expires for a non-shutdown reason — cause
+// context.DeadlineExceeded, NOT dispatch.ErrShutdown) reaches finish and clears
+// its marker, so a timed-out run is NOT auto-resumed. This is the symmetric
+// counterpart to the normal-finish, Stop, and spawn-error clear tests, and the
+// inverse of TestPendingMarkerSurvivesShutdown (the one terminal that preserves it).
+func TestPendingMarkerClearedOnTimeout(t *testing.T) {
+	fc := newFakeChat()
+	pend := newFakePending()
+	// gate never closes: the run blocks after SystemInit until the per-run timeout
+	// fires and cancels it with cause context.DeadlineExceeded.
+	fr := &sessionRunner{emitInit: "s1", emitFinal: "s1", gate: make(chan struct{})}
+	svc, d := newTestServiceWithPendingTimeout(t, fr, fc, pend, 30*time.Millisecond)
+	defer d.Close()
+
+	svc.Handle(context.Background(), testChatID, 100, "1", "long task")
+
+	// The marker is written at run start while the run is in flight.
+	waitUntil(t, func() bool { return pend.has() })
+
+	// The per-run timeout cancels the run (non-shutdown cause), the user sees the
+	// terminal "Stopped" notice...
+	waitUntil(t, func() bool {
+		text, stop := fc.snapshot()
+		return strings.Contains(text, "Stopped") && !stop
+	})
+
+	// ...and the timeout terminal clears the marker (cause is DeadlineExceeded, not
+	// ErrShutdown), so the run is not auto-resumed.
+	waitUntil(t, func() bool { return !pend.has() })
+	if dels := pend.deletes(); len(dels) == 0 || dels[len(dels)-1] != testChatID {
+		t.Fatalf("marker not cleared on timeout; deletes=%v", dels)
+	}
+}
+
 // spawnErrorRunner fails to start: Run returns a non-nil error and never emits
 // any events, modelling the CLI failing to spawn. When block is non-nil Run
 // waits on it (or ctx.Done) before returning the error, letting a test cancel

--- a/core/chat/service_test.go
+++ b/core/chat/service_test.go
@@ -1089,6 +1089,77 @@ func TestPendingMarkerSurvivesShutdown(t *testing.T) {
 	}
 }
 
+// spawnErrorRunner fails to start: Run returns a non-nil error and never emits
+// any events, modelling the CLI failing to spawn. When block is non-nil Run
+// waits on it (or ctx.Done) before returning the error, letting a test cancel
+// the run's context (e.g. via Shutdown) first so the failure is observed under a
+// shutdown cause.
+type spawnErrorRunner struct {
+	err   error
+	block chan struct{}
+}
+
+func (r *spawnErrorRunner) Run(ctx context.Context, _ string, _ claude.Options) (<-chan claude.Event, error) {
+	if r.block != nil {
+		select {
+		case <-r.block:
+		case <-ctx.Done():
+		}
+	}
+	return nil, r.err
+}
+
+// TestPendingMarkerClearedOnSpawnError asserts a run whose CLI fails to spawn
+// (runner.Run returns an error) clears its marker — a clean, non-shutdown
+// terminal that returns before finish, so it must NOT be auto-resumed. A
+// persistent spawn error would otherwise re-resume and re-leak every boot.
+func TestPendingMarkerClearedOnSpawnError(t *testing.T) {
+	fc := newFakeChat()
+	pend := newFakePending()
+	fr := &spawnErrorRunner{err: errors.New("spawn failed")}
+	svc, d := newTestServiceWithPending(t, fr, fc, pend)
+	defer d.Close()
+
+	svc.Handle(context.Background(), testChatID, 100, "1", "hello")
+
+	// The spawn-error terminal must clear the marker the run wrote at start. The
+	// marker is set and cleared within the same dispatched run, so assert on the
+	// Delete log (the transient marker may never be observable mid-flight).
+	waitUntil(t, func() bool {
+		dels := pend.deletes()
+		return len(dels) > 0 && dels[len(dels)-1] == testChatID
+	})
+	if pend.has() {
+		t.Fatalf("marker still present after spawn error; it must be cleared")
+	}
+}
+
+// TestPendingMarkerSurvivesSpawnErrorOnShutdown asserts a spawn failure caused by
+// the dispatcher SHUTTING DOWN keeps its marker so the next startup auto-resumes
+// it — the spawn-error clear is gated exactly like finish on the shutdown cause.
+func TestPendingMarkerSurvivesSpawnErrorOnShutdown(t *testing.T) {
+	fc := newFakeChat()
+	pend := newFakePending()
+	// block never closes: Run waits until Shutdown cancels its context (cause
+	// ErrShutdown), then returns the error — a shutdown-caused start failure.
+	fr := &spawnErrorRunner{err: errors.New("spawn failed"), block: make(chan struct{})}
+	svc, d := newTestServiceWithPending(t, fr, fc, pend)
+
+	svc.Handle(context.Background(), testChatID, 100, "1", "resume me")
+	waitUntil(t, func() bool { return pend.has() })
+
+	// Short drain window: the gated Run never returns until cancelled, so Shutdown
+	// cancels it with the ErrShutdown cause after the deadline.
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	_ = d.Shutdown(shutdownCtx)
+
+	// The marker must SURVIVE so the run is auto-resumed on restart.
+	if !pend.has() {
+		t.Fatalf("marker cleared on shutdown-caused spawn error; deletes=%v — a killed run must stay resumable", pend.deletes())
+	}
+}
+
 // errorResultRunner emits a SystemInit (so the session id is captured) followed
 // by a terminal Result whose IsError flag is configurable. It lets the
 // stale-session self-heal tests drive an is_error vs a clean Result. When init is

--- a/core/chat/service_test.go
+++ b/core/chat/service_test.go
@@ -1317,6 +1317,73 @@ func TestPendingQueuedAndRunningBothSurviveShutdown(t *testing.T) {
 	}
 }
 
+// resultThenBlockRunner emits SystemInit + a clean Result, signals delivered once
+// the Result has been consumed by the event loop, then BLOCKS on ctx.Done before
+// closing its event channel. This lets a test deterministically order: the run
+// reaches a clean terminal (Result delivered), and ONLY THEN is its ctx cancelled
+// with the ErrShutdown cause — modelling the microsecond window at the drain
+// deadline where an already-finished run is shutdown-cancelled.
+type resultThenBlockRunner struct {
+	delivered chan struct{} // closed after the Result has been consumed
+}
+
+func (r *resultThenBlockRunner) Run(ctx context.Context, _ string, _ claude.Options) (<-chan claude.Event, error) {
+	out := make(chan claude.Event)
+	go func() {
+		defer close(out)
+		if !emit(ctx, out, claude.Event{Type: claude.SystemInit, SessionID: "s1"}) {
+			return
+		}
+		if !emit(ctx, out, claude.Event{Type: claude.Result, Result: &claude.RunResult{Text: finalAnswer, SessionID: "s1"}}) {
+			return
+		}
+		// The Result is now in the event loop's hands (unbuffered send returned):
+		// finalResult is set. Signal the test, then block until the ctx is cancelled
+		// so finish runs AFTER the (shutdown) cancel — but with a non-nil result.
+		close(r.delivered)
+		<-ctx.Done()
+	}()
+	return out, nil
+}
+
+// TestPendingMarkerClearedOnResultEvenUnderShutdown is the phantom-resume
+// regression: a run that REACHED a clean Result and is THEN shutdown-cancelled
+// (cause dispatch.ErrShutdown) in the microsecond window at the drain deadline
+// must still CLEAR its marker — it already produced a terminal, so resuming it on
+// the next boot would be a duplicate run (re-triggering side effects). The marker
+// is kept ONLY for a run that produced nothing under shutdown (covered by
+// TestPendingMarkerSurvivesShutdown), not for one that finished.
+func TestPendingMarkerClearedOnResultEvenUnderShutdown(t *testing.T) {
+	fc := newFakeChat()
+	pend := newFakePending()
+	fr := &resultThenBlockRunner{delivered: make(chan struct{})}
+	svc, d := newTestServiceWithPending(t, fr, fc, pend)
+
+	svc.Handle(context.Background(), testChatID, 100, "1", "almost done")
+
+	// Wait until the run has delivered its clean Result (finalResult is set) and is
+	// blocked on ctx.Done — finish has not run yet.
+	select {
+	case <-fr.delivered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("run never delivered its Result")
+	}
+
+	// Now shut down: the blocked run's ctx is cancelled with the ErrShutdown cause,
+	// it returns, the channel closes, the loop breaks, and finish runs with a
+	// non-nil result under a shutdown cause.
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_ = d.Shutdown(shutdownCtx)
+
+	// The marker MUST be cleared: the run reached a terminal, so it is not a
+	// genuine mid-flight interruption and must never be phantom-resumed.
+	waitUntil(t, func() bool { return !pend.has() })
+	if dels := pend.removes(); len(dels) == 0 || dels[len(dels)-1] != testChatID {
+		t.Fatalf("marker not cleared on result under shutdown; removes=%v — finished run would be phantom-resumed", dels)
+	}
+}
+
 // TestPendingSupersedeDoesNotLoseSuccessor asserts an edit-supersede (Cancel +
 // clear-lane + enqueue the new run) leaves exactly the NEW run's marker, and the
 // cancelled run's by-id clear cannot remove that successor. This is the

--- a/core/dispatch/dispatch.go
+++ b/core/dispatch/dispatch.go
@@ -286,6 +286,15 @@ func (d *Dispatcher) Shutdown(ctx context.Context) error {
 	// give them a brief, bounded grace to deliver a terminal/persist a marker before
 	// the caller exits the process. The grace is independent of the (now-expired)
 	// drain ctx so a survivor's "Stopped"/marker write isn't itself cut off.
+	//
+	// Order matters: rootStop sets the shutdown cause (ErrShutdown) BEFORE the
+	// per-chat cancels below, so every in-flight survivor observes ErrShutdown and
+	// keeps its interrupted-run marker to drive auto-resume on restart. A user Stop
+	// whose own per-chat cancel happens to land in the narrow window just before
+	// this rootStop is instead seen as a clean context.Canceled (marker cleared, no
+	// resume). That race is intentionally left unguarded: it is vanishingly rare,
+	// user-initiated, and resolves in the safe direction — a run the user just
+	// stopped should not auto-resume — so no locking or reordering is warranted.
 	d.rootStop(ErrShutdown)
 	for _, q := range chats {
 		q.mu.Lock()

--- a/core/dispatch/dispatch.go
+++ b/core/dispatch/dispatch.go
@@ -8,10 +8,20 @@ package dispatch
 
 import (
 	"context"
+	"errors"
 	"sync"
+	"time"
 
 	"golang.org/x/sync/semaphore"
 )
+
+// ErrShutdown is the cancellation cause set on a job's context when the
+// dispatcher is shutting down the whole process (Shutdown's post-drain cancel or
+// Close), as opposed to a per-chat Cancel (Stop / edit-supersede). A run can
+// distinguish the two via context.Cause(ctx): a shutdown-cancelled run was killed
+// by a deploy/restart and should keep its interrupted-run marker for auto-resume,
+// while a user-Stopped run clears it.
+var ErrShutdown = errors.New("dispatch: shutting down")
 
 // job is one unit of work plus the per-chat cancelable context it runs under.
 type job struct {
@@ -51,10 +61,19 @@ type Dispatcher struct {
 	mu     sync.Mutex
 	chats  map[string]*chatQueue
 	closed bool
-	wg     sync.WaitGroup // tracks per-chat worker goroutines for graceful drain
+	// wg tracks per-chat worker goroutines. A worker stays alive while it is running
+	// a job and exits once it is idle and the drain/rootCtx signal fires, so
+	// wg.Wait() after closing drain blocks exactly until every in-flight job has
+	// finished on its own — the graceful-drain wait.
+	wg sync.WaitGroup
+	// drain is closed by Shutdown to start the graceful-drain phase: workers stop
+	// dequeuing NEW jobs but a job already running is left to finish on its own
+	// (its context is NOT cancelled) until the drain deadline elapses.
+	drain     chan struct{}
+	drainOnce sync.Once
 	//nolint:containedctx // root context held for the dispatcher's lifecycle; cancelled in Shutdown via rootStop.
 	rootCtx  context.Context
-	rootStop context.CancelFunc
+	rootStop context.CancelCauseFunc
 }
 
 // queueBuffer is the per-chat channel buffer: how many jobs may be queued for a
@@ -68,12 +87,12 @@ func New(maxConcurrent int) *Dispatcher {
 	if maxConcurrent < 1 {
 		maxConcurrent = 1
 	}
-	//nolint:gosec // G118: cancel is stored as rootStop and invoked in Shutdown.
-	root, stop := context.WithCancel(context.Background())
+	root, stop := context.WithCancelCause(context.Background())
 	return &Dispatcher{
 		sem:      semaphore.NewWeighted(int64(maxConcurrent)),
 		bufSize:  queueBuffer,
 		chats:    make(map[string]*chatQueue),
+		drain:    make(chan struct{}),
 		rootCtx:  root,
 		rootStop: stop,
 	}
@@ -120,16 +139,30 @@ func (d *Dispatcher) Submit(chatID string, run func(ctx context.Context)) {
 // execution within the chat falls out of the single consumer; the global cap is
 // enforced by acquiring a semaphore slot around each job's start.
 //
-// The queue channel is never closed; the worker exits when Shutdown cancels
-// rootCtx. Pending buffered jobs are abandoned (their ctx, derived from rootCtx,
-// is already cancelled). Draining queued jobs first would not help: rootCtx is
-// cancelled, so each would observe cancellation immediately.
+// The queue channel is never closed. The worker exits when Shutdown cancels
+// rootCtx (the immediate Close path) OR when the graceful drain begins (d.drain
+// closed): on drain it stops dequeuing NEW jobs and returns, leaving any job it
+// is currently running to finish on its own (that job runs inside runOne, which
+// has already returned to the loop only after the job completed). Pending
+// buffered jobs are abandoned in both cases.
 func (d *Dispatcher) worker(q *chatQueue) {
 	defer d.wg.Done()
 	for {
+		// Prioritize the shutdown signals: once draining (or rootCtx cancelled), stop
+		// dequeuing new jobs even if the buffer still holds some, so a graceful drain
+		// does not start fresh work past the SIGTERM.
+		select {
+		case <-d.drain:
+			return
+		case <-d.rootCtx.Done():
+			return
+		default:
+		}
 		select {
 		case j := <-q.ch:
 			d.runOne(q, j)
+		case <-d.drain:
+			return
 		case <-d.rootCtx.Done():
 			return
 		}
@@ -138,10 +171,12 @@ func (d *Dispatcher) worker(q *chatQueue) {
 
 // runOne acquires a global slot, installs the per-chat cancel hook, runs the
 // job, and releases the slot. The semaphore is always released via defer so a
-// panicking job cannot leak a slot.
+// panicking job cannot leak a slot. The worker stays alive (tracked on d.wg) for
+// the whole call, so a graceful Shutdown's wg.Wait() blocks until the running job
+// finishes on its own.
 func (d *Dispatcher) runOne(q *chatQueue, j job) {
 	// Block until a global slot is free (parallel across chats, capped). If the
-	// dispatcher is shutting down, abandon the job.
+	// dispatcher is shutting down (rootCtx cancelled), abandon the job.
 	if err := d.sem.Acquire(d.rootCtx, 1); err != nil {
 		return
 	}
@@ -199,10 +234,16 @@ drain:
 	}
 }
 
-// Shutdown stops accepting new jobs and cancels every in-flight job, then waits
-// for the per-chat workers to drain until ctx is done. It is safe to call more
-// than once (the closed flag guards a second pass); later Submits are dropped.
-// A simple version sufficient for Stage 9's graceful shutdown.
+// Shutdown performs a graceful drain: it stops accepting and starting NEW jobs,
+// then FIRST WAITS for already-running (in-flight) jobs to finish on their own —
+// without cancelling them — until ctx is done. A job that completes within that
+// window delivers its real result. Only jobs still running when ctx's deadline
+// elapses are cancelled (the backstop), after which Shutdown waits a little more
+// for them to unwind. It returns nil when every in-flight job finished on its own
+// within the window, or ctx.Err() when the deadline forced a cancel.
+//
+// It is safe to call more than once (the closed flag guards a second pass); later
+// Submits are dropped. Pending (queued-but-not-started) jobs are abandoned.
 func (d *Dispatcher) Shutdown(ctx context.Context) error {
 	d.mu.Lock()
 	if d.closed {
@@ -216,11 +257,36 @@ func (d *Dispatcher) Shutdown(ctx context.Context) error {
 	}
 	d.mu.Unlock()
 
-	// Cancel rootCtx so every worker exits via its select and every in-flight
-	// job's ctx (derived from rootCtx) is cancelled. Channels are never closed,
-	// which keeps a concurrent Submit's send safe. Also fire the per-chat cancel
-	// hooks so a job blocked on ctx.Done() unblocks promptly.
-	d.rootStop()
+	// Signal the graceful drain: workers stop dequeuing NEW jobs (and abandon
+	// queued ones) but leave any job they are currently running to finish on its
+	// own. We deliberately do NOT cancel rootCtx or the per-chat cancel hooks here
+	// — that is what lets an in-flight run complete and deliver its real answer.
+	d.drainOnce.Do(func() { close(d.drain) })
+
+	// Phase 1 — wait for in-flight jobs to finish on their own, up to the deadline.
+	// A worker exits once it is idle and sees drain, so wg.Wait() unblocks exactly
+	// when every currently-running job has completed (and the idle workers have
+	// returned).
+	inflightDone := make(chan struct{})
+	go func() {
+		d.wg.Wait()
+		close(inflightDone)
+	}()
+	select {
+	case <-inflightDone:
+		// Every in-flight job finished within the window; tear down the workers and
+		// return cleanly.
+		d.rootStop(ErrShutdown)
+		return nil
+	case <-ctx.Done():
+		// Deadline elapsed with survivors still running.
+	}
+
+	// Phase 2 — cancel the survivors (rootCtx + per-chat hooks) so they unwind, then
+	// give them a brief, bounded grace to deliver a terminal/persist a marker before
+	// the caller exits the process. The grace is independent of the (now-expired)
+	// drain ctx so a survivor's "Stopped"/marker write isn't itself cut off.
+	d.rootStop(ErrShutdown)
 	for _, q := range chats {
 		q.mu.Lock()
 		if q.cancel != nil {
@@ -230,25 +296,49 @@ func (d *Dispatcher) Shutdown(ctx context.Context) error {
 		q.mu.Unlock()
 	}
 
-	done := make(chan struct{})
-	go func() {
-		d.wg.Wait()
-		close(done)
-	}()
+	graceCtx, cancelGrace := context.WithTimeout(context.Background(), postCancelGrace)
+	defer cancelGrace()
 	select {
-	case <-done:
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
+	case <-inflightDone:
+	case <-graceCtx.Done():
 	}
+	return ctx.Err()
 }
 
-// Close stops the dispatcher without waiting for the drain, cancelling in-flight
-// jobs. It is a convenience over Shutdown for callers that don't need to block.
+// postCancelGrace bounds how long Shutdown waits, AFTER cancelling survivors at
+// the drain deadline, for those cancelled jobs to unwind and deliver a terminal
+// message / persist their interrupted-run marker. It keeps total shutdown well
+// under the Docker stop_grace_period so the process self-exits before SIGKILL.
+const postCancelGrace = 10 * time.Second
+
+// Close stops the dispatcher immediately, cancelling in-flight jobs without
+// waiting for the graceful drain. It is the no-drain path for callers that don't
+// need to block.
 func (d *Dispatcher) Close() {
-	// An already-cancelled context makes Shutdown return immediately after it has
-	// signalled cancellation, without blocking on the worker drain.
-	cancelled, cancel := context.WithCancel(context.Background())
-	cancel()
-	_ = d.Shutdown(cancelled)
+	d.mu.Lock()
+	if d.closed {
+		d.mu.Unlock()
+		return
+	}
+	d.closed = true
+	chats := make([]*chatQueue, 0, len(d.chats))
+	for _, q := range d.chats {
+		chats = append(chats, q)
+	}
+	d.mu.Unlock()
+
+	// Cancel everything at once: rootCtx unblocks the workers and cancels every
+	// in-flight job's ctx; the per-chat hooks unblock a job parked on ctx.Done().
+	// Also close drain so a later Shutdown is a no-op and workers always have an
+	// exit signal. Channels are never closed, keeping a concurrent Submit safe.
+	d.drainOnce.Do(func() { close(d.drain) })
+	d.rootStop(ErrShutdown)
+	for _, q := range chats {
+		q.mu.Lock()
+		if q.cancel != nil {
+			q.cancel()
+			q.cancel = nil
+		}
+		q.mu.Unlock()
+	}
 }

--- a/core/dispatch/dispatch_test.go
+++ b/core/dispatch/dispatch_test.go
@@ -183,27 +183,132 @@ func TestCancelUnknownChatNoop(_ *testing.T) {
 	d.Cancel("999") // must not panic
 }
 
-// TestShutdownDrains cancels the in-flight job and waits for workers to drain
-// within the deadline.
+// TestShutdownDrains drives a job that only exits on cancellation through the
+// graceful drain: it survives the (short) drain window, gets cancelled at the
+// deadline, and Shutdown reports the deadline error after the survivor unwinds.
+// Submits after shutdown are dropped no-ops.
 func TestShutdownDrains(t *testing.T) {
 	d := New(2)
 
 	started := make(chan struct{})
 	d.Submit("1", func(ctx context.Context) {
 		close(started)
-		<-ctx.Done() // exits only because Shutdown cancels the job
+		<-ctx.Done() // exits only because Shutdown cancels the job at the deadline
 	})
 	recv(t, started, "job did not start")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
 	defer cancel()
-	if err := d.Shutdown(ctx); err != nil {
-		t.Fatalf("Shutdown did not drain in time: %v", err)
+	if err := d.Shutdown(ctx); err == nil {
+		t.Fatal("Shutdown returned nil; the survivor outlived the drain window and should report the deadline")
 	}
 
 	// Submitting after shutdown is a dropped no-op (must not panic or run).
 	d.Submit("2", func(context.Context) { t.Fatal("job ran after shutdown") })
 	time.Sleep(20 * time.Millisecond)
+}
+
+// TestShutdownWaitsForInFlightThenCancels asserts the graceful-drain contract:
+// Shutdown first WAITS for in-flight jobs to finish on their own (without
+// cancelling them) up to the drain deadline. A job that finishes within the
+// window runs to completion uncancelled, and Shutdown blocks until it returns.
+func TestShutdownWaitsForInFlightThenCancels(t *testing.T) {
+	d := New(2)
+
+	started := make(chan struct{})
+	var cancelled atomic.Bool
+	var completed atomic.Bool
+
+	// A short job (well under the drain window): it must run to completion WITHOUT
+	// observing a cancelled context.
+	d.Submit("1", func(ctx context.Context) {
+		close(started)
+		select {
+		case <-time.After(100 * time.Millisecond):
+			completed.Store(true)
+		case <-ctx.Done():
+			cancelled.Store(true)
+		}
+	})
+	recv(t, started, "job did not start")
+
+	// Generous drain window so the 100ms job finishes inside it. Shutdown must
+	// block until the job returns on its own.
+	drainStart := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := d.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown returned error: %v", err)
+	}
+
+	if cancelled.Load() {
+		t.Fatal("in-flight job was cancelled during the drain window — it should have been left to finish")
+	}
+	if !completed.Load() {
+		t.Fatal("in-flight job did not complete on its own before Shutdown returned")
+	}
+	// Shutdown must have blocked for roughly the job's duration (not returned
+	// immediately by cancelling).
+	if elapsed := time.Since(drainStart); elapsed < 80*time.Millisecond {
+		t.Fatalf("Shutdown returned in %v, expected it to block until the job finished", elapsed)
+	}
+}
+
+// TestShutdownCancelsSurvivorsAfterDrain asserts that a job still running when the
+// drain deadline elapses gets its context cancelled (the backstop), and Shutdown
+// reports the deadline error rather than hanging forever.
+func TestShutdownCancelsSurvivorsAfterDrain(t *testing.T) {
+	d := New(2)
+
+	started := make(chan struct{})
+	cancelled := make(chan struct{})
+
+	// A long job that only exits when its context is cancelled. The drain window is
+	// short, so it must be cancelled at the deadline.
+	d.Submit("1", func(ctx context.Context) {
+		close(started)
+		<-ctx.Done()
+		close(cancelled)
+	})
+	recv(t, started, "job did not start")
+
+	// Short drain window: the job outlives it and must be cancelled.
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+	err := d.Shutdown(ctx)
+	if err == nil {
+		t.Fatal("Shutdown returned nil, want a deadline error when a survivor had to be cancelled")
+	}
+	// The survivor's context must have been cancelled at the deadline so it unwinds.
+	recv(t, cancelled, "survivor job was not cancelled after the drain deadline")
+}
+
+// TestCloseIsImmediate asserts Close cancels in-flight jobs and returns without
+// waiting for the drain window (the no-drain path used by callers that don't
+// block).
+func TestCloseIsImmediate(t *testing.T) {
+	d := New(2)
+
+	started := make(chan struct{})
+	cancelled := make(chan struct{})
+	d.Submit("1", func(ctx context.Context) {
+		close(started)
+		<-ctx.Done()
+		close(cancelled)
+	})
+	recv(t, started, "job did not start")
+
+	done := make(chan struct{})
+	go func() {
+		d.Close()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Close did not return promptly — it should not wait for a drain")
+	}
+	recv(t, cancelled, "Close did not cancel the in-flight job")
 }
 
 // TestSubmitRacesShutdown hammers the Submit||Shutdown window: many goroutines

--- a/core/pending/pending.go
+++ b/core/pending/pending.go
@@ -1,20 +1,30 @@
-// Package pending persists a small, durable map of chatID -> "interrupted run"
-// marker so a run that is still in-flight when the process is killed (e.g. a
-// SIGKILL after the graceful-drain window during a deploy) can be auto-resumed
-// on the next startup WITHOUT the user re-sending their message.
+// Package pending persists a small, durable per-chat QUEUE of "interrupted run"
+// markers so a run that is still in-flight (or merely queued) when the process is
+// killed (e.g. a SIGKILL after the graceful-drain window during a deploy) can be
+// auto-resumed on the next startup WITHOUT the user re-sending their message.
 //
-// A marker records the prompt, the dangling "Working…" anchor message id, and
-// the run's start time. It is written at run START (as early as possible, before
-// the run can be torn down) and cleared on EVERY clean terminal (normal Result,
-// RunError, timeout, user Stop / edit-supersede) so that a deliberately stopped
-// or finished run is NOT resumed. The run-start write is the only writer, so a
-// finished run is never re-marked.
+// A marker records a process-unique ID, the prompt, the dangling "Working…"
+// anchor message id, and the run's start time. A chat's dispatch lane is serial,
+// so at deploy time a chat can hold one RUNNING run plus several QUEUED runs; a
+// single per-chat marker could capture only one of them and a queued job never
+// reaches run-start to write its own. The store therefore keeps a FIFO QUEUE of
+// markers per chat, and a marker is enqueued at SUBMIT time (not run start) so a
+// queued-but-never-started job is captured too.
+//
+// Markers are cleared BY ID on every clean terminal (normal Result, RunError,
+// timeout, spawn error) so a stale or cancelled run can never remove a newer
+// queued run's marker, and a whole lane is cleared at once when the user
+// intentionally purges it (Stop / edit-supersede, where there is no resubmit to
+// preserve). A run cancelled by the dispatcher shutting the process down keeps
+// its marker so the next startup auto-resumes it.
 //
 // The implementation mirrors core/session.FileStore: a single JSON file, loaded
 // once on Open and rewritten atomically (temp file + rename) on each mutation,
-// guarded by a mutex so concurrent chats are race-safe. The value is struct-
-// shaped (see core/nudge for the struct-valued variant). JSON keeps it
-// dependency-free and trivially correct for a small map.
+// guarded by a mutex so concurrent chats are race-safe. The on-disk format is a
+// JSON object keyed by chat id whose value is the ordered slice of that chat's
+// markers, e.g. {"100":[{"id":"1",…},{"id":"2",…}]}. IDs come from a monotonic
+// counter seeded on load above the max persisted id, so an Enqueue after a
+// restart can never collide with a persisted marker the resume loop reuses.
 package pending
 
 import (
@@ -23,6 +33,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
 
 	"github.com/duckbugio/flock/internal/atomicfile"
@@ -31,27 +42,43 @@ import (
 // dirPerm is the owner-only permission for bot-created directories.
 const dirPerm os.FileMode = 0o750
 
-// Marker is one chat's interrupted-run record. AnchorMsgID may be empty when the
-// anchor message could not be created; StartedAt is the Unix-millisecond start
-// time, carried for diagnostics and future staleness pruning.
+// Marker is one interrupted-run record. ID is a process-unique decimal string
+// assigned at Enqueue (used to clear the exact entry on a terminal). AnchorMsgID
+// may be empty when the anchor message could not be created; StartedAt is the
+// Unix-millisecond start time, carried for diagnostics and future staleness
+// pruning.
 type Marker struct {
+	ID          string `json:"id"`
 	Prompt      string `json:"prompt"`
 	AnchorMsgID string `json:"anchorMsgId"`
 	StartedAt   int64  `json:"startedAt"`
 }
 
-// Store persists chatID -> Marker durably and is safe for concurrent use. The
-// chat id is the transport's opaque string id (see core/chat.ChatID).
+// Store persists a per-chat FIFO queue of markers durably and is safe for
+// concurrent use. The chat id is the transport's opaque string id (see
+// core/chat.ChatID).
 type Store interface {
-	// Set records marker for chatID and persists the change durably before
-	// returning. Called once at run start.
-	Set(chatID string, marker Marker) error
-	// Delete removes any stored marker for chatID and persists the change.
-	// Deleting an absent chat is a harmless no-op. Called on every clean terminal.
-	Delete(chatID string) error
-	// All returns a copy of every stored marker keyed by chat id, for the startup
+	// Enqueue assigns a fresh process-unique ID to m, appends it to chatID's
+	// queue, persists the change durably, and returns the assigned ID. m is
+	// passed in WITHOUT an ID. Called at submit time so a queued-but-never-started
+	// run is captured.
+	Enqueue(chatID string, m Marker) (string, error)
+	// SetAnchor sets the AnchorMsgID of the marker with the given id in chatID's
+	// queue and persists the change. A missing chat/id is a harmless no-op (the
+	// marker may already have been cleared).
+	SetAnchor(chatID, id, anchorMsgID string) error
+	// Remove drops the marker with the given id from chatID's queue and persists
+	// the change; if the queue becomes empty the chat key is removed. Removing an
+	// absent chat/id is a harmless no-op (idempotent). Called by id on a clean
+	// terminal so a stale run never removes a newer queued run's marker.
+	Remove(chatID, id string) error
+	// Clear removes ALL markers for chatID (the whole lane) and persists the
+	// change. Clearing an absent chat is a harmless no-op. Called when the user
+	// intentionally purges the lane (Stop / edit-supersede).
+	Clear(chatID string) error
+	// All returns a copy of every chat's ordered marker slice, for the startup
 	// replay loop.
-	All() map[string]Marker
+	All() map[string][]Marker
 }
 
 // FileStore is a JSON-file-backed Store. The whole map is held in memory and the
@@ -60,13 +87,14 @@ type FileStore struct {
 	path string
 
 	mu      sync.Mutex
-	markers map[string]Marker
+	markers map[string][]Marker
+	nextID  uint64 // monotonic ID counter, mutated only under mu
 }
 
 // Open loads (or creates) a FileStore at path. A missing file yields an empty
-// store; a present file is parsed as the persisted map. The parent directory is
-// created if needed. Reopening the SAME path returns whatever was last persisted,
-// which is how interrupted-run markers survive a process restart.
+// store; a present file is parsed as the persisted per-chat queue map. The parent
+// directory is created if needed. Reopening the SAME path returns whatever was
+// last persisted, which is how interrupted-run markers survive a process restart.
 func Open(path string) (*FileStore, error) {
 	if path == "" {
 		return nil, errors.New("pending: store path is empty")
@@ -74,7 +102,7 @@ func Open(path string) (*FileStore, error) {
 	if err := os.MkdirAll(filepath.Dir(path), dirPerm); err != nil {
 		return nil, fmt.Errorf("pending: create store dir: %w", err)
 	}
-	s := &FileStore{path: path, markers: map[string]Marker{}}
+	s := &FileStore{path: path, markers: map[string][]Marker{}, nextID: 1}
 	if err := s.load(); err != nil {
 		return nil, err
 	}
@@ -82,8 +110,11 @@ func Open(path string) (*FileStore, error) {
 }
 
 // load reads and decodes the backing file. A non-existent or empty file is not an
-// error (a fresh store). The on-disk format is a JSON object keyed by the chat id
-// as a string, e.g. {"100":{"prompt":"…","anchorMsgId":"42","startedAt":1}}.
+// error (a fresh store). The on-disk format is a JSON object keyed by chat id
+// whose value is that chat's ordered marker slice. After loading, the ID counter
+// is seeded to max(parsed numeric id) + 1 so a NEW Enqueue after a restart can
+// never collide with the id of a persisted-but-not-yet-cleared marker that the
+// resume loop reuses.
 func (s *FileStore) load() error {
 	data, err := os.ReadFile(s.path)
 	if err != nil {
@@ -95,31 +126,98 @@ func (s *FileStore) load() error {
 	if len(data) == 0 {
 		return nil
 	}
-	raw := map[string]Marker{}
+	raw := map[string][]Marker{}
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return fmt.Errorf("pending: parse store %s: %w", s.path, err)
 	}
+	var maxID uint64
 	for k, v := range raw {
 		s.markers[k] = v
+		for _, m := range v {
+			// Unparseable ids are ignored for the max (defensive; ids are always
+			// assigned numerically by Enqueue).
+			if n, perr := strconv.ParseUint(m.ID, 10, 64); perr == nil && n > maxID {
+				maxID = n
+			}
+		}
 	}
+	s.nextID = maxID + 1
 	return nil
 }
 
-// Set records marker for chatID and rewrites the file atomically. A nil store is
-// a no-op so callers can stay nil-safe when the store failed to open.
-func (s *FileStore) Set(chatID string, marker Marker) error {
+// Enqueue assigns a fresh ID to m, appends it to chatID's queue, persists the
+// change atomically, and returns the assigned ID. A nil store is a no-op that
+// returns "" so callers stay nil-safe when the store failed to open.
+func (s *FileStore) Enqueue(chatID string, m Marker) (string, error) {
+	if s == nil {
+		return "", nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	id := strconv.FormatUint(s.nextID, 10)
+	s.nextID++
+	m.ID = id
+	s.markers[chatID] = append(s.markers[chatID], m)
+	if err := s.persistLocked(); err != nil {
+		return "", err
+	}
+	return id, nil
+}
+
+// SetAnchor sets the AnchorMsgID of the marker with id in chatID's queue and
+// rewrites the file. A missing chat/id is a no-op (no needless rewrite); the
+// marker may already have been cleared. A nil store is a no-op.
+func (s *FileStore) SetAnchor(chatID, id, anchorMsgID string) error {
 	if s == nil {
 		return nil
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.markers[chatID] = marker
+	for i := range s.markers[chatID] {
+		if s.markers[chatID][i].ID == id {
+			s.markers[chatID][i].AnchorMsgID = anchorMsgID
+			return s.persistLocked()
+		}
+	}
+	return nil
+}
+
+// Remove drops the marker with id from chatID's queue and rewrites the file; if
+// the queue becomes empty the chat key is removed. Removing an absent chat/id is
+// a no-op (idempotent). A nil store is a no-op.
+func (s *FileStore) Remove(chatID, id string) error {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	q, ok := s.markers[chatID]
+	if !ok {
+		return nil
+	}
+	idx := -1
+	for i := range q {
+		if q[i].ID == id {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return nil
+	}
+	q = append(q[:idx], q[idx+1:]...)
+	if len(q) == 0 {
+		delete(s.markers, chatID)
+	} else {
+		s.markers[chatID] = q
+	}
 	return s.persistLocked()
 }
 
-// Delete removes chatID's stored marker and rewrites the file. Deleting an absent
-// chat is a no-op (no needless rewrite). A nil store is a no-op.
-func (s *FileStore) Delete(chatID string) error {
+// Clear removes ALL markers for chatID (the whole lane) and rewrites the file.
+// Clearing an absent chat is a no-op (no needless rewrite). A nil store is a
+// no-op.
+func (s *FileStore) Clear(chatID string) error {
 	if s == nil {
 		return nil
 	}
@@ -132,17 +230,17 @@ func (s *FileStore) Delete(chatID string) error {
 	return s.persistLocked()
 }
 
-// All returns a copy of every stored marker. A nil store yields an empty map so
-// the startup replay loop stays nil-safe.
-func (s *FileStore) All() map[string]Marker {
-	out := map[string]Marker{}
+// All returns a copy of every chat's ordered marker slice. A nil store yields an
+// empty map so the startup replay loop stays nil-safe.
+func (s *FileStore) All() map[string][]Marker {
+	out := map[string][]Marker{}
 	if s == nil {
 		return out
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for k, v := range s.markers {
-		out[k] = v
+		out[k] = append([]Marker(nil), v...)
 	}
 	return out
 }

--- a/core/pending/pending.go
+++ b/core/pending/pending.go
@@ -1,0 +1,163 @@
+// Package pending persists a small, durable map of chatID -> "interrupted run"
+// marker so a run that is still in-flight when the process is killed (e.g. a
+// SIGKILL after the graceful-drain window during a deploy) can be auto-resumed
+// on the next startup WITHOUT the user re-sending their message.
+//
+// A marker records the prompt, the dangling "Working…" anchor message id, and
+// the run's start time. It is written at run START (as early as possible, before
+// the run can be torn down) and cleared on EVERY clean terminal (normal Result,
+// RunError, timeout, user Stop / edit-supersede) so that a deliberately stopped
+// or finished run is NOT resumed. The run-start write is the only writer, so a
+// finished run is never re-marked.
+//
+// The implementation mirrors core/session.FileStore: a single JSON file, loaded
+// once on Open and rewritten atomically (temp file + rename) on each mutation,
+// guarded by a mutex so concurrent chats are race-safe. The value is struct-
+// shaped (see core/nudge for the struct-valued variant). JSON keeps it
+// dependency-free and trivially correct for a small map.
+package pending
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/duckbugio/flock/internal/atomicfile"
+)
+
+// dirPerm is the owner-only permission for bot-created directories.
+const dirPerm os.FileMode = 0o750
+
+// Marker is one chat's interrupted-run record. AnchorMsgID may be empty when the
+// anchor message could not be created; StartedAt is the Unix-millisecond start
+// time, carried for diagnostics and future staleness pruning.
+type Marker struct {
+	Prompt      string `json:"prompt"`
+	AnchorMsgID string `json:"anchorMsgId"`
+	StartedAt   int64  `json:"startedAt"`
+}
+
+// Store persists chatID -> Marker durably and is safe for concurrent use. The
+// chat id is the transport's opaque string id (see core/chat.ChatID).
+type Store interface {
+	// Set records marker for chatID and persists the change durably before
+	// returning. Called once at run start.
+	Set(chatID string, marker Marker) error
+	// Delete removes any stored marker for chatID and persists the change.
+	// Deleting an absent chat is a harmless no-op. Called on every clean terminal.
+	Delete(chatID string) error
+	// All returns a copy of every stored marker keyed by chat id, for the startup
+	// replay loop.
+	All() map[string]Marker
+}
+
+// FileStore is a JSON-file-backed Store. The whole map is held in memory and the
+// file is rewritten atomically on every mutation. It is safe for concurrent use.
+type FileStore struct {
+	path string
+
+	mu      sync.Mutex
+	markers map[string]Marker
+}
+
+// Open loads (or creates) a FileStore at path. A missing file yields an empty
+// store; a present file is parsed as the persisted map. The parent directory is
+// created if needed. Reopening the SAME path returns whatever was last persisted,
+// which is how interrupted-run markers survive a process restart.
+func Open(path string) (*FileStore, error) {
+	if path == "" {
+		return nil, errors.New("pending: store path is empty")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), dirPerm); err != nil {
+		return nil, fmt.Errorf("pending: create store dir: %w", err)
+	}
+	s := &FileStore{path: path, markers: map[string]Marker{}}
+	if err := s.load(); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// load reads and decodes the backing file. A non-existent or empty file is not an
+// error (a fresh store). The on-disk format is a JSON object keyed by the chat id
+// as a string, e.g. {"100":{"prompt":"…","anchorMsgId":"42","startedAt":1}}.
+func (s *FileStore) load() error {
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("pending: read store: %w", err)
+	}
+	if len(data) == 0 {
+		return nil
+	}
+	raw := map[string]Marker{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return fmt.Errorf("pending: parse store %s: %w", s.path, err)
+	}
+	for k, v := range raw {
+		s.markers[k] = v
+	}
+	return nil
+}
+
+// Set records marker for chatID and rewrites the file atomically. A nil store is
+// a no-op so callers can stay nil-safe when the store failed to open.
+func (s *FileStore) Set(chatID string, marker Marker) error {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.markers[chatID] = marker
+	return s.persistLocked()
+}
+
+// Delete removes chatID's stored marker and rewrites the file. Deleting an absent
+// chat is a no-op (no needless rewrite). A nil store is a no-op.
+func (s *FileStore) Delete(chatID string) error {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.markers[chatID]; !ok {
+		return nil
+	}
+	delete(s.markers, chatID)
+	return s.persistLocked()
+}
+
+// All returns a copy of every stored marker. A nil store yields an empty map so
+// the startup replay loop stays nil-safe.
+func (s *FileStore) All() map[string]Marker {
+	out := map[string]Marker{}
+	if s == nil {
+		return out
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for k, v := range s.markers {
+		out[k] = v
+	}
+	return out
+}
+
+// persistLocked writes the current map to a temp file in the same directory and
+// renames it over the target, so a crash mid-write never leaves a half-written or
+// corrupt store (rename is atomic on the same filesystem). The caller must hold
+// s.mu.
+func (s *FileStore) persistLocked() error {
+	data, err := json.Marshal(s.markers)
+	if err != nil {
+		return fmt.Errorf("pending: encode store: %w", err)
+	}
+	if err := atomicfile.Write(s.path, data, ".pending-*.tmp"); err != nil {
+		return fmt.Errorf("pending: %w", err)
+	}
+	return nil
+}

--- a/core/pending/pending_test.go
+++ b/core/pending/pending_test.go
@@ -3,63 +3,255 @@ package pending_test
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/duckbugio/flock/core/pending"
 )
 
-// TestSetGetAllRoundTrip asserts a marker set on one store is reloaded by a fresh
-// store opened on the same path (the restart path) and surfaced by All().
-func TestSetGetAllRoundTrip(t *testing.T) {
+// TestEnqueueAssignsDistinctIDs asserts each Enqueue gets a fresh, distinct ID
+// and the markers land in the chat's queue in submit order.
+func TestEnqueueAssignsDistinctIDs(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "pending.json")
 	s, err := pending.Open(path)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
-	want := pending.Marker{Prompt: "do the thing", AnchorMsgID: "42", StartedAt: 1234}
-	if err := s.Set("100", want); err != nil {
-		t.Fatalf("Set: %v", err)
+	id1, err := s.Enqueue("100", pending.Marker{Prompt: "a"})
+	if err != nil {
+		t.Fatalf("Enqueue a: %v", err)
 	}
+	id2, err := s.Enqueue("100", pending.Marker{Prompt: "b"})
+	if err != nil {
+		t.Fatalf("Enqueue b: %v", err)
+	}
+	if id1 == "" || id2 == "" || id1 == id2 {
+		t.Fatalf("expected distinct non-empty ids, got %q and %q", id1, id2)
+	}
+	q := s.All()["100"]
+	if len(q) != 2 || q[0].Prompt != "a" || q[1].Prompt != "b" {
+		t.Fatalf("queue = %+v, want ordered [a, b]", q)
+	}
+	if q[0].ID != id1 || q[1].ID != id2 {
+		t.Fatalf("queue ids = [%q,%q], want [%q,%q]", q[0].ID, q[1].ID, id1, id2)
+	}
+}
 
-	// Reopen on the same path: the marker must survive (this is what makes a
-	// killed run resumable after a restart).
+// TestAllReturnsOrderedSlices asserts All preserves per-chat submit order and
+// returns an independent copy (mutating it does not touch the store).
+func TestAllReturnsOrderedSlices(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pending.json")
+	s, err := pending.Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	for _, p := range []string{"a", "b", "c"} {
+		if _, err := s.Enqueue("1", pending.Marker{Prompt: p}); err != nil {
+			t.Fatalf("Enqueue %s: %v", p, err)
+		}
+	}
+	all := s.All()
+	q := all["1"]
+	if len(q) != 3 || q[0].Prompt != "a" || q[1].Prompt != "b" || q[2].Prompt != "c" {
+		t.Fatalf("queue = %+v, want ordered [a, b, c]", q)
+	}
+	// Mutating the returned copy must not affect the store.
+	q[0].Prompt = "mutated"
+	if again := s.All()["1"]; again[0].Prompt != "a" {
+		t.Fatalf("All returned a shared slice; store mutated to %q", again[0].Prompt)
+	}
+}
+
+// TestRemoveByID asserts Remove drops the exact entry, leaving its siblings, and
+// is idempotent (a second Remove of the same id is a harmless no-op).
+func TestRemoveByID(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pending.json")
+	s, err := pending.Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	id1, _ := s.Enqueue("1", pending.Marker{Prompt: "a"})
+	id2, _ := s.Enqueue("1", pending.Marker{Prompt: "b"})
+
+	if err := s.Remove("1", id1); err != nil {
+		t.Fatalf("Remove id1: %v", err)
+	}
+	q := s.All()["1"]
+	if len(q) != 1 || q[0].ID != id2 || q[0].Prompt != "b" {
+		t.Fatalf("after Remove id1, queue = %+v, want only b", q)
+	}
+	// Idempotent: removing the same id again is a no-op.
+	if err := s.Remove("1", id1); err != nil {
+		t.Fatalf("Remove id1 again: %v", err)
+	}
+	if len(s.All()["1"]) != 1 {
+		t.Fatalf("idempotent Remove changed the queue: %+v", s.All()["1"])
+	}
+}
+
+// TestRemoveDropsEmptyChatKey asserts removing the last marker in a chat's queue
+// deletes the chat key entirely (so All() reports no entry for it).
+func TestRemoveDropsEmptyChatKey(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pending.json")
+	s, err := pending.Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	id, _ := s.Enqueue("1", pending.Marker{Prompt: "only"})
+	if err := s.Remove("1", id); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if _, ok := s.All()["1"]; ok {
+		t.Fatalf("chat key not dropped after removing last marker: %+v", s.All())
+	}
+	// Removing from an absent chat is a no-op.
+	if err := s.Remove("1", "nope"); err != nil {
+		t.Fatalf("Remove absent chat: %v", err)
+	}
+}
+
+// TestClearDropsWholeLane asserts Clear removes every marker for the chat at once
+// and is a no-op for an absent chat.
+func TestClearDropsWholeLane(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pending.json")
+	s, err := pending.Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	_, _ = s.Enqueue("1", pending.Marker{Prompt: "a"})
+	_, _ = s.Enqueue("1", pending.Marker{Prompt: "b"})
+	_, _ = s.Enqueue("2", pending.Marker{Prompt: "c"})
+
+	if err := s.Clear("1"); err != nil {
+		t.Fatalf("Clear: %v", err)
+	}
+	if _, ok := s.All()["1"]; ok {
+		t.Fatalf("lane 1 not cleared: %+v", s.All())
+	}
+	if q := s.All()["2"]; len(q) != 1 || q[0].Prompt != "c" {
+		t.Fatalf("Clear of lane 1 affected lane 2: %+v", q)
+	}
+	// Clearing an absent chat is a no-op.
+	if err := s.Clear("999"); err != nil {
+		t.Fatalf("Clear absent: %v", err)
+	}
+}
+
+// TestSetAnchorUpdatesRightEntry asserts SetAnchor updates only the targeted
+// marker and is a harmless no-op for an absent id.
+func TestSetAnchorUpdatesRightEntry(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pending.json")
+	s, err := pending.Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	id1, _ := s.Enqueue("1", pending.Marker{Prompt: "a"})
+	id2, _ := s.Enqueue("1", pending.Marker{Prompt: "b"})
+
+	if err := s.SetAnchor("1", id2, "anchor-b"); err != nil {
+		t.Fatalf("SetAnchor: %v", err)
+	}
+	q := s.All()["1"]
+	if q[0].ID != id1 || q[0].AnchorMsgID != "" {
+		t.Fatalf("first marker anchor changed: %+v", q[0])
+	}
+	if q[1].ID != id2 || q[1].AnchorMsgID != "anchor-b" {
+		t.Fatalf("second marker anchor not set: %+v", q[1])
+	}
+	// Absent id is a no-op.
+	if err := s.SetAnchor("1", "nope", "x"); err != nil {
+		t.Fatalf("SetAnchor absent id: %v", err)
+	}
+	if err := s.SetAnchor("absent", id1, "x"); err != nil {
+		t.Fatalf("SetAnchor absent chat: %v", err)
+	}
+}
+
+// TestReopenRoundTrip asserts an enqueued queue is reloaded by a fresh store
+// opened on the same path (the restart path) and surfaced by All() in order.
+func TestReopenRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pending.json")
+	s, err := pending.Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	id1, _ := s.Enqueue("100", pending.Marker{Prompt: "first", StartedAt: 1})
+	if err := s.SetAnchor("100", id1, "42"); err != nil {
+		t.Fatalf("SetAnchor: %v", err)
+	}
+	id2, _ := s.Enqueue("100", pending.Marker{Prompt: "second", StartedAt: 2})
+
 	s2, err := pending.Open(path)
 	if err != nil {
 		t.Fatalf("reopen: %v", err)
 	}
-	all := s2.All()
-	got, ok := all["100"]
-	if !ok {
-		t.Fatalf("marker for chat 100 missing after reopen; all=%v", all)
+	q := s2.All()["100"]
+	if len(q) != 2 {
+		t.Fatalf("after reopen queue len = %d, want 2: %+v", len(q), q)
 	}
-	if got != want {
-		t.Fatalf("reloaded marker = %+v, want %+v", got, want)
+	if q[0].ID != id1 || q[0].Prompt != "first" || q[0].AnchorMsgID != "42" || q[0].StartedAt != 1 {
+		t.Fatalf("first marker mis-restored: %+v", q[0])
+	}
+	if q[1].ID != id2 || q[1].Prompt != "second" || q[1].StartedAt != 2 {
+		t.Fatalf("second marker mis-restored: %+v", q[1])
 	}
 }
 
-// TestSetIsAtomicRewrite asserts Set rewrites the whole file atomically: a second
-// Set for a different chat does not lose the first, and no temp files linger.
-func TestSetIsAtomicRewrite(t *testing.T) {
+// TestCounterResumesAboveMaxPersistedID asserts that after a reopen, a new
+// Enqueue yields an id strictly greater than every persisted id, so it can never
+// collide with a persisted-but-not-yet-cleared marker the resume loop reuses.
+func TestCounterResumesAboveMaxPersistedID(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pending.json")
+	s, err := pending.Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	var maxID uint64
+	for i := 0; i < 3; i++ {
+		id, _ := s.Enqueue("1", pending.Marker{Prompt: strconv.Itoa(i)})
+		n, _ := strconv.ParseUint(id, 10, 64)
+		if n > maxID {
+			maxID = n
+		}
+	}
+
+	s2, err := pending.Open(path)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	newID, err := s2.Enqueue("1", pending.Marker{Prompt: "after reopen"})
+	if err != nil {
+		t.Fatalf("Enqueue after reopen: %v", err)
+	}
+	n, err := strconv.ParseUint(newID, 10, 64)
+	if err != nil {
+		t.Fatalf("new id %q not numeric: %v", newID, err)
+	}
+	if n <= maxID {
+		t.Fatalf("new id %d does not exceed max persisted id %d — collision risk", n, maxID)
+	}
+}
+
+// TestEnqueueIsAtomicRewrite asserts Enqueue rewrites the whole file atomically
+// (a second Enqueue for a different chat keeps the first) and leaves no temp
+// files behind.
+func TestEnqueueIsAtomicRewrite(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "pending.json")
 	s, err := pending.Open(path)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
-	if err := s.Set("1", pending.Marker{Prompt: "a"}); err != nil {
-		t.Fatalf("Set 1: %v", err)
+	if _, err := s.Enqueue("1", pending.Marker{Prompt: "a"}); err != nil {
+		t.Fatalf("Enqueue 1: %v", err)
 	}
-	if err := s.Set("2", pending.Marker{Prompt: "b"}); err != nil {
-		t.Fatalf("Set 2: %v", err)
+	if _, err := s.Enqueue("2", pending.Marker{Prompt: "b"}); err != nil {
+		t.Fatalf("Enqueue 2: %v", err)
 	}
-
 	all := s.All()
-	if len(all) != 2 || all["1"].Prompt != "a" || all["2"].Prompt != "b" {
-		t.Fatalf("after two Sets, all=%v want both markers", all)
+	if len(all) != 2 || all["1"][0].Prompt != "a" || all["2"][0].Prompt != "b" {
+		t.Fatalf("after two Enqueues, all=%v want both lanes", all)
 	}
-
-	// The atomic write removes its temp file after the rename — only the final
-	// store file should remain in the directory.
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		t.Fatalf("read dir: %v", err)
@@ -73,40 +265,38 @@ func TestSetIsAtomicRewrite(t *testing.T) {
 	}
 }
 
-// TestDelete asserts a deleted marker is gone after Delete and that deleting an
-// absent chat is a harmless no-op.
-func TestDelete(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "pending.json")
-	s, err := pending.Open(path)
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
-	if err := s.Set("100", pending.Marker{Prompt: "x"}); err != nil {
-		t.Fatalf("Set: %v", err)
-	}
-	if err := s.Delete("100"); err != nil {
-		t.Fatalf("Delete: %v", err)
-	}
-	if _, ok := s.All()["100"]; ok {
-		t.Fatal("marker still present after Delete")
-	}
-	// Deleting an absent chat must not error.
-	if err := s.Delete("999"); err != nil {
-		t.Fatalf("Delete absent: %v", err)
-	}
-}
-
 // TestNilStoreSafe asserts a nil *FileStore behaves as a no-op store so callers
 // can keep running when the store fails to open (best-effort startup wiring).
 func TestNilStoreSafe(t *testing.T) {
 	var s *pending.FileStore
-	if err := s.Set("1", pending.Marker{}); err != nil {
-		t.Fatalf("nil Set: %v", err)
+	if id, err := s.Enqueue("1", pending.Marker{}); err != nil || id != "" {
+		t.Fatalf("nil Enqueue = (%q, %v), want (\"\", nil)", id, err)
 	}
-	if err := s.Delete("1"); err != nil {
-		t.Fatalf("nil Delete: %v", err)
+	if err := s.SetAnchor("1", "1", "a"); err != nil {
+		t.Fatalf("nil SetAnchor: %v", err)
+	}
+	if err := s.Remove("1", "1"); err != nil {
+		t.Fatalf("nil Remove: %v", err)
+	}
+	if err := s.Clear("1"); err != nil {
+		t.Fatalf("nil Clear: %v", err)
 	}
 	if got := s.All(); len(got) != 0 {
 		t.Fatalf("nil All = %v, want empty", got)
+	}
+}
+
+// TestOpenRejectsCorruptFile asserts a file that does not parse into the queue
+// shape (e.g. a stale single-object format) surfaces as an Open error rather than
+// being silently dual-decoded.
+func TestOpenRejectsCorruptFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pending.json")
+	// The old single-object-per-chat format: a chat value that is an object, not
+	// an array — it cannot decode into map[string][]Marker.
+	if err := os.WriteFile(path, []byte(`{"100":{"prompt":"x"}}`), 0o600); err != nil {
+		t.Fatalf("write corrupt file: %v", err)
+	}
+	if _, err := pending.Open(path); err == nil {
+		t.Fatal("Open accepted a corrupt/old-format file; want a parse error")
 	}
 }

--- a/core/pending/pending_test.go
+++ b/core/pending/pending_test.go
@@ -1,0 +1,112 @@
+package pending_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/duckbugio/flock/core/pending"
+)
+
+// TestSetGetAllRoundTrip asserts a marker set on one store is reloaded by a fresh
+// store opened on the same path (the restart path) and surfaced by All().
+func TestSetGetAllRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pending.json")
+	s, err := pending.Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	want := pending.Marker{Prompt: "do the thing", AnchorMsgID: "42", StartedAt: 1234}
+	if err := s.Set("100", want); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	// Reopen on the same path: the marker must survive (this is what makes a
+	// killed run resumable after a restart).
+	s2, err := pending.Open(path)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	all := s2.All()
+	got, ok := all["100"]
+	if !ok {
+		t.Fatalf("marker for chat 100 missing after reopen; all=%v", all)
+	}
+	if got != want {
+		t.Fatalf("reloaded marker = %+v, want %+v", got, want)
+	}
+}
+
+// TestSetIsAtomicRewrite asserts Set rewrites the whole file atomically: a second
+// Set for a different chat does not lose the first, and no temp files linger.
+func TestSetIsAtomicRewrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pending.json")
+	s, err := pending.Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := s.Set("1", pending.Marker{Prompt: "a"}); err != nil {
+		t.Fatalf("Set 1: %v", err)
+	}
+	if err := s.Set("2", pending.Marker{Prompt: "b"}); err != nil {
+		t.Fatalf("Set 2: %v", err)
+	}
+
+	all := s.All()
+	if len(all) != 2 || all["1"].Prompt != "a" || all["2"].Prompt != "b" {
+		t.Fatalf("after two Sets, all=%v want both markers", all)
+	}
+
+	// The atomic write removes its temp file after the rename — only the final
+	// store file should remain in the directory.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "pending.json" {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("dir entries = %v, want only pending.json (no leftover temp files)", names)
+	}
+}
+
+// TestDelete asserts a deleted marker is gone after Delete and that deleting an
+// absent chat is a harmless no-op.
+func TestDelete(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pending.json")
+	s, err := pending.Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := s.Set("100", pending.Marker{Prompt: "x"}); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if err := s.Delete("100"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, ok := s.All()["100"]; ok {
+		t.Fatal("marker still present after Delete")
+	}
+	// Deleting an absent chat must not error.
+	if err := s.Delete("999"); err != nil {
+		t.Fatalf("Delete absent: %v", err)
+	}
+}
+
+// TestNilStoreSafe asserts a nil *FileStore behaves as a no-op store so callers
+// can keep running when the store fails to open (best-effort startup wiring).
+func TestNilStoreSafe(t *testing.T) {
+	var s *pending.FileStore
+	if err := s.Set("1", pending.Marker{}); err != nil {
+		t.Fatalf("nil Set: %v", err)
+	}
+	if err := s.Delete("1"); err != nil {
+		t.Fatalf("nil Delete: %v", err)
+	}
+	if got := s.All(); len(got) != 0 {
+		t.Fatalf("nil All = %v, want empty", got)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,6 +70,22 @@ type Config struct {
 	LogLevel              string `env:"LOG_LEVEL" envDefault:"INFO"`
 	MaxConcurrentChatRuns int    `env:"MAX_CONCURRENT_CHAT_RUNS" envDefault:"4"`
 
+	// ShutdownDrainSeconds bounds the graceful-drain window on SIGTERM: how long
+	// the dispatcher WAITS for in-flight runs to finish on their own before
+	// cancelling the survivors (a run that finishes within the window delivers its
+	// real answer, not "⏹ Stopped."). It must stay strictly below the Docker
+	// stop_grace_period (75s) so the process self-exits before SIGKILL. The default
+	// is 45s; set SHUTDOWN_DRAIN_SECONDS to override.
+	ShutdownDrainSeconds int `env:"SHUTDOWN_DRAIN_SECONDS" envDefault:"45"`
+
+	// PendingStorePath is the JSON file persisting chatID -> interrupted-run marker
+	// (prompt + anchor message id + start time) so a run killed mid-flight on a
+	// deploy is auto-resumed on the next startup. When empty it defaults to
+	// <APPROVED_DIRECTORY>/pending.json (see PendingStoreFile), which lives under
+	// the workspace data dir — a persisted named volume, so the marker survives a
+	// --force-recreate — never inside a repo.
+	PendingStorePath string `env:"PENDING_STORE_PATH"`
+
 	// SessionStorePath is the JSON file persisting chatID -> session_id for
 	// --resume continuity across messages and restarts (plan §4). When empty it
 	// defaults to <APPROVED_DIRECTORY>/sessions.json (see SessionStoreFile), which
@@ -224,6 +240,34 @@ func (c Config) SessionStoreFile() string {
 		return c.SessionStorePath
 	}
 	return filepath.Join(c.ApprovedDirectory, "sessions.json")
+}
+
+// defaultShutdownDrain is the fallback graceful-drain window applied when
+// SHUTDOWN_DRAIN_SECONDS is non-positive. Draining must never be fully disabled
+// (a zero window would cancel every in-flight run immediately), so a bad/zero
+// override falls back to the documented 45s default.
+const defaultShutdownDrain = 45 * time.Second
+
+// ShutdownDrain returns the graceful-drain window as a Duration: how long
+// Shutdown waits for in-flight runs to finish before cancelling survivors. A
+// non-positive SHUTDOWN_DRAIN_SECONDS falls back to defaultShutdownDrain so the
+// drain is never disabled.
+func (c Config) ShutdownDrain() time.Duration {
+	if c.ShutdownDrainSeconds <= 0 {
+		return defaultShutdownDrain
+	}
+	return time.Duration(c.ShutdownDrainSeconds) * time.Second
+}
+
+// PendingStoreFile returns the path to the JSON interrupted-run store, defaulting
+// to <ApprovedDirectory>/pending.json when PENDING_STORE_PATH is unset so it
+// lives under the workspace data dir alongside the session/cost stores, never
+// inside any repo.
+func (c Config) PendingStoreFile() string {
+	if strings.TrimSpace(c.PendingStorePath) != "" {
+		return c.PendingStorePath
+	}
+	return filepath.Join(c.ApprovedDirectory, "pending.json")
 }
 
 // RateLimitWindow returns the per-user rate-limit window as a Duration, or 0

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -248,15 +248,41 @@ func (c Config) SessionStoreFile() string {
 // override falls back to the documented 45s default.
 const defaultShutdownDrain = 45 * time.Second
 
+// maxShutdownDrain caps the graceful-drain window. The shutdown budget is
+// drain + the dispatcher's post-cancel grace (dispatch.postCancelGrace = 10s),
+// and that total MUST stay below the Docker compose stop_grace_period (75s) so
+// the process self-exits before SIGKILL. 60 + 10 = 70 < 75 leaves 5s of
+// headroom. Raising stop_grace_period would require raising this cap to match.
+const maxShutdownDrain = 60 * time.Second
+
 // ShutdownDrain returns the graceful-drain window as a Duration: how long
-// Shutdown waits for in-flight runs to finish before cancelling survivors. A
+// Shutdown waits for in-flight runs to finish before cancelling survivors.
+//
+// The window is clamped to [defaultShutdownDrain, maxShutdownDrain]. A
 // non-positive SHUTDOWN_DRAIN_SECONDS falls back to defaultShutdownDrain so the
-// drain is never disabled.
+// drain is never disabled, and a value above the cap is clamped to
+// maxShutdownDrain. The cap exists because the total shutdown budget is
+// drain + the dispatcher's post-cancel grace (dispatch.postCancelGrace, 10s),
+// and that sum must stay below the compose stop_grace_period (75s) so the
+// process self-exits before SIGKILL — 60 + 10 = 70 < 75. Raising
+// stop_grace_period would require raising maxShutdownDrain to match.
 func (c Config) ShutdownDrain() time.Duration {
 	if c.ShutdownDrainSeconds <= 0 {
 		return defaultShutdownDrain
 	}
-	return time.Duration(c.ShutdownDrainSeconds) * time.Second
+	d := time.Duration(c.ShutdownDrainSeconds) * time.Second
+	if d > maxShutdownDrain {
+		return maxShutdownDrain
+	}
+	return d
+}
+
+// ShutdownDrainClamped reports whether the configured SHUTDOWN_DRAIN_SECONDS
+// exceeded maxShutdownDrain and was clamped down by ShutdownDrain. Startup logs
+// a one-line warning when this is true so an operator who set, say, 120 sees why
+// the effective window is 60s.
+func (c Config) ShutdownDrainClamped() bool {
+	return time.Duration(c.ShutdownDrainSeconds)*time.Second > maxShutdownDrain
 }
 
 // PendingStoreFile returns the path to the JSON interrupted-run store, defaulting

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -179,6 +179,62 @@ func TestClaudeTimeoutDefault(t *testing.T) {
 	}
 }
 
+func TestShutdownDrain(t *testing.T) {
+	for _, tt := range []struct {
+		secs int
+		want time.Duration
+	}{
+		{0, 45 * time.Second},  // non-positive falls back to the 45s default
+		{-5, 45 * time.Second}, // negative also falls back
+		{30, 30 * time.Second}, // override honored
+		{60, 60 * time.Second}, // override honored
+	} {
+		c := Config{ShutdownDrainSeconds: tt.secs}
+		if got := c.ShutdownDrain(); got != tt.want {
+			t.Errorf("ShutdownDrain(%d) = %v, want %v", tt.secs, got, tt.want)
+		}
+	}
+}
+
+func TestShutdownDrainDefault(t *testing.T) {
+	t.Setenv("TELEGRAM_BOT_TOKEN", "token")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() unexpected error: %v", err)
+	}
+	if cfg.ShutdownDrainSeconds != 45 {
+		t.Fatalf("default ShutdownDrainSeconds = %d, want 45", cfg.ShutdownDrainSeconds)
+	}
+	if got := cfg.ShutdownDrain(); got != 45*time.Second {
+		t.Fatalf("default ShutdownDrain() = %v, want %v", got, 45*time.Second)
+	}
+}
+
+func TestShutdownDrainOverride(t *testing.T) {
+	t.Setenv("TELEGRAM_BOT_TOKEN", "token")
+	t.Setenv("SHUTDOWN_DRAIN_SECONDS", "60")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() unexpected error: %v", err)
+	}
+	if got := cfg.ShutdownDrain(); got != 60*time.Second {
+		t.Fatalf("override ShutdownDrain() = %v, want %v", got, 60*time.Second)
+	}
+}
+
+func TestPendingStoreFile(t *testing.T) {
+	// Explicit path wins.
+	c := Config{PendingStorePath: "/var/lib/duck/p.json", ApprovedDirectory: "/workspace"}
+	if got := c.PendingStoreFile(); got != "/var/lib/duck/p.json" {
+		t.Errorf("PendingStoreFile() = %q, want explicit path", got)
+	}
+	// Otherwise derive from APPROVED_DIRECTORY.
+	c = Config{ApprovedDirectory: "/workspace"}
+	if got := c.PendingStoreFile(); got != "/workspace/pending.json" {
+		t.Errorf("PendingStoreFile() = %q, want /workspace/pending.json", got)
+	}
+}
+
 func TestSessionStoreFile(t *testing.T) {
 	// Explicit path wins.
 	c := Config{SessionStorePath: "/var/lib/duck/s.json", ApprovedDirectory: "/workspace"}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -184,14 +184,35 @@ func TestShutdownDrain(t *testing.T) {
 		secs int
 		want time.Duration
 	}{
-		{0, 45 * time.Second},  // non-positive falls back to the 45s default
-		{-5, 45 * time.Second}, // negative also falls back
-		{30, 30 * time.Second}, // override honored
-		{60, 60 * time.Second}, // override honored
+		{0, 45 * time.Second},   // non-positive falls back to the 45s default
+		{-5, 45 * time.Second},  // negative also falls back
+		{30, 30 * time.Second},  // in-range override honored
+		{60, 60 * time.Second},  // exactly the cap passes through
+		{61, 60 * time.Second},  // just over the cap clamps to 60s
+		{120, 60 * time.Second}, // well over the cap clamps to 60s
 	} {
 		c := Config{ShutdownDrainSeconds: tt.secs}
 		if got := c.ShutdownDrain(); got != tt.want {
 			t.Errorf("ShutdownDrain(%d) = %v, want %v", tt.secs, got, tt.want)
+		}
+	}
+}
+
+func TestShutdownDrainClamped(t *testing.T) {
+	for _, tt := range []struct {
+		secs int
+		want bool
+	}{
+		{0, false},  // fallback, not a clamp
+		{-5, false}, // fallback, not a clamp
+		{45, false}, // in range
+		{60, false}, // exactly the cap is not over it
+		{61, true},  // just over the cap is clamped
+		{120, true}, // well over the cap is clamped
+	} {
+		c := Config{ShutdownDrainSeconds: tt.secs}
+		if got := c.ShutdownDrainClamped(); got != tt.want {
+			t.Errorf("ShutdownDrainClamped(%d) = %v, want %v", tt.secs, got, tt.want)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Makes flock shut down gracefully on deploy and resume interrupted work after restart. Previously a deploy (`docker compose up -d --force-recreate` → SIGTERM) **killed** any in-flight run and left a frozen "Working…" message, forcing the user to send another message to continue.

Two parts:

- **A — true graceful drain.** On SIGTERM the dispatcher now stops accepting new work and **waits** for in-flight runs to finish on their own up to a bounded drain window (default 45s, `SHUTDOWN_DRAIN_SECONDS`), cancelling only the runs that don't finish in time, then a short post-cancel grace lets stragglers deliver. Docker `stop_grace_period` raised to **75s** (> drain) so SIGKILL never beats the drain.
- **B — auto-resume after restart.** A run still in-flight when killed leaves a durable per-chat marker (`core/pending`: prompt + anchor message id + start time). On startup the bot reads markers and re-injects each prompt via the existing `Inject` path, so work resumes **without the user poking it**. Markers are cleared on every clean terminal, so a normally-finished or user-Stopped run is never resumed.

## How it works

- `dispatch.Shutdown` reworked to **wait-then-cancel**: Phase 1 waits on the worker WaitGroup until the drain deadline without cancelling; Phase 2 cancels survivors with cause `ErrShutdown` and waits a bounded 10s grace. `Close()` stays immediate.
- The `ErrShutdown` cancellation cause is what distinguishes a deploy-kill (keep the marker → resume) from a user Stop / normal finish (clear the marker → do not resume).
- The marker is written at run **start** (after the workspace resolves, before the CLI spawns) — like the existing `session_id` persistence — so a run killed at the deadline, or even before the session is known, is still resumable. The conversation itself continues via the existing durable session store (`--resume`).
- `core/pending` mirrors `core/session`: atomic file write (temp + fsync + rename), mutex, `0600`/`0750` perms, default path on the persisted `workspace` volume so markers survive `--force-recreate`.

## Acceptance criteria

- [x] **AC1** — `Shutdown` waits for in-flight runs (no cancel) up to the drain window; only stragglers are cancelled; a run finishing in time delivers its real answer, not "Stopped". `Close()` still immediate.
- [x] **AC2** — drain window configurable via `SHUTDOWN_DRAIN_SECONDS` (default 45), used in `main.go` (old 5s const removed); `stop_grace_period: 75s` on the `bot` service in both `docker-compose.yml` and the Ansible template.
- [x] **AC3** — durable per-chat marker written at run start (not at finish, not gated on session init); atomic + mutex; modeled on `core/session`.
- [x] **AC4** — startup replay re-injects each marker via `Inject` before serving, throttled by the existing concurrency cap; best-effort edit of the dangling anchor; markers are not cleared at replay (idempotent).
- [x] **AC5** — marker cleared on every clean terminal (Result / RunError / timeout / user Stop / spawn error), **except** a shutdown-caused cancel; a user-Stopped or finished run is never auto-resumed.

## Verification

- `golangci-lint run` — 0 issues
- `go test -race ./...` — all packages pass (19/19 with tests); the timing-based drain tests are stable under `-race -count=2/3`
- `go build ./cmd/flock-telegram` — ok
- `go mod tidy` — no drift

New tests cover: wait-then-cancel + survivor-cancel + immediate Close (`core/dispatch`); marker round-trip / atomic rewrite / nil-safety (`core/pending`); marker set-at-start, cleared-on-finish, cleared-on-Stop, cleared-on-spawn-error, **survives-shutdown** (`core/chat`); config defaults + overrides.

## Risks

- Drain/grace alignment: 45s drain + 10s grace = 55s, comfortably under the 75s `stop_grace_period`; if these are reconfigured, keep `stop_grace_period` strictly above drain + grace.
- A persistent spawn failure no longer loops (the spawn-error terminal now clears its marker).
- The marker stores only the prompt + anchor id + timestamp — no tokens or PII; same disk-exposure profile as the existing session store.


## Note — VK adapter (shared dispatcher)

`cmd/duck-vk` shares the same `dispatch.Dispatcher` whose `Shutdown` semantics change here (cancel-then-wait → wait-then-cancel + post-cancel grace). The VK adapter is intentionally left untouched in this PR: it keeps its own 5s drain ctx and wires no `Pending` store, so it gains the improved graceful-drain behavior (bounded ≤ ~15s) but no auto-resume, and nothing is left half-built. Giving VK its own `SHUTDOWN_DRAIN_SECONDS` + `stop_grace_period` (and optionally auto-resume) is a sensible follow-up, out of scope for this Telegram-focused change.
