### PR TITLE
feat(claude): configurable effort level via CLAUDE_EFFORT (incl. ultracode)

### DIFF
--- a/cmd/duck-vk/main.go
+++ b/cmd/duck-vk/main.go
@@ -92,6 +92,7 @@ func run() int {
 	opts := claude.Options{
 		Model:    cfg.ClaudeModel,
 		MaxTurns: cfg.ClaudeMaxTurns,
+		Effort:   cfg.ClaudeEffort,
 		Env:      claudeEnv(cfg),
 	}
 

--- a/cmd/flock-telegram/main.go
+++ b/cmd/flock-telegram/main.go
@@ -92,6 +92,7 @@ func run() int {
 	opts := claude.Options{
 		Model:    cfg.ClaudeModel,
 		MaxTurns: cfg.ClaudeMaxTurns,
+		Effort:   cfg.ClaudeEffort,
 		Env:      claudeEnv(cfg),
 	}
 

--- a/core/claude/runner.go
+++ b/core/claude/runner.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os/exec"
 	"strconv"
 	"sync"
@@ -74,11 +75,19 @@ type ImageInput struct {
 
 // Options configures a single Run.
 type Options struct {
-	SessionID string   // resume an existing session; omit --resume when empty
-	Workdir   string   // working/allowed dir; also the child's cwd
-	Model     string   // --model value
-	MaxTurns  int      // --max-turns value
-	Env       []string // child environment (auth, etc.); inherited when nil
+	SessionID string // resume an existing session; omit --resume when empty
+	Workdir   string // working/allowed dir; also the child's cwd
+	Model     string // --model value
+	MaxTurns  int    // --max-turns value
+	// Effort selects the reasoning effort level / "ultracode" mode passed to the
+	// claude CLI. Empty means "pass nothing" (the model's default effort applies).
+	// The standard levels (low, medium, high, xhigh, max) map to the --effort flag.
+	// The special value "ultracode" is NOT a valid --effort value: it is a Claude
+	// Code setting (xhigh to the model PLUS dynamic-workflow orchestration) that can
+	// only be enabled via --settings '{"ultracode":true}'. An unrecognized value is
+	// ignored (logged) so a bad env can't break the CLI invocation. See buildArgs.
+	Effort string
+	Env    []string // child environment (auth, etc.); inherited when nil
 	// Images, when non-empty, switches the run to stream-json stdin input: the
 	// prompt and these image blocks are written as one user message to the child's
 	// stdin (then stdin is closed), enabling Claude vision. When empty the run uses
@@ -212,6 +221,7 @@ func buildArgs(o Options, prompt string, stdinMode bool) []string {
 	if o.MaxTurns > 0 {
 		args = append(args, "--max-turns", strconv.Itoa(o.MaxTurns))
 	}
+	args = applyEffort(args, o.Effort)
 	args = append(args, "--permission-mode", "bypassPermissions")
 	if o.SessionID != "" {
 		args = append(args, "--resume", o.SessionID)
@@ -220,6 +230,94 @@ func buildArgs(o Options, prompt string, stdinMode bool) []string {
 		args = append(args, prompt)
 	}
 	return args
+}
+
+// effortUltracode is the special effort value that selects Claude Code's
+// "ultracode" mode (xhigh to the model PLUS dynamic-workflow orchestration). It
+// is NOT a valid --effort level and is NOT accepted by --effort or
+// CLAUDE_CODE_EFFORT_LEVEL — it can only be enabled via --settings, the /effort
+// menu, or an SDK control request, so we set it via --settings '{"ultracode":true}'.
+const effortUltracode = "ultracode"
+
+// standardEfforts is the set of values accepted by the CLI's --effort flag (the
+// regular reasoning-effort levels). "ultracode" is deliberately NOT here — it
+// takes the --settings path instead (see applyEffort).
+var standardEfforts = map[string]struct{}{
+	"low":    {},
+	"medium": {},
+	"high":   {},
+	"xhigh":  {},
+	"max":    {},
+}
+
+// applyEffort appends the effort-related CLI flags for the configured level and
+// returns the extended args. The mapping is:
+//   - "" (empty/unset): append nothing — the model's default effort applies.
+//   - "ultracode": enable Claude Code's ultracode setting via --settings. If args
+//     ALREADY carries a --settings flag (e.g. flock passes one for permissions),
+//     "ultracode": true is MERGED into that existing JSON (parse -> set key ->
+//     re-marshal) so we never emit a second, conflicting --settings; otherwise a
+//     fresh --settings '{"ultracode":true}' is appended. (As of this writing
+//     buildArgs does NOT pass --settings, so the append branch is taken; the merge
+//     branch is kept so adding a --settings flag later stays correct.)
+//   - a standard level (low/medium/high/xhigh/max): append --effort <level>.
+//   - any other value: ignore it (logged) so a bad CLAUDE_EFFORT env can't break
+//     the CLI invocation.
+func applyEffort(args []string, effort string) []string {
+	switch effort {
+	case "":
+		return args
+	case effortUltracode:
+		return applyUltracode(args)
+	default:
+		if _, ok := standardEfforts[effort]; ok {
+			return append(args, "--effort", effort)
+		}
+		slog.Warn("ignoring unknown claude effort level", "effort", effort)
+		return args
+	}
+}
+
+// applyUltracode enables the ultracode setting. If args already contains a
+// --settings flag, its JSON value is parsed, "ultracode": true is set, and the
+// value is re-marshaled in place (so a single merged --settings is emitted). If
+// the existing value can't be parsed as a JSON object, it is left untouched and
+// ultracode is skipped (logged) rather than risk corrupting the existing
+// settings. When no --settings flag is present, a fresh one is appended.
+func applyUltracode(args []string) []string {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] != "--settings" {
+			continue
+		}
+		merged, ok := mergeUltracode(args[i+1])
+		if !ok {
+			slog.Warn("could not merge ultracode into existing --settings; leaving settings unchanged",
+				"settings", args[i+1])
+			return args
+		}
+		args[i+1] = merged
+		return args
+	}
+	return append(args, "--settings", `{"ultracode":true}`)
+}
+
+// mergeUltracode parses the existing --settings JSON object, sets
+// "ultracode": true, and re-marshals it. It returns ok=false when the value is
+// not a JSON object (so the caller leaves the original settings untouched).
+func mergeUltracode(settings string) (string, bool) {
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(settings), &obj); err != nil {
+		return "", false
+	}
+	if obj == nil {
+		obj = map[string]any{}
+	}
+	obj["ultracode"] = true
+	b, err := json.Marshal(obj)
+	if err != nil {
+		return "", false
+	}
+	return string(b), true
 }
 
 // userMessageEnvelope builds the single newline-terminated stream-json "user"

--- a/core/claude/runner_test.go
+++ b/core/claude/runner_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -368,6 +369,125 @@ func TestBuildArgs_AddDirNeverSwallowsPrompt(t *testing.T) {
 	if next := args[idx+2]; !strings.HasPrefix(next, "--") || next == prompt {
 		t.Fatalf("token after --add-dir value must be a flag, got %q; args = %q", next, args)
 	}
+}
+
+// TestBuildArgs_Effort covers the CLAUDE_EFFORT mapping in buildArgs: empty emits
+// nothing, a standard level (max) becomes "--effort max", "ultracode" takes the
+// --settings '{"ultracode":true}' path (NOT --effort, since ultracode is not a
+// valid --effort value), and an unknown value is ignored so a bad env can't break
+// the invocation. buildArgs does not currently emit a --settings flag of its own,
+// so the ultracode case must append exactly one fresh --settings (the merge path
+// is exercised separately by TestApplyEffort_UltracodeMerges).
+func TestBuildArgs_Effort(t *testing.T) {
+	const prompt = "hello"
+	tests := []struct {
+		name          string
+		effort        string
+		wantEffort    string // expected value after "--effort"; "" means no --effort flag
+		wantSettings  string // expected value after "--settings"; "" means no --settings flag
+		wantNoEffort  bool   // assert "--effort" is entirely absent
+		wantNoSetting bool   // assert "--settings" is entirely absent
+	}{
+		{name: "empty passes nothing", effort: "", wantNoEffort: true, wantNoSetting: true},
+		{name: "standard low", effort: "low", wantEffort: "low", wantNoSetting: true},
+		{name: "standard max", effort: "max", wantEffort: "max", wantNoSetting: true},
+		{name: "standard xhigh", effort: "xhigh", wantEffort: "xhigh", wantNoSetting: true},
+		{name: "ultracode via settings", effort: "ultracode", wantSettings: `{"ultracode":true}`, wantNoEffort: true},
+		{name: "unknown ignored", effort: "bogus", wantNoEffort: true, wantNoSetting: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			args := buildArgs(Options{Model: "m", MaxTurns: 40, Effort: tc.effort}, prompt, false)
+
+			if tc.wantNoEffort && flagValue(args, "--effort") != "" {
+				t.Errorf("expected no --effort flag; args = %q", args)
+			}
+			if tc.wantEffort != "" {
+				if got := flagValue(args, "--effort"); got != tc.wantEffort {
+					t.Errorf("--effort = %q, want %q; args = %q", got, tc.wantEffort, args)
+				}
+			}
+			if tc.wantNoSetting && flagValue(args, "--settings") != "" {
+				t.Errorf("expected no --settings flag; args = %q", args)
+			}
+			if tc.wantSettings != "" {
+				got := flagValue(args, "--settings")
+				if got == "" {
+					t.Fatalf("expected --settings flag; args = %q", args)
+				}
+				// Compare semantically (key set), not byte-for-byte, so map ordering
+				// in the marshaled JSON can't flake the test.
+				if !jsonEqual(t, got, tc.wantSettings) {
+					t.Errorf("--settings = %q, want equivalent of %q; args = %q", got, tc.wantSettings, args)
+				}
+			}
+			// The prompt must always survive as the trailing arg regardless of effort.
+			if len(args) == 0 || args[len(args)-1] != prompt {
+				t.Errorf("prompt must remain the last arg; args = %q", args)
+			}
+		})
+	}
+}
+
+// TestApplyEffort_UltracodeMerges asserts the MERGE branch of the ultracode path:
+// when the args already carry a --settings flag (e.g. flock starts passing one for
+// permissions), "ultracode": true is merged INTO that existing JSON object rather
+// than appended as a second, conflicting --settings. Existing keys are preserved.
+func TestApplyEffort_UltracodeMerges(t *testing.T) {
+	args := []string{"--settings", `{"permissions":{"allow":["Bash"]}}`}
+	got := applyEffort(args, "ultracode")
+
+	// Exactly one --settings flag must remain (no duplicate appended).
+	if n := countFlag(got, "--settings"); n != 1 {
+		t.Fatalf("want exactly one --settings flag after merge, got %d; args = %q", n, got)
+	}
+	val := flagValue(got, "--settings")
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(val), &obj); err != nil {
+		t.Fatalf("merged --settings is not valid JSON: %v; value = %q", err, val)
+	}
+	if got, ok := obj["ultracode"].(bool); !ok || !got {
+		t.Errorf("merged --settings missing ultracode:true; value = %q", val)
+	}
+	if _, ok := obj["permissions"]; !ok {
+		t.Errorf("merge dropped the existing permissions key; value = %q", val)
+	}
+}
+
+// flagValue returns the token immediately following the first occurrence of flag
+// in args, or "" if the flag is absent (or is the final token with no value).
+func flagValue(args []string, flag string) string {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == flag {
+			return args[i+1]
+		}
+	}
+	return ""
+}
+
+// countFlag returns how many times flag appears in args.
+func countFlag(args []string, flag string) int {
+	n := 0
+	for _, a := range args {
+		if a == flag {
+			n++
+		}
+	}
+	return n
+}
+
+// jsonEqual reports whether two JSON strings decode to equal values, ignoring
+// object key ordering in the serialized form.
+func jsonEqual(t *testing.T, a, b string) bool {
+	t.Helper()
+	var av, bv any
+	if err := json.Unmarshal([]byte(a), &av); err != nil {
+		t.Fatalf("decode %q: %v", a, err)
+	}
+	if err := json.Unmarshal([]byte(b), &bv); err != nil {
+		t.Fatalf("decode %q: %v", b, err)
+	}
+	return reflect.DeepEqual(av, bv)
 }
 
 // TestRun_ImageStdinMode asserts that a run carrying an image switches to

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,6 +56,12 @@ type Config struct {
 	ClaudeModel          string `env:"CLAUDE_MODEL" envDefault:"claude-opus-4-8"`
 	ClaudeBin            string `env:"CLAUDE_BIN" envDefault:"claude"`
 	ClaudeMaxTurns       int    `env:"CLAUDE_MAX_TURNS" envDefault:"40"`
+	// ClaudeEffort is the reasoning effort level passed to the claude CLI (set by
+	// roost via CLAUDE_EFFORT). Standard levels (low, medium, high, xhigh, max) map
+	// to --effort; the special value "ultracode" enables Claude Code's ultracode
+	// setting (via --settings). Empty (the default) passes nothing, so the model's
+	// default effort applies. The mapping/validation lives in core/claude buildArgs.
+	ClaudeEffort string `env:"CLAUDE_EFFORT"`
 
 	// ClaudeTimeoutSeconds bounds a single run's delivery: it is applied as a
 	// per-run context deadline. When it elapses the run is cancelled (delivery


### PR DESCRIPTION
Threads a per-bot Claude reasoning-effort selection (set by roost via the CLAUDE_EFFORT env var) into the claude CLI.

- claude.Options.Effort -> buildArgs: standard level (low|medium|high|xhigh|max) -> --effort <level>; **ultracode** -> --settings {"ultracode":true} (a Claude Code setting = xhigh + dynamic-workflow orchestration, NOT a valid --effort value). Empty = model default; unknown value logged+dropped; defensive merge if --settings is ever already present.
- config ClaudeEffort from env CLAUDE_EFFORT; both entrypoints pass it.
- Tests cover each case + the ultracode merge. lint/tests/build green.

Pairs with duckbugio/roost#60 (the CLAUDE_EFFORT catalog field + dropdown UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)