### PR TITLE
fix(chat): stop live progress reading as a duplicate "Working…" bubble

### DIFF
--- a/core/chat/service.go
+++ b/core/chat/service.go
@@ -41,7 +41,16 @@ const minEditInterval = 3 * time.Second
 // anchorText is the persistent message sent at the start of a run. It carries the
 // Stop button (which an ephemeral draft can't) and is later edited into the final
 // answer; the live progress streams separately as a draft.
-const anchorText = "⏳ Working…"
+//
+// Its wording is deliberately NOT the live frame's "Working… (Ns)" header. Where
+// drafts are supported (Telegram 1:1) the anchor and the draft are two SEPARATE
+// bubbles shown side by side, so a "Working…" anchor read as a duplicate of the
+// live "Working… (Ns)" preview (the reported double-bubble bug). A neutral holder
+// line pairs with the live draft without looking like a second progress message.
+// In the edit fallback (groups, VK — no draft) render() overwrites the anchor with
+// the live frame on the first tick, so this text only shows for the brief
+// pre-first-tick instant there; the single-bubble behavior is unchanged.
+const anchorText = "⏳ In progress…"
 
 // workspaceEnsurer resolves a chat's isolated workspace path, creating it (and
 // rendering CLAUDE.md + agents) on first use. *workspace.Renderer satisfies it;

--- a/core/chat/service_test.go
+++ b/core/chat/service_test.go
@@ -523,10 +523,12 @@ func TestRunStreamsProgressAsDraftThenClears(t *testing.T) {
 
 	fc.mu.Lock()
 	defer fc.mu.Unlock()
-	// The anchor was sent as the fixed Stop-bearing anchor text — progress did NOT
-	// ride it (it streams as drafts).
-	if len(fc.sent) == 0 || !strings.Contains(fc.sent[0], "Working") {
-		t.Fatalf("anchor not sent as the Working anchor; sent=%v", fc.sent)
+	// The anchor was sent as the fixed Stop-bearing holder text (anchorText) —
+	// progress did NOT ride it (it streams as drafts). The anchor text is
+	// deliberately NOT the live "Working… (Ns)" frame so it can't read as a
+	// duplicate of the draft preview beside it (the double-bubble fix).
+	if len(fc.sent) == 0 || fc.sent[0] != anchorText {
+		t.Fatalf("anchor not sent as the fixed anchor text %q; sent=%v", anchorText, fc.sent)
 	}
 	// Live progress streamed via at least one draft preview...
 	if len(fc.drafts) == 0 || !strings.Contains(fc.drafts[0], "Working") {
@@ -642,18 +644,21 @@ func TestEditFallbackRespectsMinInterval(t *testing.T) {
 		t.Fatal("no edits happened in fallback mode; counter would be frozen")
 	}
 
-	// The counter advanced across windows: the anchor text shows the elapsed seconds
-	// climbing past the first window, proving the throttle didn't park render().
-	text, _ := fc.snapshot()
-	if !strings.Contains(text, "Working") {
-		t.Fatalf("anchor not showing progress: %q", text)
-	}
-	wantSecs := (windows * 5 * int(step)) / int(time.Second)
-	if wantSecs > 0 && !strings.Contains(text, "("+strconv.Itoa(wantSecs)+"s)") &&
-		!strings.Contains(text, "("+strconv.Itoa(wantSecs-1)+"s)") &&
-		!strings.Contains(text, "("+strconv.Itoa(wantSecs-2)+"s)") {
-		t.Fatalf("counter did not advance to ~%ds: %q", wantSecs, text)
-	}
+	// The counter advanced across windows without the throttle freezing render().
+	// Advancing the clock one more full minEditInterval past the loop's last value
+	// puts the next fast tick unambiguously past the throttle window — whatever the
+	// exact time of the last in-loop edit — so one final edit is deterministically
+	// due. Poll for the counter to reach that value: the real ticker fires the edit
+	// asynchronously, so sampling a single instant is racy under -race scheduling
+	// (the prior approach intermittently observed the counter one window behind when
+	// the last tick had not yet landed or the throttle window straddled the ceiling).
+	clk.advance(minEditInterval)
+	wantSecs := (windows*5*int(step) + int(minEditInterval)) / int(time.Second)
+	waitUntil(t, func() bool {
+		text, _ := fc.snapshot()
+		return strings.Contains(text, "Working") &&
+			strings.Contains(text, "("+strconv.Itoa(wantSecs)+"s)")
+	})
 
 	close(gate)
 }


### PR DESCRIPTION
## Problem

In **1:1 Telegram chats** a run shows **two near-identical "Working…" bubbles**:

- the persistent **anchor** message (`⏳ Working…`, carries the Stop button), and
- the live **draft** preview (`Working… (Ns)`), streamed via `sendMessageDraft`.

`sendMessageDraft` only renders in private chats, so 1:1 takes the draft path (anchor **+** draft = 2 bubbles, ~1s cadence). In **groups** drafts are unsupported, the loop falls back to editing the single anchor in place (~3s cadence), so there is **no duplicate** there. The two-bubble effect is the reported bug.

## Fix

Rename the anchor holder text `⏳ Working…` → `⏳ In progress…` so it pairs with the live draft instead of duplicating it (chosen direction: keep the smooth 1s stream, de-duplicate the anchor). The anchor still carries Stop and is edited into the final answer. In the edit fallback (groups, VK — no draft) `render()` overwrites the anchor with the live frame on the first tick, so single-bubble behavior is **unchanged**.

One-line behavioral change; everything else is the doc comment + test updates.

## Also: de-flake `TestEditFallbackRespectsMinInterval`

Pre-existing flake (reproduced ~20% on `main`, independent of this change): it sampled the counter at a single instant after driving a fake clock, which under `-race` intermittently saw the counter one window behind (final edit not yet landed, or the throttle window straddled the ceiling). Now it advances the clock one more `minEditInterval` to make a final edit deterministically due, and polls for it. 20/20 green under `-race`.

## Verification

- `core/chat` 20/20 under `-race`
- full `task tests` green, `task lint` 0 issues
