### PR TITLE
fix(chat): render run progress as a single in-place edited bubble

### DIFF
--- a/core/chat/service.go
+++ b/core/chat/service.go
@@ -38,19 +38,12 @@ const tickInterval = 1 * time.Second
 // never throttled by this — only the fallback edit branch.
 const minEditInterval = 3 * time.Second
 
-// anchorText is the persistent message sent at the start of a run. It carries the
-// Stop button (which an ephemeral draft can't) and is later edited into the final
-// answer; the live progress streams separately as a draft.
-//
-// Its wording is deliberately NOT the live frame's "Working… (Ns)" header. Where
-// drafts are supported (Telegram 1:1) the anchor and the draft are two SEPARATE
-// bubbles shown side by side, so a "Working…" anchor read as a duplicate of the
-// live "Working… (Ns)" preview (the reported double-bubble bug). A neutral holder
-// line pairs with the live draft without looking like a second progress message.
-// In the edit fallback (groups, VK — no draft) render() overwrites the anchor with
-// the live frame on the first tick, so this text only shows for the brief
-// pre-first-tick instant there; the single-bubble behavior is unchanged.
-const anchorText = "⏳ In progress…"
+// anchorText is the persistent progress message sent at the start of a run. It
+// carries the Stop button and is edited IN PLACE with the live "Working… (Ns)"
+// frame on each (throttled) tick, then edited into the final answer — so a whole
+// run is exactly ONE chat bubble, identical on every platform. This initial text
+// shows only until the first tick replaces it with the live frame.
+const anchorText = "⏳ Working…"
 
 // workspaceEnsurer resolves a chat's isolated workspace path, creating it (and
 // rendering CLAUDE.md + agents) on first use. *workspace.Renderer satisfies it;
@@ -454,30 +447,19 @@ func (s *Service) run(
 	var (
 		lastSent       string
 		throttledUntil time.Time
-		// lastEditAt is the wall-clock time of the last SUCCESSFUL fallback edit; its
-		// zero value lets the first fallback edit fire promptly (so a mid-run flip from
-		// draft to fallback isn't blocked). Only the edit fallback consults it.
-		lastEditAt time.Time
-		// draftStreaming holds while we push live progress as an ephemeral draft (the
-		// rate-limit-free path). The first failed StreamDraft flips it off and the run
-		// falls back to editing the anchor for its remainder.
-		draftStreaming = progressMsgID != ""
-		finalResult    *claude.RunResult
-		finalErr       error
+		// lastEditAt is the wall-clock time of the last SUCCESSFUL progress edit; its
+		// zero value lets the first edit fire promptly.
+		lastEditAt  time.Time
+		finalResult *claude.RunResult
+		finalErr    error
 	)
 
-	// Seed the live preview immediately so it appears without waiting for a tick.
-	if draftStreaming {
-		if err := s.chat.StreamDraft(ctx, chatID, runID, prog.Frame(), true); err != nil {
-			draftStreaming = false
-			s.log.Debug("draft streaming unsupported; falling back to edits", "error", err)
-		} else {
-			lastSent = prog.Frame()
-		}
-	}
-
-	// render pushes the current progress frame: as a rate-limit-free draft preview
-	// while draftStreaming holds, else by editing the anchor (rate-limit aware).
+	// render edits the single anchor message in place with the current progress
+	// frame, rate-limit aware. The anchor IS the one live progress bubble (it also
+	// carries the Stop button), so a run is exactly ONE message on every platform.
+	// Telegram caps message edits, so real edits are throttled to one per
+	// minEditInterval; the 1s ticker only advances the in-memory counter, and most
+	// ticks early-return on frame==lastSent or the throttle.
 	render := func() {
 		if progressMsgID == "" {
 			return
@@ -486,24 +468,14 @@ func (s *Service) run(
 		if frame == lastSent {
 			return
 		}
-		if draftStreaming {
-			err := s.chat.StreamDraft(ctx, chatID, runID, frame, true)
-			if err == nil {
-				lastSent = frame
-				return
-			}
-			// Drafts unsupported here: edit the anchor for the rest of the run.
-			draftStreaming = false
-			s.log.Debug("draft stream failed; falling back to edits", "error", err)
-		}
-		// Fallback: edit the anchor. Skip while rate-limited so we don't hammer the
-		// throttled endpoint (which prolongs the back-off and starves final delivery).
+		// Skip while rate-limited so we don't hammer the throttled endpoint (which
+		// prolongs the back-off and starves final delivery).
 		if !throttledUntil.IsZero() && s.nowFunc().Before(throttledUntil) {
 			return
 		}
-		// Also throttle real edits to one per minEditInterval: the 1s ticker would
-		// otherwise spam the rate-limited Edit endpoint and provoke the 429s above.
-		// The zero value of lastEditAt lets the first fallback edit fire immediately.
+		// Throttle real edits to one per minEditInterval: the 1s ticker would otherwise
+		// spam the rate-limited Edit endpoint and provoke 429s. The zero value of
+		// lastEditAt lets the first edit fire immediately.
 		if !lastEditAt.IsZero() && s.nowFunc().Sub(lastEditAt) < minEditInterval {
 			return
 		}
@@ -546,13 +518,11 @@ loop:
 			case claude.RunError:
 				finalErr = ev.Err
 			default:
-				// Fold the activity event into the renderer and, in draft mode, push it
-				// to the live preview RIGHT AWAY (drafts have no edit rate limit) so the
-				// stream reflects what's happening in real time instead of once a tick.
-				// In the edit fallback we leave rendering to the (rate-limited) ticker.
-				if prog.Observe(ev) && draftStreaming {
-					render()
-				}
+				// Fold the activity event into the renderer. Rendering is left to the
+				// (rate-limited) ticker — the Edit endpoint can't keep up with per-event
+				// edits, so an event only updates the in-memory ring and the next tick
+				// flushes it (throttled).
+				prog.Observe(ev)
 			}
 		}
 	}
@@ -564,7 +534,7 @@ loop:
 	// case their NEXT request is denied (the crossing request still ran).
 	s.recordCost(userID, finalResult)
 
-	s.finish(ctx, chatID, progressMsgID, runID, markerID, finalResult, finalErr, ctx.Err())
+	s.finish(ctx, chatID, progressMsgID, markerID, finalResult, finalErr, ctx.Err())
 
 	// Self-heal a stale/poisoned resume id: when a run that USED a resume session
 	// id terminates with an is_error Result, drop the stored session for this chat
@@ -704,7 +674,7 @@ func (s *Service) clearLanePending(chatID ChatID) {
 // finish renders the terminal message and replaces the progress message with it
 // (chunked when the answer exceeds the platform's message size limit).
 func (s *Service) finish(
-	ctx context.Context, chatID ChatID, progressMsgID MessageID, runID, markerID string,
+	ctx context.Context, chatID ChatID, progressMsgID MessageID, markerID string,
 	res *claude.RunResult, runErr, ctxErr error,
 ) {
 	// Use a background context for delivery: the run ctx may be cancelled by Stop
@@ -726,9 +696,6 @@ func (s *Service) finish(
 	if !genuinelyInterrupted {
 		s.removePending(chatID, markerID)
 	}
-	// Clear the live draft preview (empty text) so it doesn't linger beside the
-	// persisted answer. Best-effort; harmless if no draft was ever streamed.
-	_ = s.chat.StreamDraft(deliverCtx, chatID, runID, "", false)
 	var text string
 	switch {
 	case ctxErr != nil && res == nil && runErr == nil:

--- a/core/chat/service_test.go
+++ b/core/chat/service_test.go
@@ -42,19 +42,17 @@ func openRealStore(path string) (*session.FileStore, error) {
 // the final state. It is safe for concurrent use because edits arrive from the
 // ticker goroutine and the run goroutine.
 type fakeChat struct {
-	mu       sync.Mutex
-	nextID   int
-	texts    map[MessageID]string // current text per message id
-	hasStop  map[MessageID]bool   // whether the message currently shows a Stop button
-	deleted  map[MessageID]bool
-	sent     []string // every Send'd text, in order
-	docs     []string // every SendDocument'd filename, in order
-	nudges   []string // every SendStarNudge'd text, in order
-	drafts   []string // every successful StreamDraft'd text, in order (live preview)
-	draftMD  []bool   // asMarkdown flag for each successful StreamDraft, parallel to drafts
-	draftErr error    // when set, StreamDraft returns it (simulates no draft support)
-	editErr  error    // when set, Edit returns it (e.g. a 429 to exercise throttling)
-	edits    int      // count of Edit calls (progress + final), for the throttle test
+	mu      sync.Mutex
+	nextID  int
+	texts   map[MessageID]string // current text per message id
+	hasStop map[MessageID]bool   // whether the message currently shows a Stop button
+	deleted map[MessageID]bool
+	sent    []string // every Send'd text, in order
+	docs    []string // every SendDocument'd filename, in order
+	nudges  []string // every SendStarNudge'd text, in order
+	drafts  []string // StreamDraft'd text; the run loop no longer drafts, so tests assert this stays empty
+	editErr error    // when set, Edit returns it (e.g. a 429 to exercise throttling)
+	edits   int      // count of Edit calls (progress + final), for the throttle test
 }
 
 func newFakeChat() *fakeChat {
@@ -101,14 +99,10 @@ func (f *fakeChat) editCount() int {
 	return f.edits
 }
 
-func (f *fakeChat) StreamDraft(_ context.Context, _ ChatID, _, text string, asMarkdown bool) error {
+func (f *fakeChat) StreamDraft(_ context.Context, _ ChatID, _, text string, _ bool) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	if f.draftErr != nil {
-		return f.draftErr
-	}
 	f.drafts = append(f.drafts, text)
-	f.draftMD = append(f.draftMD, asMarkdown)
 	return nil
 }
 
@@ -501,10 +495,11 @@ func TestRunRendersProgressThenFinal(t *testing.T) {
 	})
 }
 
-// TestRunStreamsProgressAsDraftThenClears asserts live progress is pushed via the
-// rate-limit-free draft preview (not by editing the anchor), and that the draft is
-// cleared when the answer is finalized into the anchor.
-func TestRunStreamsProgressAsDraftThenClears(t *testing.T) {
+// TestRunDeliversSingleProgressBubble asserts a run is exactly ONE chat bubble: the
+// anchor (carrying the Stop button) is edited in place with progress and then with
+// the final answer, and NO draft preview is ever streamed — so a 1:1 chat no longer
+// shows a second "Working…" bubble beside the anchor.
+func TestRunDeliversSingleProgressBubble(t *testing.T) {
 	fc := newFakeChat()
 	fr := &fakeRunner{events: []claude.Event{
 		{Type: claude.SystemInit, SessionID: "s1"},
@@ -523,57 +518,20 @@ func TestRunStreamsProgressAsDraftThenClears(t *testing.T) {
 
 	fc.mu.Lock()
 	defer fc.mu.Unlock()
-	// The anchor was sent as the fixed Stop-bearing holder text (anchorText) —
-	// progress did NOT ride it (it streams as drafts). The anchor text is
-	// deliberately NOT the live "Working… (Ns)" frame so it can't read as a
-	// duplicate of the draft preview beside it (the double-bubble fix).
+	// The anchor was sent as the fixed Stop-bearing anchor text; it is then edited in
+	// place (progress, then the answer) — one persistent message for the whole run.
 	if len(fc.sent) == 0 || fc.sent[0] != anchorText {
 		t.Fatalf("anchor not sent as the fixed anchor text %q; sent=%v", anchorText, fc.sent)
 	}
-	// Live progress streamed via at least one draft preview...
-	if len(fc.drafts) == 0 || !strings.Contains(fc.drafts[0], "Working") {
-		t.Fatalf("progress not streamed as a draft; drafts=%v", fc.drafts)
-	}
-	// ...rendered as markdown/HTML so `code` and **bold** don't show as raw text.
-	if !fc.draftMD[0] {
-		t.Fatalf("progress draft not pushed with asMarkdown=true; draftMD=%v", fc.draftMD)
-	}
-	// ...and the draft is cleared (empty) once the answer is finalized.
-	last := len(fc.drafts) - 1
-	if fc.drafts[last] != "" {
-		t.Fatalf("draft not cleared on finish; last draft = %q", fc.drafts[last])
-	}
-	// The clear is plain (no formatting) — empty text carries no markdown.
-	if fc.draftMD[last] {
-		t.Fatalf("draft clear should be plain (asMarkdown=false); draftMD=%v", fc.draftMD)
-	}
-}
-
-// TestRunFallsBackToEditsWhenDraftFails asserts that if draft streaming is
-// unsupported (StreamDraft errors), the run still delivers the answer by editing
-// the anchor — nothing is lost and no draft is recorded.
-func TestRunFallsBackToEditsWhenDraftFails(t *testing.T) {
-	fc := newFakeChat()
-	fc.draftErr = errors.New("drafts unsupported")
-	fr := &fakeRunner{events: []claude.Event{
-		{Type: claude.ToolUse, Tool: "Bash"},
-		{Type: claude.Result, Result: &claude.RunResult{Text: finalAnswer}},
-	}}
-	svc, d := newTestService(t, fr, fc)
-	defer d.Close()
-
-	svc.Handle(context.Background(), "100", 100, "1", "hello")
-
-	// Despite drafts failing, the answer still lands — delivered by editing the anchor.
-	waitUntil(t, func() bool {
-		text, stop := fc.snapshot()
-		return text == finalAnswer && !stop
-	})
-
-	fc.mu.Lock()
-	defer fc.mu.Unlock()
+	// No draft preview was ever streamed: the single bubble is the anchor edited in
+	// place, so a 1:1 chat shows no second "Working…" bubble beside it.
 	if len(fc.drafts) != 0 {
-		t.Fatalf("no draft should succeed in fallback mode; got %v", fc.drafts)
+		t.Fatalf("progress must not stream as a draft (single-bubble); drafts=%v", fc.drafts)
+	}
+	// The answer replaced the anchor via an Edit (waitUntil already saw the anchor
+	// text become the answer with the Stop button cleared), not a fresh Send.
+	if fc.edits == 0 {
+		t.Fatalf("answer not delivered by editing the anchor; edits=%d", fc.edits)
 	}
 }
 
@@ -597,14 +555,13 @@ func (c *manualClock) advance(d time.Duration) {
 	c.t = c.t.Add(d)
 }
 
-// TestEditFallbackRespectsMinInterval drives the rate-limited Edit fallback (drafts
-// disabled) with many fast ticks while advancing the injected clock in small steps,
-// and asserts that real edits are bounded to roughly one per minEditInterval window
-// (not one per tick) AND that the rendered counter still advances across windows —
-// i.e. the throttle bounds edits without freezing the counter.
-func TestEditFallbackRespectsMinInterval(t *testing.T) {
+// TestProgressEditsRespectMinInterval drives the rate-limited progress edits with
+// many fast ticks while advancing the injected clock in small steps, and asserts
+// that real edits are bounded to roughly one per minEditInterval window (not one per
+// tick) AND that the rendered counter still advances across windows — i.e. the
+// throttle bounds edits without freezing the counter.
+func TestProgressEditsRespectMinInterval(t *testing.T) {
 	fc := newFakeChat()
-	fc.draftErr = errors.New("drafts unsupported") // force the edit fallback
 	gate := make(chan struct{})
 	fr := &fakeRunner{
 		events: []claude.Event{{Type: claude.ToolUse, Tool: "Bash"}},


### PR DESCRIPTION
## Problem

Even after #31 renamed the anchor, a **1:1 Telegram run still showed two bubbles**: the persistent anchor (Stop button) **plus** a live `Working… (Ns)` draft preview (`sendMessageDraft`). Renaming the anchor only de-duplicated the *text* — the second bubble remained, which still reads as the bug.

## Fix — Variant 1: one bubble (chosen by the user)

Drop draft streaming from the run loop entirely. The **anchor IS the live progress message**: it is edited in place with the `Working… (Ns)` frame (throttled to one edit per `minEditInterval` ≈ 3s) and then into the final answer — **exactly one bubble per run**, identical on every platform. This is the behavior groups/VK already had (and that the user confirmed is fine). The Stop button stays on the anchor.

Trade-off (Telegram API constraint, accepted): a single Stop-bearing message can't be edited faster than ~3s without 429s, so the counter ticks ~3s instead of the draft's 1s. You can't have single-bubble + Stop button + 1s smooth at once.

### Changes
- `service.go`: remove the draft seed, `draftStreaming`, the draft branch in `render()`, the per-event draft render, and the `finish()` draft clear; drop the now-unused `runID` arg from `finish()`. Revert `anchorText` to `⏳ Working…`.
- `service_test.go`: replace the two draft tests with `TestRunDeliversSingleProgressBubble` (anchor sent, **zero drafts**, answer delivered via edit); rename the throttle test to `TestProgressEditsRespectMinInterval`; drop the now-dead fake draft fields.

`Transport.StreamDraft` + adapter implementations are left in place (now unused by the loop) for a separate cleanup PR.

## Verification
- `core/chat` + `TestProgressEditsRespectMinInterval` 15× under `-race`: green
- full `task tests` green, `task lint` 0 issues
