### PR TITLE
feat(chat): separate progress steps with a blank line

### DIFF
--- a/core/chat/progress.go
+++ b/core/chat/progress.go
@@ -50,8 +50,9 @@ const toolDetailSeparator = " · "
 // Telegram's 4096 limit counts) is <= source length. The limit therefore still holds.
 const frameBudgetMax = 3500
 
-// separatorRunes is the rune count of the "\n\n" that separates the header from
-// the activity lines in a frame.
+// separatorRunes is the rune count of the "\n\n" blank-line separator placed
+// between each block of a frame — the header, the optional "+N earlier" indicator,
+// and every activity line — so the steps read as visually separated blocks.
 const separatorRunes = 2
 
 // Activity-line prefixes: a thought balloon for the model's text, and a wrench as
@@ -470,19 +471,14 @@ func (p *Progress) Frame() string {
 	// shown count), so each dropped line raises N by one — keeping the indicator
 	// self-consistent with the drop loop below.
 	assemble := func(ringLines []string) string {
-		var b strings.Builder
-		_, _ = b.WriteString(header)
-		// A blank line sets the activity ("thoughts") apart from the Working header.
-		_, _ = b.WriteString("\n")
+		// Join the header, the optional "+N earlier" indicator and each activity line
+		// with a blank line between them, so the steps read as separated blocks.
+		blocks := []string{header}
 		if hidden := p.total - len(ringLines); hidden > 0 {
-			_ = b.WriteByte('\n')
-			_, _ = fmt.Fprintf(&b, elidedFormat, hidden)
+			blocks = append(blocks, fmt.Sprintf(elidedFormat, hidden))
 		}
-		for _, line := range ringLines {
-			_ = b.WriteByte('\n')
-			_, _ = b.WriteString(line)
-		}
-		return b.String()
+		blocks = append(blocks, ringLines...)
+		return strings.Join(blocks, "\n\n")
 	}
 	for len(lines) > 1 && utf8.RuneCountInString(assemble(lines)) > frameBudgetMax {
 		lines = lines[1:]
@@ -501,8 +497,8 @@ func (p *Progress) Frame() string {
 	// capLine's TEXT cap keeps the whole frame in bounds.
 	overhead := utf8.RuneCountInString(header) + separatorRunes
 	if hidden := p.total - 1; hidden > 0 {
-		// The indicator line plus its leading newline.
-		overhead += 1 + utf8.RuneCountInString(fmt.Sprintf(elidedFormat, hidden))
+		// The indicator block plus its own blank-line separator before the line.
+		overhead += separatorRunes + utf8.RuneCountInString(fmt.Sprintf(elidedFormat, hidden))
 	}
 	for _, prefix := range activityPrefixes {
 		if strings.HasPrefix(lines[0], prefix) {

--- a/core/chat/progress_test.go
+++ b/core/chat/progress_test.go
@@ -54,10 +54,11 @@ func TestActivityRingBounded(t *testing.T) {
 		p.Observe(claude.Event{Type: claude.ToolUse, Tool: tool})
 	}
 	frame := p.Frame()
-	lines := strings.Split(frame, "\n")
-	// 1 header + 1 blank separator + 1 "+2 earlier" indicator + 3 activity lines.
-	if len(lines) != 6 {
-		t.Fatalf("expected header + blank + indicator + 3 ring lines, got %d lines: %q", len(lines), frame)
+	// Blocks are separated by a blank line ("\n\n"): 1 header + 1 "+2 earlier"
+	// indicator + 3 activity lines (the ring is bounded to ringSize=3).
+	blocks := strings.Split(frame, "\n\n")
+	if len(blocks) != 5 {
+		t.Fatalf("expected header + indicator + 3 ring lines, got %d blocks: %q", len(blocks), frame)
 	}
 	// Five pushed, three shown: two scrolled off above the window.
 	if !strings.Contains(frame, "+2 earlier") {
@@ -69,6 +70,28 @@ func TestActivityRingBounded(t *testing.T) {
 	}
 	if strings.Contains(frame, "Read") || strings.Contains(frame, "Grep") {
 		t.Fatalf("ring did not evict oldest tools: %q", frame)
+	}
+}
+
+// TestFrameSeparatesStepsWithBlankLine asserts each activity step is set apart by a
+// blank line, so the steps read as separated blocks instead of a run-together wall.
+func TestFrameSeparatesStepsWithBlankLine(t *testing.T) {
+	var elapsed time.Duration
+	p := NewProgress(fakeClock(&elapsed), 5, "")
+	p.Observe(claude.Event{Type: claude.ToolUse, Tool: "Read"})
+	p.Observe(claude.Event{Type: claude.ToolUse, Tool: "Bash"})
+
+	frame := p.Frame()
+	// Blocks are separated by a blank line ("\n\n"): the header + one block per step.
+	blocks := strings.Split(frame, "\n\n")
+	if len(blocks) != 3 {
+		t.Fatalf("expected header + 2 blank-line-separated steps, got %d blocks: %q", len(blocks), frame)
+	}
+	// Each activity block is a single line — no two steps run together inside a block.
+	for _, b := range blocks[1:] {
+		if strings.Contains(b, "\n") {
+			t.Fatalf("steps not blank-line separated; block has an embedded newline: %q", b)
+		}
 	}
 }
 


### PR DESCRIPTION
## What

The live `Working… (Ns)` progress frame rendered its activity ring with single newlines between steps, so model thoughts and tool calls ran together into a wall of text (user feedback: "добавить разделение между шагами").

Separate each step with a blank line: `assemble()` now joins the header, the `+N earlier` indicator and every activity line with `"\n\n"` instead of `"\n"`.

```
⠏ Working… (6m 49s)

💭 Понял — продолжаю…

⌨️ Bash · cd /workspace/…

🔧 Workflow
```

## Changes
- `progress.go`: `assemble()` joins blocks with `"\n\n"`; the single-survivor hard-truncate overhead now accounts for the indicator's blank-line separator. Frame budget enforcement is unchanged (the drop-oldest loop re-measures the real `assemble()`).
- `progress_test.go`: `TestActivityRingBounded` counts blocks (split on `"\n\n"`); new `TestFrameSeparatesStepsWithBlankLine`.

## Verification
- full `task tests` green, `task lint` 0 issues
