### PR TITLE
chore(chat): remove the unused draft-streaming subsystem

### DIFF
--- a/adapters/telegram/bot.go
+++ b/adapters/telegram/bot.go
@@ -158,51 +158,6 @@ func (c *botChat) Edit(
 	return err
 }
 
-// StreamDraft streams text as an ephemeral live preview keyed by draftID (repeated
-// calls update the same preview; an empty text clears it). It is rate-limit-free
-// relative to EditMessageText, so it carries the live run progress while the answer
-// is persisted with Send/Edit. A draft can't hold an inline keyboard, which is why
-// the Stop button rides a separate anchor message. When asMarkdown is set the frame
-// is rendered as HTML, but — unlike Send/Edit — it falls back to a plain draft on ANY
-// error (not just a parse error) so enabling markup can never knock the preview off
-// the rate-limit-free draft path. asMarkdown is ignored when text is empty (clear).
-func (c *botChat) StreamDraft(ctx context.Context, chatID chat.ChatID, draftID, text string, asMarkdown bool) error {
-	// Rich path first: stream the frame as a native rich draft (sendRichMessageDraft),
-	// passing the Markdown straight through. On any failure fall through to the legacy
-	// HTML/plain draft below — identical contract, so the run loop's draft fallback is
-	// unaffected. Skipped for the empty-text clear (handled by the legacy path).
-	if c.richAttemptable(asMarkdown, text) {
-		err := c.rich.streamDraft(ctx, parseChatID(chatID), draftIDToInt(draftID), richMarkdown(text))
-		c.recordRich(err)
-		if err == nil {
-			return nil
-		}
-	}
-	params := &bot.SendMessageDraftParams{
-		ChatID:  parseChatID(chatID),
-		DraftID: draftID,
-		Text:    text,
-	}
-	if asMarkdown && text != "" {
-		params.Text = MarkdownToHTML(text)
-		params.ParseMode = models.ParseModeHTML
-	}
-	_, err := c.b.SendMessageDraft(ctx, params)
-	if err != nil && asMarkdown && text != "" {
-		// The HTML attempt failed — retry as PLAIN text, UNCONDITIONALLY (not only on
-		// an isParseError). The draft transport may reject parse_mode with an error that
-		// doesn't mention "parse", or not support it at all; if that error propagates,
-		// the run loop flips draftStreaming off and drops to the rate-limited edit
-		// fallback for the rest of the run (smooth ~1s preview -> throttled ~3s steps).
-		// A plain draft keeps the preview on the rate-limit-free path; worst case it is
-		// an unformatted but still-live frame.
-		params.Text = text
-		params.ParseMode = ""
-		_, err = c.b.SendMessageDraft(ctx, params)
-	}
-	return err
-}
-
 // trySendRich attempts to send text as a Bot API 10.1 rich message. It returns
 // (id, true) on success; ("", false) tells Send to fall back to the legacy
 // HTML/plain path. It is a no-op (false) unless rich is enabled, asMarkdown is
@@ -233,27 +188,6 @@ func (c *botChat) tryEditRich(
 	err := c.rich.edit(ctx, chatID, messageID, richMarkdown(text), stopMarkup(stopRunID))
 	c.recordRich(err)
 	return err == nil
-}
-
-// draftIDToInt maps the neutral string draft id (the run id) to the non-zero
-// int64 sendRichMessageDraft requires, stably: the same run id always yields the
-// same id (so Telegram animates updates to one draft), and a zero hash is bumped
-// to 1 since the API rejects draft_id 0.
-func draftIDToInt(draftID string) int64 {
-	const (
-		fnvOffset = 1469598103934665603
-		fnvPrime  = 1099511628211
-	)
-	var h uint64 = fnvOffset
-	for i := 0; i < len(draftID); i++ {
-		h ^= uint64(draftID[i])
-		h *= fnvPrime
-	}
-	id := int64(h >> 1) // shift out the sign bit so the id is always positive
-	if id == 0 {
-		id = 1
-	}
-	return id
 }
 
 // nowTime reads the breaker clock, defaulting to time.Now when none is injected.

--- a/adapters/telegram/bot_rich_test.go
+++ b/adapters/telegram/bot_rich_test.go
@@ -1,4 +1,4 @@
-//nolint:testpackage // whitebox: tests the unexported rich gating/fallback in Send/Edit/StreamDraft
+//nolint:testpackage // whitebox: tests the unexported rich gating/fallback in Send/Edit
 package telegram
 
 import (
@@ -18,14 +18,11 @@ import (
 // fakeRich is a stub richTransport: it records calls and returns a configured id
 // or error so the gating/fallback decisions can be tested without HTTP.
 type fakeRich struct {
-	sendID    int
-	sendErr   error
-	editErr   error
-	draftErr  error
-	sendN     int32
-	editN     int32
-	draftN    int32
-	lastDraft inputRichMessage
+	sendID  int
+	sendErr error
+	editErr error
+	sendN   int32
+	editN   int32
 }
 
 func (f *fakeRich) send(_ context.Context, _ int64, _ inputRichMessage, _ models.ReplyMarkup) (int, error) {
@@ -38,15 +35,9 @@ func (f *fakeRich) edit(_ context.Context, _ int64, _ int, _ inputRichMessage, _
 	return f.editErr
 }
 
-func (f *fakeRich) streamDraft(_ context.Context, _, _ int64, msg inputRichMessage) error {
-	atomic.AddInt32(&f.draftN, 1)
-	f.lastDraft = msg
-	return f.draftErr
-}
-
 // legacyBotServer builds a *bot.Bot pointed at a fake Bot API that counts the
-// legacy sendMessage/editMessageText/sendMessageDraft calls and always succeeds.
-func legacyBotServer(t *testing.T, sendHits, editHits, draftHits *int32) *bot.Bot {
+// legacy sendMessage/editMessageText calls and always succeeds.
+func legacyBotServer(t *testing.T, sendHits, editHits *int32) *bot.Bot {
 	t.Helper()
 	ok := func(w http.ResponseWriter, _ *http.Request) {
 		if err := json.NewEncoder(w).Encode(map[string]any{
@@ -64,12 +55,6 @@ func legacyBotServer(t *testing.T, sendHits, editHits, draftHits *int32) *bot.Bo
 	mux.HandleFunc("/bot123:ABC/editMessageText", func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(editHits, 1)
 		ok(w, r)
-	})
-	mux.HandleFunc("/bot123:ABC/sendMessageDraft", func(w http.ResponseWriter, _ *http.Request) {
-		atomic.AddInt32(draftHits, 1)
-		if err := json.NewEncoder(w).Encode(map[string]any{"ok": true, "result": true}); err != nil {
-			t.Errorf("encode draft response: %v", err)
-		}
 	})
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
@@ -113,8 +98,8 @@ func TestTrySendRichGating(t *testing.T) {
 // TestSendRichSuccessSkipsLegacy: a successful rich send returns the rich id and
 // never touches the legacy sendMessage endpoint.
 func TestSendRichSuccessSkipsLegacy(t *testing.T) {
-	var sendHits, editHits, draftHits int32
-	b := legacyBotServer(t, &sendHits, &editHits, &draftHits)
+	var sendHits, editHits int32
+	b := legacyBotServer(t, &sendHits, &editHits)
 	c := &botChat{b: b, enableRich: true, rich: &fakeRich{sendID: 4242}}
 
 	id, err := c.Send(context.Background(), "555", "# Hi\n\nbody", "", true)
@@ -132,8 +117,8 @@ func TestSendRichSuccessSkipsLegacy(t *testing.T) {
 // TestSendRichErrorFallsBackToLegacy: a rich failure falls through to the legacy
 // sendMessage, which delivers the answer.
 func TestSendRichErrorFallsBackToLegacy(t *testing.T) {
-	var sendHits, editHits, draftHits int32
-	b := legacyBotServer(t, &sendHits, &editHits, &draftHits)
+	var sendHits, editHits int32
+	b := legacyBotServer(t, &sendHits, &editHits)
 	fr := &fakeRich{sendErr: errors.New("rich boom")}
 	c := &botChat{b: b, enableRich: true, rich: fr}
 
@@ -154,8 +139,8 @@ func TestSendRichErrorFallsBackToLegacy(t *testing.T) {
 
 // TestEditRichErrorFallsBackToLegacy mirrors the Send fallback for Edit.
 func TestEditRichErrorFallsBackToLegacy(t *testing.T) {
-	var sendHits, editHits, draftHits int32
-	b := legacyBotServer(t, &sendHits, &editHits, &draftHits)
+	var sendHits, editHits int32
+	b := legacyBotServer(t, &sendHits, &editHits)
 	fr := &fakeRich{editErr: errors.New("rich boom")}
 	c := &botChat{b: b, enableRich: true, rich: fr}
 
@@ -164,44 +149,6 @@ func TestEditRichErrorFallsBackToLegacy(t *testing.T) {
 	}
 	if atomic.LoadInt32(&editHits) != 1 {
 		t.Errorf("legacy editMessageText hits = %d, want 1 (fallback)", editHits)
-	}
-}
-
-// TestStreamDraftRichSuccessSkipsLegacy: a successful rich draft never touches the
-// legacy sendMessageDraft endpoint and carries the Markdown frame.
-func TestStreamDraftRichSuccessSkipsLegacy(t *testing.T) {
-	var sendHits, editHits, draftHits int32
-	b := legacyBotServer(t, &sendHits, &editHits, &draftHits)
-	fr := &fakeRich{}
-	c := &botChat{b: b, enableRich: true, rich: fr}
-
-	if err := c.StreamDraft(context.Background(), "555", "run-1", "**frame**", true); err != nil {
-		t.Fatalf("StreamDraft: %v", err)
-	}
-	if atomic.LoadInt32(&fr.draftN) != 1 {
-		t.Errorf("rich streamDraft calls = %d, want 1", fr.draftN)
-	}
-	if fr.lastDraft.Markdown != "**frame**" {
-		t.Errorf("draft markdown = %q, want the frame text", fr.lastDraft.Markdown)
-	}
-	if atomic.LoadInt32(&draftHits) != 0 {
-		t.Errorf("legacy sendMessageDraft hits = %d, want 0 (rich succeeded)", draftHits)
-	}
-}
-
-// TestStreamDraftRichErrorFallsBackToLegacy: a rich draft failure falls through to
-// the legacy SendMessageDraft.
-func TestStreamDraftRichErrorFallsBackToLegacy(t *testing.T) {
-	var sendHits, editHits, draftHits int32
-	b := legacyBotServer(t, &sendHits, &editHits, &draftHits)
-	fr := &fakeRich{draftErr: errors.New("rich boom")}
-	c := &botChat{b: b, enableRich: true, rich: fr}
-
-	if err := c.StreamDraft(context.Background(), "555", "run-1", "frame", true); err != nil {
-		t.Fatalf("StreamDraft: %v", err)
-	}
-	if atomic.LoadInt32(&draftHits) != 1 {
-		t.Errorf("legacy sendMessageDraft hits = %d, want 1 (fallback)", draftHits)
 	}
 }
 
@@ -238,8 +185,8 @@ func TestRecordRichBreaker(t *testing.T) {
 // TestRichBreakerStopsAttempts: once the breaker trips, Send stops attempting the
 // rich path during the cooldown (no further calls to the rich transport).
 func TestRichBreakerStopsAttempts(t *testing.T) {
-	var sendHits, editHits, draftHits int32
-	b := legacyBotServer(t, &sendHits, &editHits, &draftHits)
+	var sendHits, editHits int32
+	b := legacyBotServer(t, &sendHits, &editHits)
 	fr := &fakeRich{sendErr: errors.New("unsupported")}
 	c := &botChat{b: b, enableRich: true, rich: fr}
 
@@ -286,8 +233,8 @@ func TestRichBreakerCooldownProbe(t *testing.T) {
 // TestSendRichDisabledUsesLegacy: with the flag off, Send takes the legacy path
 // untouched (no rich transport configured).
 func TestSendRichDisabledUsesLegacy(t *testing.T) {
-	var sendHits, editHits, draftHits int32
-	b := legacyBotServer(t, &sendHits, &editHits, &draftHits)
+	var sendHits, editHits int32
+	b := legacyBotServer(t, &sendHits, &editHits)
 	c := &botChat{b: b, enableRich: false} // rich nil — exactly today's behaviour
 
 	if _, err := c.Send(context.Background(), "555", "hello", "", true); err != nil {
@@ -295,24 +242,5 @@ func TestSendRichDisabledUsesLegacy(t *testing.T) {
 	}
 	if atomic.LoadInt32(&sendHits) != 1 {
 		t.Errorf("legacy sendMessage hits = %d, want 1", sendHits)
-	}
-}
-
-// TestDraftIDToInt asserts the run-id → non-zero int64 mapping is stable and
-// distinguishes different ids (sendRichMessageDraft requires a non-zero integer).
-func TestDraftIDToInt(t *testing.T) {
-	if a, b := draftIDToInt("run-1"), draftIDToInt("run-1"); a != b {
-		t.Errorf("not stable: %d != %d", a, b)
-	}
-	if draftIDToInt("run-1") == draftIDToInt("run-2") {
-		t.Error("distinct run ids collided")
-	}
-	for _, s := range []string{"", "0", "run-1", "duck/-5238983644/x"} {
-		if draftIDToInt(s) == 0 {
-			t.Errorf("draftIDToInt(%q) = 0, want non-zero", s)
-		}
-		if draftIDToInt(s) < 0 {
-			t.Errorf("draftIDToInt(%q) = %d, want positive", s, draftIDToInt(s))
-		}
 	}
 }

--- a/adapters/telegram/richtransport.go
+++ b/adapters/telegram/richtransport.go
@@ -21,12 +21,11 @@ import (
 const defaultTelegramAPIBase = "https://api.telegram.org"
 
 // richTransport sends Bot API 10.1 rich messages. It is an interface so the
-// adapter's Send/Edit/StreamDraft can be unit-tested with a fake, and so the HTTP
-// shim is swappable when the upstream lib gains native rich support.
+// adapter's Send/Edit can be unit-tested with a fake, and so the HTTP shim is
+// swappable when the upstream lib gains native rich support.
 type richTransport interface {
 	send(ctx context.Context, chatID int64, msg inputRichMessage, markup models.ReplyMarkup) (messageID int, err error)
 	edit(ctx context.Context, chatID int64, messageID int, msg inputRichMessage, markup models.ReplyMarkup) error
-	streamDraft(ctx context.Context, chatID, draftID int64, msg inputRichMessage) error
 }
 
 // httpRichTransport calls the rich methods directly over HTTP. It exists because
@@ -81,18 +80,6 @@ func (t *httpRichTransport) edit(
 		body["reply_markup"] = markup
 	}
 	_, err := t.call(ctx, "editMessageText", body)
-	return err
-}
-
-// streamDraft posts sendRichMessageDraft: an ephemeral ~30s live preview keyed by
-// an INTEGER draft_id (non-zero; same id animates an update). A draft carries no
-// inline keyboard, so no markup is passed (the Stop button rides the separate
-// anchor message, as on the legacy draft path).
-func (t *httpRichTransport) streamDraft(
-	ctx context.Context, chatID, draftID int64, msg inputRichMessage,
-) error {
-	body := map[string]any{"chat_id": chatID, "draft_id": draftID, "rich_message": msg}
-	_, err := t.call(ctx, "sendRichMessageDraft", body)
 	return err
 }
 

--- a/adapters/telegram/richtransport_test.go
+++ b/adapters/telegram/richtransport_test.go
@@ -86,25 +86,6 @@ func TestHTTPRichTransportEdit(t *testing.T) {
 	}
 }
 
-func TestHTTPRichTransportStreamDraft(t *testing.T) {
-	rs := newRichServer(t, `{"ok":true,"result":true}`)
-	tr := newHTTPRichTransport("123:ABC", rs.srv.URL, rs.srv.Client())
-
-	if err := tr.streamDraft(context.Background(), 555, 99, richMarkdown("frame")); err != nil {
-		t.Fatalf("streamDraft: %v", err)
-	}
-	if !strings.HasSuffix(rs.lastPath, "/sendRichMessageDraft") {
-		t.Errorf("path = %q, want .../sendRichMessageDraft", rs.lastPath)
-	}
-	// draft_id is an integer per the verified schema.
-	if rs.lastBody["draft_id"].(float64) != 99 {
-		t.Errorf("draft_id = %v, want 99", rs.lastBody["draft_id"])
-	}
-	if rs.richMessageField(t)["markdown"] != "frame" {
-		t.Errorf("rich_message.markdown = %v, want frame", rs.richMessageField(t)["markdown"])
-	}
-}
-
 // TestHTTPRichTransportRedactsToken asserts a transport-level error (net/http
 // embeds the token-bearing request URL in its message) never leaks the token.
 func TestHTTPRichTransportRedactsToken(t *testing.T) {

--- a/adapters/vk/api.go
+++ b/adapters/vk/api.go
@@ -2,7 +2,7 @@
 // core/chat conversation layer. It is a hand-rolled net/http client against the
 // VK API (https://api.vk.com/method/<method>, v=5.199) — deliberately NO VK SDK,
 // to keep the dependency tree minimal (net/http only). It implements
-// core/chat.Transport (Send/Edit/Delete/SendDocument/StreamDraft/SendStarNudge/
+// core/chat.Transport (Send/Edit/Delete/SendDocument/SendStarNudge/
 // Capabilities) over messages.send/messages.edit/messages.delete and the
 // docs.* upload dance, classifies VK flood/rate errors for the RetryAfter seam,
 // renders the inline Stop keyboard, runs the Bots Long Poll receive loop, maps

--- a/adapters/vk/bot.go
+++ b/adapters/vk/bot.go
@@ -139,18 +139,6 @@ func (c *botChat) warnKeyboardsDisabled() {
 	})
 }
 
-// StreamDraft is unsupported on VK: it has no ephemeral live-draft primitive, so
-// this returns an error unconditionally. The Service treats that as "drafts
-// unsupported" and falls back to editing the anchor message (the rate-limited
-// progress path), exactly as on a platform without drafts.
-func (c *botChat) StreamDraft(_ context.Context, _ chat.ChatID, _, _ string, _ bool) error {
-	return errDraftUnsupported
-}
-
-// errDraftUnsupported signals the Service that VK cannot stream an ephemeral
-// draft, so it should drive progress via Edit instead.
-var errDraftUnsupported = errors.New("vk: live draft preview unsupported; use message edits")
-
 // Delete removes messageID for everyone; failures are non-fatal to the caller.
 func (c *botChat) Delete(ctx context.Context, chatID chat.ChatID, messageID chat.MessageID) error {
 	return c.api.MessagesDelete(ctx, parsePeerID(chatID), parseMessageID(messageID))

--- a/adapters/vk/bot_test.go
+++ b/adapters/vk/bot_test.go
@@ -112,14 +112,6 @@ func TestSendDocumentUploadsThenSends(t *testing.T) {
 	}
 }
 
-func TestStreamDraftUnsupported(t *testing.T) {
-	c := NewBotChat(NewClient("tok"), 100, 1)
-	err := c.StreamDraft(context.Background(), "200", "draft", "frame", true)
-	if !errors.Is(err, errDraftUnsupported) {
-		t.Errorf("StreamDraft error = %v, want errDraftUnsupported (Service falls back to Edit)", err)
-	}
-}
-
 func TestRetryAfterClassifiesFloodErrors(t *testing.T) {
 	for _, tc := range []struct {
 		name   string

--- a/cmd/duck-vk/main.go
+++ b/cmd/duck-vk/main.go
@@ -1,8 +1,8 @@
 // Command duck-vk is the Go VKontakte (VK) community-bot adapter for flock. Each
 // allowed VK user's DM/mention is dispatched to that chat's isolated workspace
 // and run through the core/claude Runner; the event stream renders to one live
-// "Working… (Ns)" progress message with a Stop button (edited in place, as VK has
-// no ephemeral draft), replaced by the final answer on completion. Runs are
+// "Working… (Ns)" progress message with a Stop button (edited in place), replaced
+// by the final answer on completion. Runs are
 // parallel across chats (capped) and serial within a chat (core/dispatch); each
 // chat gets its own /workspace/chat_<peer_id> with a rendered CLAUDE.md + agents
 // (core/workspace). It wires the SAME shared core/chat.Service the Telegram

--- a/core/chat/service.go
+++ b/core/chat/service.go
@@ -23,10 +23,11 @@ import (
 	"github.com/duckbugio/flock/core/pending"
 )
 
-// tickInterval is how often the wall-clock ticker refreshes the progress frame
-// when no event arrives — it advances the elapsed counter/spinner during a silent
-// tool call (§7.2). Activity events refresh the live draft immediately (see the run
-// loop), so this only governs the quiet-period cadence.
+// tickInterval is how often the wall-clock ticker re-renders the progress frame —
+// it advances the elapsed counter/spinner and flushes any activity folded into the
+// ring since the last tick. Activity events only update the in-memory ring; the
+// ticker is the sole render trigger (real edits are further throttled to
+// minEditInterval), so this is the progress refresh cadence.
 const tickInterval = 1 * time.Second
 
 // minEditInterval throttles real edits in the rate-limited fallback path. Drafts
@@ -423,10 +424,9 @@ func (s *Service) run(
 	start := s.nowFunc()
 	prog := NewProgress(func() time.Duration { return s.nowFunc().Sub(start) }, 0, workdir)
 
-	// The anchor: a persistent message that carries the Stop button (a draft can't)
-	// and is later edited into the final answer. It stays static while live progress
-	// streams as a draft; only the fallback path (no draft support) edits it. An
-	// empty id means no anchor was created (Send failed) — we can still deliver.
+	// The anchor: a persistent message that carries the Stop button and is edited in
+	// place with the live progress frame, then with the final answer. An empty id
+	// means no anchor was created (Send failed) — we can still deliver.
 	progressMsgID, err := s.chat.Send(ctx, chatID, anchorText, runID, false)
 	if err != nil {
 		// Without an anchor we can still deliver the result; keep going.

--- a/core/chat/service_test.go
+++ b/core/chat/service_test.go
@@ -50,7 +50,6 @@ type fakeChat struct {
 	sent    []string // every Send'd text, in order
 	docs    []string // every SendDocument'd filename, in order
 	nudges  []string // every SendStarNudge'd text, in order
-	drafts  []string // StreamDraft'd text; the run loop no longer drafts, so tests assert this stays empty
 	editErr error    // when set, Edit returns it (e.g. a 429 to exercise throttling)
 	edits   int      // count of Edit calls (progress + final), for the throttle test
 }
@@ -97,13 +96,6 @@ func (f *fakeChat) editCount() int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.edits
-}
-
-func (f *fakeChat) StreamDraft(_ context.Context, _ ChatID, _, text string, _ bool) error {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	f.drafts = append(f.drafts, text)
-	return nil
 }
 
 func (f *fakeChat) Delete(_ context.Context, _ ChatID, messageID MessageID) error {
@@ -522,11 +514,6 @@ func TestRunDeliversSingleProgressBubble(t *testing.T) {
 	// place (progress, then the answer) — one persistent message for the whole run.
 	if len(fc.sent) == 0 || fc.sent[0] != anchorText {
 		t.Fatalf("anchor not sent as the fixed anchor text %q; sent=%v", anchorText, fc.sent)
-	}
-	// No draft preview was ever streamed: the single bubble is the anchor edited in
-	// place, so a 1:1 chat shows no second "Working…" bubble beside it.
-	if len(fc.drafts) != 0 {
-		t.Fatalf("progress must not stream as a draft (single-bubble); drafts=%v", fc.drafts)
 	}
 	// The answer replaced the anchor via an Edit (waitUntil already saw the anchor
 	// text become the answer with the Stop button cleared), not a fresh Send.

--- a/core/chat/transport.go
+++ b/core/chat/transport.go
@@ -34,13 +34,6 @@ type Transport interface {
 	// Edit updates an existing message's text (and Stop markup, when stopRunID is
 	// non-empty; empty clears the markup). asMarkdown behaves as for Send.
 	Edit(ctx context.Context, chatID ChatID, messageID MessageID, text, stopRunID string, asMarkdown bool) error
-	// StreamDraft streams text as an ephemeral live "draft" preview keyed by
-	// draftID: repeated calls update the same preview (rate-limit-free, unlike
-	// Edit) and an empty text clears it. Used for live run progress; the answer is
-	// persisted with Send/Edit. asMarkdown behaves as for Send/Edit (ignored when
-	// text is empty). Returns an error when the platform can't stream a draft, so
-	// the caller can fall back to editing a normal message.
-	StreamDraft(ctx context.Context, chatID ChatID, draftID, text string, asMarkdown bool) error
 	// Delete removes a message; failures are non-fatal to the caller.
 	Delete(ctx context.Context, chatID ChatID, messageID MessageID) error
 	// SendDocument uploads a local file to the chat as a document/attachment. The
@@ -67,10 +60,10 @@ type Capabilities struct {
 	// chunker (Telegram 4096). A non-positive value selects a safe default.
 	MaxMessageRunes int
 	// CanSendRich: the platform can render Bot API 10.1 rich messages (structured
-	// blocks + a native rich draft) instead of the legacy MarkdownToHTML/plain
-	// path. It is purely additive — false (the zero value) keeps a transport on the
-	// exact pre-rich behaviour, so a platform that does not set it (VK) needs no
-	// change. Telegram sets it from the ENABLE_RICH_MESSAGES flag; even there the
+	// blocks) instead of the legacy MarkdownToHTML/plain path. It is purely additive
+	// — false (the zero value) keeps a transport on the exact pre-rich behaviour, so
+	// a platform that does not set it (VK) needs no change. Telegram sets it from the
+	// ENABLE_RICH_MESSAGES flag; even there the
 	// rich path always falls back to MarkdownToHTML/plain on any error, so the flag
 	// is a feature toggle, never a hard dependency.
 	CanSendRich bool

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -124,8 +124,8 @@ type Config struct {
 	RequireGroupMention bool `env:"REQUIRE_GROUP_MENTION" envDefault:"false"`
 
 	// EnableRichMessages toggles Bot API 10.1 rich rendering in the Telegram adapter
-	// (Rich Markdown answers + native rich draft). Default true: answers/progress are
-	// sent via sendRichMessage/sendRichMessageDraft. It can never break delivery — the
+	// (Rich Markdown answers). Default true: answers are sent via sendRichMessage and
+	// edited via editMessageText(rich_message=…). It can never break delivery — the
 	// rich path falls back to the legacy MarkdownToHTML/plain rendering on any error,
 	// and the adapter latches rich OFF for the process after repeated failures (so a
 	// deployment where the live API does not yet serve these methods stops paying the


### PR DESCRIPTION
Follow-up cleanup to #32 (single-bubble progress). The run loop no longer streams Telegram drafts, so `StreamDraft` is dead code everywhere. Removes it from the `Transport` interface, the Telegram adapter (`StreamDraft` + `draftIDToInt` + `richTransport.streamDraft` + the `sendRichMessageDraft` HTTP call), the VK adapter (`StreamDraft` + `errDraftUnsupported`), and all draft-specific tests/fakes; tidies stale draft mentions in comments.

**No behavior change** — the removed code was already unreachable after #32. Net **-211 lines**.

Verified: `go build`/`go vet`/`task tests` (-race) all green, `task lint` 0 issues.