### PR TITLE
feat(chat): bare "⌨️ Bash" line + emoji on the "+N earlier" indicator

### DIFF
--- a/core/chat/progress.go
+++ b/core/chat/progress.go
@@ -113,9 +113,10 @@ func buildActivityPrefixes() []string {
 }
 
 // elidedFormat renders the "+N earlier" indicator prepended to the activity block
-// when older lines have scrolled off above the visible window. It is plain English
-// to match the rest of the UI ("Working…", "Stop").
-const elidedFormat = "+%d earlier"
+// when older lines have scrolled off above the visible window. The leading clock
+// emoji matches the activity-line style (every line carries an emoji prefix), so
+// the indicator reads as part of the ring instead of a bare stray line.
+const elidedFormat = "🕓 +%d earlier"
 
 // Units used by formatElapsed to humanize the elapsed counter.
 const (
@@ -191,8 +192,13 @@ func activityLine(e claude.Event, baseDir string) (string, bool) {
 			tool = "tool"
 		}
 		line := tool
-		if detail := toolDetail(tool, e.ToolInput, baseDir); detail != "" {
-			line += toolDetailSeparator + detail
+		// Bash is shown as just "⌨️ Bash": the command itself is long, noisy, and adds
+		// little to the live progress (and can carry secrets). Every other tool still
+		// shows its detail (file path, pattern, query…) — only Bash is bare.
+		if !strings.EqualFold(tool, "bash") {
+			if detail := toolDetail(tool, e.ToolInput, baseDir); detail != "" {
+				line += toolDetailSeparator + detail
+			}
 		}
 		return toolLinePrefix(tool) + truncateRunes(line, recentSnippetMax), true
 	case claude.Text:

--- a/core/chat/progress_test.go
+++ b/core/chat/progress_test.go
@@ -137,7 +137,10 @@ func TestToolUseDetailEnrichment(t *testing.T) {
 			name: "notebookedit file_path", tool: "NotebookEdit",
 			input: `{"file_path":"nb.ipynb"}`, wantSub: "✏️ NotebookEdit · nb.ipynb", wantSep: true,
 		},
-		{name: "bash command", tool: "Bash", input: `{"command":"go test ./..."}`, wantSub: "⌨️ Bash · go test ./...", wantSep: true},
+		{
+			name: "bash command hidden", tool: "Bash",
+			input: `{"command":"go test ./..."}`, wantSub: "⌨️ Bash", wantSep: false, wantMiss: " · ",
+		},
 		{
 			name: "grep pattern", tool: "Grep",
 			input: `{"pattern":"func main","path":"core"}`, wantSub: "🔍 Grep · func main", wantSep: true,
@@ -228,17 +231,33 @@ func TestToolLinePrefixPerTool(t *testing.T) {
 	}
 }
 
-func TestToolUseDetailCollapsesMultilineCommand(t *testing.T) {
+// TestToolDetailCollapsesMultilineCommand checks toolDetail collapses a multi-line
+// detail to one line. Bash is no longer shown with its command in the live frame
+// (see activityLine), so this exercises toolDetail directly rather than via Frame.
+func TestToolDetailCollapsesMultilineCommand(t *testing.T) {
+	got := toolDetail("Bash", []byte("{\"command\":\"echo one\\n   echo two\\n\\techo three\"}"), "")
+	if got != "echo one echo two echo three" {
+		t.Fatalf("multi-line command not collapsed to one line: %q", got)
+	}
+}
+
+// TestActivityLineHidesBashCommand asserts a Bash tool_use renders as a bare
+// "⌨️ Bash" line — never its command — while another tool still shows its detail.
+func TestActivityLineHidesBashCommand(t *testing.T) {
 	var elapsed time.Duration
 	p := NewProgress(fakeClock(&elapsed), 5, "")
-	p.Observe(claude.Event{
-		Type:      claude.ToolUse,
-		Tool:      "Bash",
-		ToolInput: []byte("{\"command\":\"echo one\\n   echo two\\n\\techo three\"}"),
-	})
+	p.Observe(claude.Event{Type: claude.ToolUse, Tool: "Bash", ToolInput: []byte(`{"command":"echo secret"}`)})
+	p.Observe(claude.Event{Type: claude.ToolUse, Tool: "Read", ToolInput: []byte(`{"file_path":"main.go"}`)})
+
 	frame := p.Frame()
-	if !strings.Contains(frame, "⌨️ Bash · echo one echo two echo three") {
-		t.Fatalf("multi-line command not collapsed to one line: %q", frame)
+	if !strings.Contains(frame, "⌨️ Bash") {
+		t.Fatalf("Bash line missing: %q", frame)
+	}
+	if strings.Contains(frame, "echo secret") {
+		t.Fatalf("Bash command leaked into the frame: %q", frame)
+	}
+	if !strings.Contains(frame, "📖 Read · main.go") {
+		t.Fatalf("non-Bash tool lost its detail: %q", frame)
 	}
 }
 
@@ -735,9 +754,9 @@ func TestElidedIndicatorShownWhenEvicted(t *testing.T) {
 		t.Fatalf("expected +%d earlier indicator: %q", extra, frame)
 	}
 	// The indicator must be the FIRST line of the activity block: header, blank,
-	// then the indicator.
+	// then the indicator (carrying the clock-emoji prefix, like the activity lines).
 	lines := strings.Split(frame, "\n")
-	if len(lines) < 3 || lines[2] != "+"+strconv.Itoa(extra)+" earlier" {
+	if len(lines) < 3 || lines[2] != "🕓 +"+strconv.Itoa(extra)+" earlier" {
 		t.Fatalf("indicator not first activity line: %q", frame)
 	}
 	// Exactly ringSize activity lines are kept below the indicator.


### PR DESCRIPTION
Two live-progress tweaks from user feedback:

1. **Bash shows just `⌨️ Bash`** — the command is no longer rendered in the progress frame (long, noisy, can carry secrets). Every other tool still shows its detail (file path / pattern / query / url). The suppression is at the render layer (`activityLine`); `toolDetail` and its secret-redaction are untouched (still unit-tested directly).
2. **`+N earlier` indicator gets a 🕓 prefix** so it matches the emoji style of the activity lines (💭/⌨️/📖/…) instead of reading as a bare stray line.

Tests: updated the table case + multiline test (now exercises `toolDetail` directly) + the indicator-first assertion; added `TestActivityLineHidesBashCommand`. `task tests` (-race) green, `task lint` 0 issues.