### PR TITLE
feat(claude): wire context7 MCP docs server into every run

### DIFF
--- a/cmd/duck-vk/main.go
+++ b/cmd/duck-vk/main.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -94,6 +95,18 @@ func run() int {
 		MaxTurns: cfg.ClaudeMaxTurns,
 		Effort:   cfg.ClaudeEffort,
 		Env:      claudeEnv(cfg),
+	}
+	// Wire the context7 MCP docs server (up-to-date, version-specific library/API
+	// docs) into every run when enabled. A write failure is non-fatal — the bot
+	// runs without it, exactly as before.
+	if cfg.EnableContext7 {
+		mcpPath := filepath.Join(cfg.ApprovedDirectory, ".flock-mcp.json")
+		if err := claude.WriteContext7MCPConfig(mcpPath); err != nil {
+			logger.Warn("write context7 mcp config; running without docs MCP", "error", err)
+		} else {
+			opts.MCPConfig = mcpPath
+			logger.Info("context7 MCP enabled", "config", mcpPath)
+		}
 	}
 
 	ws := &workspace.Renderer{

--- a/cmd/flock-telegram/main.go
+++ b/cmd/flock-telegram/main.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -94,6 +95,18 @@ func run() int {
 		MaxTurns: cfg.ClaudeMaxTurns,
 		Effort:   cfg.ClaudeEffort,
 		Env:      claudeEnv(cfg),
+	}
+	// Wire the context7 MCP docs server (up-to-date, version-specific library/API
+	// docs) into every run when enabled. A write failure is non-fatal — the bot
+	// runs without it, exactly as before.
+	if cfg.EnableContext7 {
+		mcpPath := filepath.Join(cfg.ApprovedDirectory, ".flock-mcp.json")
+		if err := claude.WriteContext7MCPConfig(mcpPath); err != nil {
+			logger.Warn("write context7 mcp config; running without docs MCP", "error", err)
+		} else {
+			opts.MCPConfig = mcpPath
+			logger.Info("context7 MCP enabled", "config", mcpPath)
+		}
 	}
 
 	// Per-chat workspaces (isolated /workspace/chat_<id> with a rendered CLAUDE.md

--- a/core/claude/mcp.go
+++ b/core/claude/mcp.go
@@ -1,0 +1,43 @@
+package claude
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// context7URL is the context7 MCP HTTP endpoint. context7 serves up-to-date,
+// version-specific library/API documentation as tools (resolve-library-id,
+// get-library-docs), so the agent looks real docs up instead of guessing from
+// stale training data — the single highest-leverage accuracy boost for a coding
+// agent. The free tier needs no auth; an unreachable endpoint never breaks a run
+// (the CLI just runs without these tools).
+const context7URL = "https://mcp.context7.com/mcp"
+
+// mcpConfigPerm is the owner-only permission for the written MCP config file.
+const mcpConfigPerm os.FileMode = 0o600
+
+// WriteContext7MCPConfig writes an MCP servers config enabling the context7 docs
+// server to path (overwriting any existing file) and returns an error only on a
+// write/marshal failure. The path is then passed to each run as Options.MCPConfig
+// (--mcp-config). The config matches the Claude Code .mcp.json schema:
+//
+//	{"mcpServers":{"context7":{"type":"http","url":"https://mcp.context7.com/mcp"}}}
+func WriteContext7MCPConfig(path string) error {
+	cfg := map[string]any{
+		"mcpServers": map[string]any{
+			"context7": map[string]any{
+				"type": "http",
+				"url":  context7URL,
+			},
+		},
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal mcp config: %w", err)
+	}
+	if err := os.WriteFile(path, data, mcpConfigPerm); err != nil {
+		return fmt.Errorf("write mcp config %s: %w", path, err)
+	}
+	return nil
+}

--- a/core/claude/mcp_test.go
+++ b/core/claude/mcp_test.go
@@ -1,0 +1,42 @@
+package claude_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/duckbugio/flock/core/claude"
+)
+
+// TestWriteContext7MCPConfig asserts the written file is valid JSON matching the
+// Claude Code .mcp.json schema with a context7 HTTP docs server.
+func TestWriteContext7MCPConfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mcp.json")
+	if err := claude.WriteContext7MCPConfig(path); err != nil {
+		t.Fatalf("WriteContext7MCPConfig: %v", err)
+	}
+	//nolint:gosec // G304: path is a test-controlled temp file.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read written config: %v", err)
+	}
+	// Decode into maps (not a tagged struct) so the test carries no snake/camel json
+	// tags of its own — it just checks the on-disk shape.
+	var cfg map[string]map[string]map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("written config is not valid JSON: %v\n%s", err, data)
+	}
+	c7, ok := cfg["mcpServers"]["context7"]
+	if !ok {
+		t.Fatalf("context7 server missing from config: %s", data)
+	}
+	if c7["type"] != "http" {
+		t.Errorf("context7 type = %v, want http", c7["type"])
+	}
+	url, _ := c7["url"].(string)
+	if !strings.HasPrefix(url, "https://") || !strings.Contains(url, "context7") {
+		t.Errorf("context7 url = %q, want an https context7 endpoint", url)
+	}
+}

--- a/core/claude/runner.go
+++ b/core/claude/runner.go
@@ -79,6 +79,12 @@ type Options struct {
 	Workdir   string // working/allowed dir; also the child's cwd
 	Model     string // --model value
 	MaxTurns  int    // --max-turns value
+	// MCPConfig, when non-empty, is the path to an MCP servers JSON passed to the
+	// CLI as --mcp-config, so the run can use those tools (e.g. context7 library
+	// docs). It is set only when the config was written at startup, so an empty
+	// value (feature disabled or a write failure) is a no-op — and an unreachable
+	// MCP server never breaks a run, the CLI just runs without those tools.
+	MCPConfig string
 	// Effort selects the reasoning effort level / "ultracode" mode passed to the
 	// claude CLI. Empty means "pass nothing" (the model's default effort applies).
 	// The standard levels (low, medium, high, xhigh, max) map to the --effort flag.
@@ -214,6 +220,12 @@ func buildArgs(o Options, prompt string, stdinMode bool) []string {
 	// (--permission-mode at minimum) after its value stops the variadic in time.
 	if o.Workdir != "" {
 		args = append(args, "--add-dir", o.Workdir)
+	}
+	// --mcp-config is ALSO variadic (`--mcp-config <configs...>`); like --add-dir it
+	// must precede the single-value flags so the parser doesn't swallow them as extra
+	// config paths. The next flag (--model/--permission-mode) stops the variadic.
+	if o.MCPConfig != "" {
+		args = append(args, "--mcp-config", o.MCPConfig)
 	}
 	if o.Model != "" {
 		args = append(args, "--model", o.Model)

--- a/core/claude/runner_test.go
+++ b/core/claude/runner_test.go
@@ -371,6 +371,38 @@ func TestBuildArgs_AddDirNeverSwallowsPrompt(t *testing.T) {
 	}
 }
 
+// TestBuildArgs_MCPConfig asserts --mcp-config is emitted only when MCPConfig is
+// set, and — being variadic like --add-dir — its value is followed by a flag (the
+// variadic stop) so it can't swallow the prompt or another flag's value.
+func TestBuildArgs_MCPConfig(t *testing.T) {
+	const prompt = "hi"
+	for _, a := range buildArgs(Options{Workdir: "/ws", Model: "m", MaxTurns: 40}, prompt, false) {
+		if a == "--mcp-config" {
+			t.Fatal("--mcp-config emitted when MCPConfig empty")
+		}
+	}
+	args := buildArgs(Options{Workdir: "/ws", MCPConfig: "/etc/mcp.json", Model: "m", MaxTurns: 40}, prompt, false)
+	idx := -1
+	for i, a := range args {
+		if a == "--mcp-config" {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		t.Fatalf("--mcp-config not emitted when MCPConfig set; args = %q", args)
+	}
+	if idx+2 >= len(args) {
+		t.Fatalf("--mcp-config at the tail with nothing after its value; args = %q", args)
+	}
+	if got := args[idx+1]; got != "/etc/mcp.json" {
+		t.Fatalf("--mcp-config value = %q, want /etc/mcp.json; args = %q", got, args)
+	}
+	if next := args[idx+2]; !strings.HasPrefix(next, "--") {
+		t.Fatalf("token after --mcp-config value must be a flag (variadic stop), got %q; args = %q", next, args)
+	}
+}
+
 // TestBuildArgs_Effort covers the CLAUDE_EFFORT mapping in buildArgs: empty emits
 // nothing, a standard level (max) becomes "--effort max", "ultracode" takes the
 // --settings '{"ultracode":true}' path (NOT --effort, since ultracode is not a

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -145,6 +145,14 @@ type Config struct {
 	TeamTemplatePath string `env:"TEAM_TEMPLATE_PATH" envDefault:"/opt/duck/CLAUDE.workspace.md.tmpl"`
 	TeamAgentsDir    string `env:"TEAM_AGENTS_DIR" envDefault:"/opt/duck/agents"`
 
+	// EnableContext7 wires the context7 MCP docs server into every run (an
+	// .mcp.json is written at startup and passed via --mcp-config). context7 gives
+	// the agent up-to-date, version-specific library/API docs so it stops guessing
+	// outdated APIs — the highest-leverage accuracy boost for a coding agent. The
+	// free tier needs no key; an unreachable server never breaks a run. Set
+	// ENABLE_CONTEXT7=false to opt out.
+	EnableContext7 bool `env:"ENABLE_CONTEXT7" envDefault:"true"`
+
 	// Git startup wiring (core/gitsetup). Mirrors the Python entrypoint's git
 	// portion. GitToken/GitUser also feed the inline credential helper and the
 	// Gitea poller; they are read from the env, never written to a config file.


### PR DESCRIPTION
First step of the flock bot quality upgrade. Adds the **context7 MCP docs server** so the agent fetches up-to-date, version-specific library/API docs (tools `resolve-library-id` / `get-library-docs`) instead of guessing from stale training data — the highest-leverage **accuracy** boost for a coding agent, with no extra model processes (safe on the memory-constrained bot host).

- `claude.WriteContext7MCPConfig` writes an `.mcp.json` (context7 HTTP, free tier, no key) at startup; both bot `main`s write it to `<APPROVED_DIRECTORY>/.flock-mcp.json` when `ENABLE_CONTEXT7` (default true).
- `Options.MCPConfig` + `buildArgs` emit `--mcp-config <path>` (variadic-safe, beside `--add-dir`). Empty/disabled = no-op; an unreachable MCP server never breaks a run.
- `ENABLE_CONTEXT7` knob (default true) to opt out.

Verified in a live bot container: claude 2.1.173 supports `--mcp-config`, context7 endpoint reachable, node/npx present. No new deps (stdlib only). `task tests` (-race) green, `task lint` 0 issues.