### PR TITLE
feat(workspace): render Agent Skills into each chat workspace

### DIFF
--- a/adapters/telegram/Dockerfile
+++ b/adapters/telegram/Dockerfile
@@ -78,6 +78,7 @@ COPY --from=build /out/flock-telegram /usr/local/bin/flock-telegram
 
 # Shared team config — rendered per chat into the workspace by core/workspace at runtime.
 COPY --chown=claude:claude core/agents/*.md /opt/duck/agents/
+COPY --chown=claude:claude core/skills /opt/duck/skills
 COPY --chown=claude:claude core/CLAUDE.workspace.md.tmpl /opt/duck/CLAUDE.workspace.md.tmpl
 
 USER claude

--- a/adapters/vk/Dockerfile
+++ b/adapters/vk/Dockerfile
@@ -80,6 +80,7 @@ COPY --from=build /out/duck-vk /usr/local/bin/duck-vk
 
 # Shared team config — rendered per chat into the workspace by core/workspace at runtime.
 COPY --chown=claude:claude core/agents/*.md /opt/duck/agents/
+COPY --chown=claude:claude core/skills /opt/duck/skills
 COPY --chown=claude:claude core/CLAUDE.workspace.md.tmpl /opt/duck/CLAUDE.workspace.md.tmpl
 
 USER claude

--- a/cmd/duck-vk/main.go
+++ b/cmd/duck-vk/main.go
@@ -113,6 +113,7 @@ func run() int {
 		BaseDir:        cfg.ApprovedDirectory,
 		TemplatePath:   cfg.TeamTemplatePath,
 		AgentsDir:      cfg.TeamAgentsDir,
+		SkillsDir:      cfg.TeamSkillsDir,
 		PrePRCycles:    cfg.PrePRCycles,
 		PrReviewCycles: cfg.PrReviewCycles,
 		EnablePRReview: cfg.EnablePRReview,

--- a/cmd/flock-telegram/main.go
+++ b/cmd/flock-telegram/main.go
@@ -115,6 +115,7 @@ func run() int {
 		BaseDir:        cfg.ApprovedDirectory,
 		TemplatePath:   cfg.TeamTemplatePath,
 		AgentsDir:      cfg.TeamAgentsDir,
+		SkillsDir:      cfg.TeamSkillsDir,
 		PrePRCycles:    cfg.PrePRCycles,
 		PrReviewCycles: cfg.PrReviewCycles,
 		EnablePRReview: cfg.EnablePRReview,

--- a/core/skills/library-docs-lookup/SKILL.md
+++ b/core/skills/library-docs-lookup/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: library-docs-lookup
+description: When writing code against an external library, framework, SDK, or API, look up its CURRENT documentation with the context7 MCP tools instead of relying on memory. Use whenever you import/call a third-party package or hit an unfamiliar or fast-moving API.
+---
+
+# Look up real library docs (don't guess the API)
+
+Training data goes stale: library APIs, method signatures, config keys, and best
+practices change between versions. Guessing them is a top source of subtly-wrong
+code. When you touch an external library/framework/SDK/API, get the CURRENT docs.
+
+## How
+
+The `context7` MCP server is available. Use its tools:
+
+1. **`resolve-library-id`** — resolve the library name (e.g. "tauri",
+   "centrifuge-go", "react-query") to its context7 id.
+2. **`get-library-docs`** — fetch the up-to-date docs for that id, scoped to the
+   topic/symbol you need (the specific hook, method, or config option).
+
+Pull the version the project actually depends on — check `go.mod` /
+`package.json` / `Cargo.toml` / `requirements.txt` — not "latest", when they
+differ.
+
+## When to use it
+
+- Calling a method/option you're not 100% sure exists in the version in use.
+- Wiring up a new dependency, an SDK client, or a framework feature.
+- An unfamiliar or fast-moving library (cloud SDKs, web frameworks, build tools).
+- A compile/runtime error that looks like an API mismatch.
+
+## When NOT to bother
+
+- The standard library or a tiny, stable utility you know cold.
+- Pure project-internal code — read the repo, not external docs.
+
+Prefer one focused docs lookup over a wrong guess you then have to debug.

--- a/core/skills/verification-before-completion/SKILL.md
+++ b/core/skills/verification-before-completion/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: verification-before-completion
+description: Before telling the user a coding task is done, actually verify it — build, run the relevant tests/linter, and confirm the change does what was asked with no regressions. Use whenever you are about to claim a change is finished, fixed, or working.
+---
+
+# Verify before you claim it's done
+
+Saying "done" without checking is the most common way an agent ships a broken
+change. Before you report a coding task as finished, fixed, or working, VERIFY
+it — do not assume.
+
+## Checklist (do it, don't narrate it)
+
+1. **Build / compile** what you changed. If it doesn't build, it isn't done.
+2. **Run the relevant tests** with the project's own command (a `Taskfile`/
+   `Makefile` target, `go test`, `npm test`, …). Run the narrowest command that
+   covers your change first, then the fuller suite if it's cheap. If the area you
+   changed has no test and the change is non-trivial, add one.
+3. **Run the linter/formatter** the project uses and fix what it flags.
+4. **Re-read the request** and confirm EVERY part is addressed — not just the
+   easy part. Check the edge cases and error paths you touched.
+5. **Look for regressions** — did the change break a caller, a contract, a test,
+   or a neighbouring feature?
+
+## Reporting
+
+- Report what you actually ran and its result ("`go test ./...` green, `task
+  lint` 0 issues"), never "should work".
+- If something failed, or you could not verify a part, SAY SO plainly — never
+  paper over a failure or a skipped step.
+- If a test fails, fix the code (or the test, if the test was wrong) before
+  claiming done — don't hand back a red build.
+
+A task is "done" only when you have evidence it works, not when the code looks
+right.

--- a/core/workspace/workspace.go
+++ b/core/workspace/workspace.go
@@ -31,6 +31,9 @@ type Renderer struct {
 	TemplatePath string
 	// AgentsDir holds the dev-team agent *.md files to copy into .claude/agents/.
 	AgentsDir string
+	// SkillsDir holds the Agent Skills to copy into .claude/skills/ (each skill is a
+	// <name>/SKILL.md subdirectory). Empty or a missing dir disables skills.
+	SkillsDir string
 
 	// PrePRCycles, PrReviewCycles, EnablePRReview and GitHost are substituted into
 	// the template for the ${PRE_PR_CYCLES} ${PR_REVIEW_CYCLES} ${ENABLE_PR_REVIEW}
@@ -61,6 +64,9 @@ func (r *Renderer) Ensure(chatID string) (string, error) {
 		return "", err
 	}
 	if err := r.copyAgents(agentsDst); err != nil {
+		return "", err
+	}
+	if err := r.copySkills(filepath.Join(ws, ".claude", "skills")); err != nil {
 		return "", err
 	}
 	return ws, nil
@@ -169,4 +175,54 @@ func (r *Renderer) copyAgents(agentsDst string) error {
 		}
 	}
 	return nil
+}
+
+// copySkills mirrors SkillsDir into skillsDst, preserving each skill's
+// subdirectory layout (.claude/skills/<name>/SKILL.md plus any supporting files).
+// A skill loads on demand, so this is additive context that costs nothing until
+// used. An empty or absent SkillsDir is a no-op (skills are an optional feature);
+// only a copy failure inside an existing dir is an error.
+func (r *Renderer) copySkills(skillsDst string) error {
+	if r.SkillsDir == "" {
+		return nil
+	}
+	info, err := os.Stat(r.SkillsDir)
+	if os.IsNotExist(err) {
+		return nil // not baked in this image — skip silently (optional feature)
+	}
+	if err != nil {
+		return fmt.Errorf("stat skills dir: %w", err)
+	}
+	if !info.IsDir() {
+		return nil
+	}
+	return filepath.WalkDir(r.SkillsDir, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(r.SkillsDir, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+		dst := filepath.Join(skillsDst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(dst, dirPerm)
+		}
+		//nolint:gosec // G304: path comes from WalkDir over an internal baked dir.
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read skill %s: %w", rel, err)
+		}
+		if err := os.MkdirAll(filepath.Dir(dst), dirPerm); err != nil {
+			return fmt.Errorf("create skill dir %s: %w", rel, err)
+		}
+		//nolint:gosec // G703: dst is a join of internal dirs and baked entry names.
+		if err := os.WriteFile(dst, data, filePerm); err != nil {
+			return fmt.Errorf("write skill %s: %w", rel, err)
+		}
+		return nil
+	})
 }

--- a/core/workspace/workspace_test.go
+++ b/core/workspace/workspace_test.go
@@ -96,6 +96,47 @@ func TestEnsureRendersWorkspace(t *testing.T) {
 	}
 }
 
+// TestEnsureCopiesSkills asserts the skills tree (each <name>/SKILL.md) is mirrored
+// into the workspace's .claude/skills/, preserving the subdirectory layout.
+func TestEnsureCopiesSkills(t *testing.T) {
+	r := newTestRenderer(t)
+	skills := t.TempDir()
+	skillDir := filepath.Join(skills, "verification")
+	if err := os.MkdirAll(skillDir, 0o750); err != nil {
+		t.Fatalf("mkdir skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("# verify"), 0o600); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+	r.SkillsDir = skills
+
+	ws, err := r.Ensure("9")
+	if err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+	dst := filepath.Join(ws, ".claude", "skills", "verification", "SKILL.md")
+	body, err := os.ReadFile(dst) //nolint:gosec // G304: controlled temp/workspace path
+	if err != nil {
+		t.Fatalf("SKILL.md not copied: %v", err)
+	}
+	if string(body) != "# verify" {
+		t.Fatalf("SKILL.md content = %q, want %q", body, "# verify")
+	}
+}
+
+// TestEnsureSkillsOptional asserts an unset SkillsDir is a no-op: Ensure succeeds
+// and writes no .claude/skills/ directory.
+func TestEnsureSkillsOptional(t *testing.T) {
+	r := newTestRenderer(t) // SkillsDir unset
+	ws, err := r.Ensure("8")
+	if err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(ws, ".claude", "skills")); !os.IsNotExist(err) {
+		t.Fatalf("skills dir should not exist when SkillsDir unset (err=%v)", err)
+	}
+}
+
 // TestUploadsDir asserts the uploads dir resolves to <workspace>/uploads, is
 // created, and is NOT nested inside any directory that contains a .git (so
 // uploaded files can never enter a repo working tree / commit — AC4).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -144,6 +144,10 @@ type Config struct {
 	// Dockerfile's /opt/duck layout). Rendered per chat by core/workspace.
 	TeamTemplatePath string `env:"TEAM_TEMPLATE_PATH" envDefault:"/opt/duck/CLAUDE.workspace.md.tmpl"`
 	TeamAgentsDir    string `env:"TEAM_AGENTS_DIR" envDefault:"/opt/duck/agents"`
+	// TeamSkillsDir holds the Agent Skills baked into the image (each skill is a
+	// <name>/SKILL.md subdirectory) copied into each workspace's .claude/skills/.
+	// Empty or a missing dir disables skill rendering (the run just has no skills).
+	TeamSkillsDir string `env:"TEAM_SKILLS_DIR" envDefault:"/opt/duck/skills"`
 
 	// EnableContext7 wires the context7 MCP docs server into every run (an
 	// .mcp.json is written at startup and passed via --mcp-config). context7 gives


### PR DESCRIPTION
Second step of the bot quality upgrade (stacked on #36). Adds the **skills** plumbing the workspace was missing, so the agent gains reusable, on-demand methodology — guiding the **single** agent (no extra model processes, safe on the memory-constrained host) rather than fanning out more subagents.

- `core/workspace`: `Renderer.SkillsDir` + recursive `copySkills` (mirrors the baked `<name>/SKILL.md` tree into the workspace `.claude/skills/`); `Ensure` wires it. Empty/missing dir = no-op.
- `TEAM_SKILLS_DIR` knob (default `/opt/duck/skills`); both Dockerfiles bake `core/skills`; both bot mains set `Renderer.SkillsDir`.
- Two starter skills:
  - `verification-before-completion` — build/test/lint and confirm the change before claiming a task done.
  - `library-docs-lookup` — use the context7 MCP tools (from #36) to fetch current library/API docs instead of guessing.

`task tests` (-race) green, `task lint` 0 issues.

> Base is `feat/context7-mcp` (#36) — retarget to `main` once #36 merges. Part of the batched bot-quality upgrade; deploy with the batch.