### PR TITLE
Bake screenshot + DX-runner capabilities into runtime images

### DIFF
--- a/adapters/telegram/Dockerfile
+++ b/adapters/telegram/Dockerfile
@@ -118,7 +118,7 @@ RUN set -eux; \
 COPY tools/shotter/shot.mjs tools/shotter/package.json tools/shotter/package-lock.json /opt/duck/shotter/
 COPY tools/shotter/shot /usr/local/bin/shot
 RUN set -eux; \
-    npm install --omit=dev --prefix /opt/duck/shotter; \
+    npm ci --omit=dev --prefix /opt/duck/shotter; \
     npm cache clean --force; \
     chmod 0755 /usr/local/bin/shot; \
     chmod 0644 /opt/duck/shotter/shot.mjs; \

--- a/adapters/telegram/Dockerfile
+++ b/adapters/telegram/Dockerfile
@@ -36,17 +36,22 @@ FROM node:24-bookworm-slim
 ENV DEBIAN_FRONTEND=noninteractive
 
 # chromium is the Debian system browser that backs the `shot` screenshot helper
-# (see /opt/duck/shotter below); it is installed in THIS existing apt layer, under
+# (see /opt/shotter below); it is installed in THIS existing apt layer, under
 # the SAME single `apt-get update`, on purpose. An extra apt source / a second
 # `apt-get update` previously tipped the QEMU-emulated arm64 build over its memory
 # limit (OOM), so we do not add one. Version is intentionally unpinned (apt latest).
 # `make` ships here too (it lives in the base Debian repos) so the team can invoke a
 # project's own Makefile targets; the other dev-experience runners (task, just) come
 # from release tarballs below since they are not in the Debian repos.
+# The fonts-* packages are required because --no-install-recommends drops chromium's
+# font deps, which would render Cyrillic/emoji as tofu boxes — this is a RU-facing
+# bot, so Latin + Cyrillic (noto-core) + colour emoji are installed explicitly
+# (noto-cjk is deliberately excluded: it is very large and not needed here).
 RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
-        ca-certificates curl gnupg git ripgrep ffmpeg chromium make; \
+        ca-certificates curl gnupg git ripgrep ffmpeg chromium make \
+        fonts-liberation fonts-noto-core fonts-noto-color-emoji; \
     install -m 0755 -d /etc/apt/keyrings; \
     curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc; \
     chmod a+r /etc/apt/keyrings/docker.asc; \
@@ -61,28 +66,40 @@ RUN set -eux; \
 # tarball, NOT the apt repo: that extra apt source tipped the QEMU-emulated arm64
 # build over its memory limit during `apt-get update` (OOM: "Cannot allocate
 # memory"). One arch-matched binary is far lighter and keeps the multi-arch build
-# green. Uses the latest release, falling back to a pinned version if the GitHub API
-# is unreachable/rate-limited at build time.
+# green. The version is PINNED (no GitHub-API `latest` lookup, so builds are
+# reproducible) and the downloaded tarball's sha256 is verified against the official
+# per-arch checksum BEFORE install — the build fails on any mismatch.
+ARG GH_VERSION=2.95.0
 RUN set -eux; \
     arch="$(dpkg --print-architecture)"; \
-    ver="$(curl -fsSL https://api.github.com/repos/cli/cli/releases/latest 2>/dev/null | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p')"; \
-    [ -n "$ver" ] || ver="2.45.0"; \
-    curl -fsSL "https://github.com/cli/cli/releases/download/v${ver}/gh_${ver}_linux_${arch}.tar.gz" -o /tmp/gh.tgz; \
+    case "$arch" in \
+        amd64) sha="25d1e4729e8808c9ed3d613e96ebd3f3e44446f2d368c89d878a71a36ddb3d8c" ;; \
+        arm64) sha="d41e0b3b6218e5741c8bb4db39b16e53a59e0e06299a8489bd38f623ef7ebaae" ;; \
+        *) echo "unsupported arch for gh: $arch" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${arch}.tar.gz" -o /tmp/gh.tgz; \
+    echo "${sha}  /tmp/gh.tgz" | sha256sum -c -; \
     tar -xzf /tmp/gh.tgz -C /tmp; \
-    install -m 0755 "/tmp/gh_${ver}_linux_${arch}/bin/gh" /usr/local/bin/gh; \
-    rm -rf /tmp/gh.tgz "/tmp/gh_${ver}_linux_${arch}"
+    install -m 0755 "/tmp/gh_${GH_VERSION}_linux_${arch}/bin/gh" /usr/local/bin/gh; \
+    rm -rf /tmp/gh.tgz "/tmp/gh_${GH_VERSION}_linux_${arch}"
 
 # Task (go-task) runner so the team can drive a project's own Taskfile.yml targets
 # (e.g. `task lint`, `task test`). Installed from the official GitHub release tarball
 # for the SAME reason as `gh` above: an apt source for it would add a second
 # `apt-get update` that OOMs the QEMU-emulated arm64 build. The tarball ships the
-# `task` binary at its root; arch comes from dpkg (amd64/arm64). Latest release with
-# a pinned fallback if the GitHub API is unreachable/rate-limited at build time.
+# `task` binary at its root; arch comes from dpkg (amd64/arm64). The version is
+# PINNED and the tarball's sha256 is verified against the official per-arch checksum
+# BEFORE install — the build fails on any mismatch.
+ARG TASK_VERSION=3.51.1
 RUN set -eux; \
     arch="$(dpkg --print-architecture)"; \
-    ver="$(curl -fsSL https://api.github.com/repos/go-task/task/releases/latest 2>/dev/null | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p')"; \
-    [ -n "$ver" ] || ver="3.40.0"; \
-    curl -fsSL "https://github.com/go-task/task/releases/download/v${ver}/task_linux_${arch}.tar.gz" -o /tmp/task.tgz; \
+    case "$arch" in \
+        amd64) sha="da7e92f0ff961ef2aae7cfecbad8d1fd2a08d7b09ba968673adf7ff389b243b5" ;; \
+        arm64) sha="49c58bb00eff2449a5553f3b3e694fc424e0dc04d5c669d8831126daee1000f8" ;; \
+        *) echo "unsupported arch for task: $arch" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://github.com/go-task/task/releases/download/v${TASK_VERSION}/task_linux_${arch}.tar.gz" -o /tmp/task.tgz; \
+    echo "${sha}  /tmp/task.tgz" | sha256sum -c -; \
     tar -xzf /tmp/task.tgz -C /tmp task; \
     install -m 0755 /tmp/task /usr/local/bin/task; \
     rm -f /tmp/task.tgz /tmp/task
@@ -91,38 +108,43 @@ RUN set -eux; \
 # check`). Same tarball-not-apt rationale as `gh`/`task` above (arm64 OOM avoidance).
 # just's release assets are named by LLVM target triple, NOT dpkg arch, so we map
 # amd64 -> x86_64-unknown-linux-musl and arm64 -> aarch64-unknown-linux-musl; the
-# tag carries no leading `v`. The tarball ships the `just` binary at its root. Latest
-# release with a pinned fallback if the GitHub API is unreachable at build time.
+# tag carries no leading `v`. The tarball ships the `just` binary at its root. The
+# version is PINNED and the tarball's sha256 is verified against the official
+# per-arch checksum BEFORE install — the build fails on any mismatch.
+ARG JUST_VERSION=1.53.0
 RUN set -eux; \
     case "$(dpkg --print-architecture)" in \
-        amd64) triple="x86_64-unknown-linux-musl" ;; \
-        arm64) triple="aarch64-unknown-linux-musl" ;; \
+        amd64) triple="x86_64-unknown-linux-musl"; \
+               sha="7fedeb22c7e14d9ef1551e8b793700866d80f409f9884b0e80ebb65c11d4874d" ;; \
+        arm64) triple="aarch64-unknown-linux-musl"; \
+               sha="f29d8e72380bc144465f632c7d59da311205eef2923d57511708b05b82f2e64f" ;; \
         *) echo "unsupported arch for just: $(dpkg --print-architecture)" >&2; exit 1 ;; \
     esac; \
-    ver="$(curl -fsSL https://api.github.com/repos/casey/just/releases/latest 2>/dev/null | sed -n 's/.*"tag_name": *"v\{0,1\}\([^"]*\)".*/\1/p')"; \
-    [ -n "$ver" ] || ver="1.36.0"; \
-    curl -fsSL "https://github.com/casey/just/releases/download/${ver}/just-${ver}-${triple}.tar.gz" -o /tmp/just.tgz; \
+    curl -fsSL "https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-${triple}.tar.gz" -o /tmp/just.tgz; \
+    echo "${sha}  /tmp/just.tgz" | sha256sum -c -; \
     tar -xzf /tmp/just.tgz -C /tmp just; \
     install -m 0755 /tmp/just /usr/local/bin/just; \
     rm -f /tmp/just.tgz /tmp/just
 
 # `shot` screenshot helper: the Node implementation (driving system chromium via
-# puppeteer-core) lives at /opt/duck/shotter/shot.mjs; the thin wrapper goes on
-# PATH at /usr/local/bin/shot. puppeteer-core is installed as a LOCAL dependency in
-# the script's own directory (NOT global) because shot.mjs is an ES module, and ESM
+# puppeteer-core) lives at /opt/shotter/shot.mjs; the thin wrapper goes on PATH at
+# /usr/local/bin/shot. puppeteer-core is installed as a LOCAL dependency in the
+# script's own directory (NOT global) because shot.mjs is an ES module, and ESM
 # `import` resolution walks up from the script dir / ignores NODE_PATH — so the
-# package must live in /opt/duck/shotter/node_modules to resolve. Everything is
-# root-owned + world-readable/executable so the uid 1000 `claude` runtime user can
-# run it as a system tool. The COPY/npm run as root at build time; chromium runs as
-# the unprivileged user at runtime.
-COPY tools/shotter/shot.mjs tools/shotter/package.json tools/shotter/package-lock.json /opt/duck/shotter/
+# package must live in /opt/shotter/node_modules to resolve. It is installed UNDER
+# /opt/shotter (NOT /opt/duck) on purpose: the later `chown -R claude:claude
+# /opt/duck` re-owns the dev-team config to the runtime user, and the tooling must
+# NOT be re-owned — keeping it at /opt/shotter leaves it root-owned + world-readable
+# (chmod -R a+rX), so the uid 1000 `claude` runtime user can run it but cannot tamper
+# with its own tooling. The COPY/npm run as root at build time; chromium runs as the
+# unprivileged user at runtime.
+COPY tools/shotter/shot.mjs tools/shotter/package.json tools/shotter/package-lock.json /opt/shotter/
 COPY tools/shotter/shot /usr/local/bin/shot
 RUN set -eux; \
-    npm ci --omit=dev --prefix /opt/duck/shotter; \
+    npm ci --omit=dev --prefix /opt/shotter; \
     npm cache clean --force; \
     chmod 0755 /usr/local/bin/shot; \
-    chmod 0644 /opt/duck/shotter/shot.mjs; \
-    chmod -R a+rX /opt/duck/shotter
+    chmod -R a+rX /opt/shotter
 
 # Non-root runtime user; pre-create writable dirs so named volumes inherit uid 1000.
 # /app/data is kept for volume-layout parity with the previous image. The node base

--- a/adapters/telegram/Dockerfile
+++ b/adapters/telegram/Dockerfile
@@ -40,10 +40,13 @@ ENV DEBIAN_FRONTEND=noninteractive
 # the SAME single `apt-get update`, on purpose. An extra apt source / a second
 # `apt-get update` previously tipped the QEMU-emulated arm64 build over its memory
 # limit (OOM), so we do not add one. Version is intentionally unpinned (apt latest).
+# `make` ships here too (it lives in the base Debian repos) so the team can invoke a
+# project's own Makefile targets; the other dev-experience runners (task, just) come
+# from release tarballs below since they are not in the Debian repos.
 RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
-        ca-certificates curl gnupg git ripgrep ffmpeg chromium; \
+        ca-certificates curl gnupg git ripgrep ffmpeg chromium make; \
     install -m 0755 -d /etc/apt/keyrings; \
     curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc; \
     chmod a+r /etc/apt/keyrings/docker.asc; \
@@ -68,6 +71,40 @@ RUN set -eux; \
     tar -xzf /tmp/gh.tgz -C /tmp; \
     install -m 0755 "/tmp/gh_${ver}_linux_${arch}/bin/gh" /usr/local/bin/gh; \
     rm -rf /tmp/gh.tgz "/tmp/gh_${ver}_linux_${arch}"
+
+# Task (go-task) runner so the team can drive a project's own Taskfile.yml targets
+# (e.g. `task lint`, `task test`). Installed from the official GitHub release tarball
+# for the SAME reason as `gh` above: an apt source for it would add a second
+# `apt-get update` that OOMs the QEMU-emulated arm64 build. The tarball ships the
+# `task` binary at its root; arch comes from dpkg (amd64/arm64). Latest release with
+# a pinned fallback if the GitHub API is unreachable/rate-limited at build time.
+RUN set -eux; \
+    arch="$(dpkg --print-architecture)"; \
+    ver="$(curl -fsSL https://api.github.com/repos/go-task/task/releases/latest 2>/dev/null | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p')"; \
+    [ -n "$ver" ] || ver="3.40.0"; \
+    curl -fsSL "https://github.com/go-task/task/releases/download/v${ver}/task_linux_${arch}.tar.gz" -o /tmp/task.tgz; \
+    tar -xzf /tmp/task.tgz -C /tmp task; \
+    install -m 0755 /tmp/task /usr/local/bin/task; \
+    rm -f /tmp/task.tgz /tmp/task
+
+# just runner so the team can drive a project's own justfile recipes (e.g. `just
+# check`). Same tarball-not-apt rationale as `gh`/`task` above (arm64 OOM avoidance).
+# just's release assets are named by LLVM target triple, NOT dpkg arch, so we map
+# amd64 -> x86_64-unknown-linux-musl and arm64 -> aarch64-unknown-linux-musl; the
+# tag carries no leading `v`. The tarball ships the `just` binary at its root. Latest
+# release with a pinned fallback if the GitHub API is unreachable at build time.
+RUN set -eux; \
+    case "$(dpkg --print-architecture)" in \
+        amd64) triple="x86_64-unknown-linux-musl" ;; \
+        arm64) triple="aarch64-unknown-linux-musl" ;; \
+        *) echo "unsupported arch for just: $(dpkg --print-architecture)" >&2; exit 1 ;; \
+    esac; \
+    ver="$(curl -fsSL https://api.github.com/repos/casey/just/releases/latest 2>/dev/null | sed -n 's/.*"tag_name": *"v\{0,1\}\([^"]*\)".*/\1/p')"; \
+    [ -n "$ver" ] || ver="1.36.0"; \
+    curl -fsSL "https://github.com/casey/just/releases/download/${ver}/just-${ver}-${triple}.tar.gz" -o /tmp/just.tgz; \
+    tar -xzf /tmp/just.tgz -C /tmp just; \
+    install -m 0755 /tmp/just /usr/local/bin/just; \
+    rm -f /tmp/just.tgz /tmp/just
 
 # `shot` screenshot helper: the Node implementation (driving system chromium via
 # puppeteer-core) lives at /opt/duck/shotter/shot.mjs; the thin wrapper goes on

--- a/adapters/telegram/Dockerfile
+++ b/adapters/telegram/Dockerfile
@@ -35,17 +35,22 @@ FROM node:24-bookworm-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+# chromium is the Debian system browser that backs the `shot` screenshot helper
+# (see /opt/duck/shotter below); it is installed in THIS existing apt layer, under
+# the SAME single `apt-get update`, on purpose. An extra apt source / a second
+# `apt-get update` previously tipped the QEMU-emulated arm64 build over its memory
+# limit (OOM), so we do not add one. Version is intentionally unpinned (apt latest).
 RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
-        ca-certificates curl gnupg git ripgrep ffmpeg; \
+        ca-certificates curl gnupg git ripgrep ffmpeg chromium; \
     install -m 0755 -d /etc/apt/keyrings; \
     curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc; \
     chmod a+r /etc/apt/keyrings/docker.asc; \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian $(. /etc/os-release && echo $VERSION_CODENAME) stable" > /etc/apt/sources.list.d/docker.list; \
     apt-get update; \
     apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin; \
-    npm install -g @anthropic-ai/claude-code; \
+    npm install -g @anthropic-ai/claude-code puppeteer-core; \
     npm cache clean --force; \
     apt-get clean; rm -rf /var/lib/apt/lists/*
 
@@ -63,6 +68,14 @@ RUN set -eux; \
     tar -xzf /tmp/gh.tgz -C /tmp; \
     install -m 0755 "/tmp/gh_${ver}_linux_${arch}/bin/gh" /usr/local/bin/gh; \
     rm -rf /tmp/gh.tgz "/tmp/gh_${ver}_linux_${arch}"
+
+# `shot` screenshot helper: the Node implementation (driving system chromium via
+# puppeteer-core) lives at /opt/duck/shotter/shot.mjs; the thin wrapper goes on
+# PATH at /usr/local/bin/shot. Both are root-owned + world-executable/readable so
+# the uid 1000 `claude` runtime user can run them as a system tool.
+COPY tools/shotter/shot.mjs /opt/duck/shotter/shot.mjs
+COPY tools/shotter/shot /usr/local/bin/shot
+RUN chmod 0755 /usr/local/bin/shot; chmod 0644 /opt/duck/shotter/shot.mjs
 
 # Non-root runtime user; pre-create writable dirs so named volumes inherit uid 1000.
 # /app/data is kept for volume-layout parity with the previous image. The node base

--- a/adapters/telegram/Dockerfile
+++ b/adapters/telegram/Dockerfile
@@ -50,7 +50,7 @@ RUN set -eux; \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian $(. /etc/os-release && echo $VERSION_CODENAME) stable" > /etc/apt/sources.list.d/docker.list; \
     apt-get update; \
     apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin; \
-    npm install -g @anthropic-ai/claude-code puppeteer-core; \
+    npm install -g @anthropic-ai/claude-code; \
     npm cache clean --force; \
     apt-get clean; rm -rf /var/lib/apt/lists/*
 
@@ -71,11 +71,21 @@ RUN set -eux; \
 
 # `shot` screenshot helper: the Node implementation (driving system chromium via
 # puppeteer-core) lives at /opt/duck/shotter/shot.mjs; the thin wrapper goes on
-# PATH at /usr/local/bin/shot. Both are root-owned + world-executable/readable so
-# the uid 1000 `claude` runtime user can run them as a system tool.
-COPY tools/shotter/shot.mjs /opt/duck/shotter/shot.mjs
+# PATH at /usr/local/bin/shot. puppeteer-core is installed as a LOCAL dependency in
+# the script's own directory (NOT global) because shot.mjs is an ES module, and ESM
+# `import` resolution walks up from the script dir / ignores NODE_PATH — so the
+# package must live in /opt/duck/shotter/node_modules to resolve. Everything is
+# root-owned + world-readable/executable so the uid 1000 `claude` runtime user can
+# run it as a system tool. The COPY/npm run as root at build time; chromium runs as
+# the unprivileged user at runtime.
+COPY tools/shotter/shot.mjs tools/shotter/package.json tools/shotter/package-lock.json /opt/duck/shotter/
 COPY tools/shotter/shot /usr/local/bin/shot
-RUN chmod 0755 /usr/local/bin/shot; chmod 0644 /opt/duck/shotter/shot.mjs
+RUN set -eux; \
+    npm install --omit=dev --prefix /opt/duck/shotter; \
+    npm cache clean --force; \
+    chmod 0755 /usr/local/bin/shot; \
+    chmod 0644 /opt/duck/shotter/shot.mjs; \
+    chmod -R a+rX /opt/duck/shotter
 
 # Non-root runtime user; pre-create writable dirs so named volumes inherit uid 1000.
 # /app/data is kept for volume-layout parity with the previous image. The node base

--- a/adapters/vk/Dockerfile
+++ b/adapters/vk/Dockerfile
@@ -37,17 +37,22 @@ FROM node:24-bookworm-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+# chromium is the Debian system browser that backs the `shot` screenshot helper
+# (see /opt/duck/shotter below); it is installed in THIS existing apt layer, under
+# the SAME single `apt-get update`, on purpose. An extra apt source / a second
+# `apt-get update` previously tipped the QEMU-emulated arm64 build over its memory
+# limit (OOM), so we do not add one. Version is intentionally unpinned (apt latest).
 RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
-        ca-certificates curl gnupg git ripgrep ffmpeg; \
+        ca-certificates curl gnupg git ripgrep ffmpeg chromium; \
     install -m 0755 -d /etc/apt/keyrings; \
     curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc; \
     chmod a+r /etc/apt/keyrings/docker.asc; \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian $(. /etc/os-release && echo $VERSION_CODENAME) stable" > /etc/apt/sources.list.d/docker.list; \
     apt-get update; \
     apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin; \
-    npm install -g @anthropic-ai/claude-code; \
+    npm install -g @anthropic-ai/claude-code puppeteer-core; \
     npm cache clean --force; \
     apt-get clean; rm -rf /var/lib/apt/lists/*
 
@@ -65,6 +70,14 @@ RUN set -eux; \
     tar -xzf /tmp/gh.tgz -C /tmp; \
     install -m 0755 "/tmp/gh_${ver}_linux_${arch}/bin/gh" /usr/local/bin/gh; \
     rm -rf /tmp/gh.tgz "/tmp/gh_${ver}_linux_${arch}"
+
+# `shot` screenshot helper: the Node implementation (driving system chromium via
+# puppeteer-core) lives at /opt/duck/shotter/shot.mjs; the thin wrapper goes on
+# PATH at /usr/local/bin/shot. Both are root-owned + world-executable/readable so
+# the uid 1000 `claude` runtime user can run them as a system tool.
+COPY tools/shotter/shot.mjs /opt/duck/shotter/shot.mjs
+COPY tools/shotter/shot /usr/local/bin/shot
+RUN chmod 0755 /usr/local/bin/shot; chmod 0644 /opt/duck/shotter/shot.mjs
 
 # Non-root runtime user; pre-create writable dirs so named volumes inherit uid 1000.
 # /app/data is kept for volume-layout parity with the previous image. The node base

--- a/adapters/vk/Dockerfile
+++ b/adapters/vk/Dockerfile
@@ -120,7 +120,7 @@ RUN set -eux; \
 COPY tools/shotter/shot.mjs tools/shotter/package.json tools/shotter/package-lock.json /opt/duck/shotter/
 COPY tools/shotter/shot /usr/local/bin/shot
 RUN set -eux; \
-    npm install --omit=dev --prefix /opt/duck/shotter; \
+    npm ci --omit=dev --prefix /opt/duck/shotter; \
     npm cache clean --force; \
     chmod 0755 /usr/local/bin/shot; \
     chmod 0644 /opt/duck/shotter/shot.mjs; \

--- a/adapters/vk/Dockerfile
+++ b/adapters/vk/Dockerfile
@@ -42,10 +42,13 @@ ENV DEBIAN_FRONTEND=noninteractive
 # the SAME single `apt-get update`, on purpose. An extra apt source / a second
 # `apt-get update` previously tipped the QEMU-emulated arm64 build over its memory
 # limit (OOM), so we do not add one. Version is intentionally unpinned (apt latest).
+# `make` ships here too (it lives in the base Debian repos) so the team can invoke a
+# project's own Makefile targets; the other dev-experience runners (task, just) come
+# from release tarballs below since they are not in the Debian repos.
 RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
-        ca-certificates curl gnupg git ripgrep ffmpeg chromium; \
+        ca-certificates curl gnupg git ripgrep ffmpeg chromium make; \
     install -m 0755 -d /etc/apt/keyrings; \
     curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc; \
     chmod a+r /etc/apt/keyrings/docker.asc; \
@@ -70,6 +73,40 @@ RUN set -eux; \
     tar -xzf /tmp/gh.tgz -C /tmp; \
     install -m 0755 "/tmp/gh_${ver}_linux_${arch}/bin/gh" /usr/local/bin/gh; \
     rm -rf /tmp/gh.tgz "/tmp/gh_${ver}_linux_${arch}"
+
+# Task (go-task) runner so the team can drive a project's own Taskfile.yml targets
+# (e.g. `task lint`, `task test`). Installed from the official GitHub release tarball
+# for the SAME reason as `gh` above: an apt source for it would add a second
+# `apt-get update` that OOMs the QEMU-emulated arm64 build. The tarball ships the
+# `task` binary at its root; arch comes from dpkg (amd64/arm64). Latest release with
+# a pinned fallback if the GitHub API is unreachable/rate-limited at build time.
+RUN set -eux; \
+    arch="$(dpkg --print-architecture)"; \
+    ver="$(curl -fsSL https://api.github.com/repos/go-task/task/releases/latest 2>/dev/null | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p')"; \
+    [ -n "$ver" ] || ver="3.40.0"; \
+    curl -fsSL "https://github.com/go-task/task/releases/download/v${ver}/task_linux_${arch}.tar.gz" -o /tmp/task.tgz; \
+    tar -xzf /tmp/task.tgz -C /tmp task; \
+    install -m 0755 /tmp/task /usr/local/bin/task; \
+    rm -f /tmp/task.tgz /tmp/task
+
+# just runner so the team can drive a project's own justfile recipes (e.g. `just
+# check`). Same tarball-not-apt rationale as `gh`/`task` above (arm64 OOM avoidance).
+# just's release assets are named by LLVM target triple, NOT dpkg arch, so we map
+# amd64 -> x86_64-unknown-linux-musl and arm64 -> aarch64-unknown-linux-musl; the
+# tag carries no leading `v`. The tarball ships the `just` binary at its root. Latest
+# release with a pinned fallback if the GitHub API is unreachable at build time.
+RUN set -eux; \
+    case "$(dpkg --print-architecture)" in \
+        amd64) triple="x86_64-unknown-linux-musl" ;; \
+        arm64) triple="aarch64-unknown-linux-musl" ;; \
+        *) echo "unsupported arch for just: $(dpkg --print-architecture)" >&2; exit 1 ;; \
+    esac; \
+    ver="$(curl -fsSL https://api.github.com/repos/casey/just/releases/latest 2>/dev/null | sed -n 's/.*"tag_name": *"v\{0,1\}\([^"]*\)".*/\1/p')"; \
+    [ -n "$ver" ] || ver="1.36.0"; \
+    curl -fsSL "https://github.com/casey/just/releases/download/${ver}/just-${ver}-${triple}.tar.gz" -o /tmp/just.tgz; \
+    tar -xzf /tmp/just.tgz -C /tmp just; \
+    install -m 0755 /tmp/just /usr/local/bin/just; \
+    rm -f /tmp/just.tgz /tmp/just
 
 # `shot` screenshot helper: the Node implementation (driving system chromium via
 # puppeteer-core) lives at /opt/duck/shotter/shot.mjs; the thin wrapper goes on

--- a/adapters/vk/Dockerfile
+++ b/adapters/vk/Dockerfile
@@ -38,17 +38,22 @@ FROM node:24-bookworm-slim
 ENV DEBIAN_FRONTEND=noninteractive
 
 # chromium is the Debian system browser that backs the `shot` screenshot helper
-# (see /opt/duck/shotter below); it is installed in THIS existing apt layer, under
+# (see /opt/shotter below); it is installed in THIS existing apt layer, under
 # the SAME single `apt-get update`, on purpose. An extra apt source / a second
 # `apt-get update` previously tipped the QEMU-emulated arm64 build over its memory
 # limit (OOM), so we do not add one. Version is intentionally unpinned (apt latest).
 # `make` ships here too (it lives in the base Debian repos) so the team can invoke a
 # project's own Makefile targets; the other dev-experience runners (task, just) come
 # from release tarballs below since they are not in the Debian repos.
+# The fonts-* packages are required because --no-install-recommends drops chromium's
+# font deps, which would render Cyrillic/emoji as tofu boxes — this is a RU-facing
+# bot, so Latin + Cyrillic (noto-core) + colour emoji are installed explicitly
+# (noto-cjk is deliberately excluded: it is very large and not needed here).
 RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
-        ca-certificates curl gnupg git ripgrep ffmpeg chromium make; \
+        ca-certificates curl gnupg git ripgrep ffmpeg chromium make \
+        fonts-liberation fonts-noto-core fonts-noto-color-emoji; \
     install -m 0755 -d /etc/apt/keyrings; \
     curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc; \
     chmod a+r /etc/apt/keyrings/docker.asc; \
@@ -63,28 +68,40 @@ RUN set -eux; \
 # tarball, NOT the apt repo: that extra apt source tipped the QEMU-emulated arm64
 # build over its memory limit during `apt-get update` (OOM: "Cannot allocate
 # memory"). One arch-matched binary is far lighter and keeps the multi-arch build
-# green. Uses the latest release, falling back to a pinned version if the GitHub API
-# is unreachable/rate-limited at build time.
+# green. The version is PINNED (no GitHub-API `latest` lookup, so builds are
+# reproducible) and the downloaded tarball's sha256 is verified against the official
+# per-arch checksum BEFORE install — the build fails on any mismatch.
+ARG GH_VERSION=2.95.0
 RUN set -eux; \
     arch="$(dpkg --print-architecture)"; \
-    ver="$(curl -fsSL https://api.github.com/repos/cli/cli/releases/latest 2>/dev/null | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p')"; \
-    [ -n "$ver" ] || ver="2.45.0"; \
-    curl -fsSL "https://github.com/cli/cli/releases/download/v${ver}/gh_${ver}_linux_${arch}.tar.gz" -o /tmp/gh.tgz; \
+    case "$arch" in \
+        amd64) sha="25d1e4729e8808c9ed3d613e96ebd3f3e44446f2d368c89d878a71a36ddb3d8c" ;; \
+        arm64) sha="d41e0b3b6218e5741c8bb4db39b16e53a59e0e06299a8489bd38f623ef7ebaae" ;; \
+        *) echo "unsupported arch for gh: $arch" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${arch}.tar.gz" -o /tmp/gh.tgz; \
+    echo "${sha}  /tmp/gh.tgz" | sha256sum -c -; \
     tar -xzf /tmp/gh.tgz -C /tmp; \
-    install -m 0755 "/tmp/gh_${ver}_linux_${arch}/bin/gh" /usr/local/bin/gh; \
-    rm -rf /tmp/gh.tgz "/tmp/gh_${ver}_linux_${arch}"
+    install -m 0755 "/tmp/gh_${GH_VERSION}_linux_${arch}/bin/gh" /usr/local/bin/gh; \
+    rm -rf /tmp/gh.tgz "/tmp/gh_${GH_VERSION}_linux_${arch}"
 
 # Task (go-task) runner so the team can drive a project's own Taskfile.yml targets
 # (e.g. `task lint`, `task test`). Installed from the official GitHub release tarball
 # for the SAME reason as `gh` above: an apt source for it would add a second
 # `apt-get update` that OOMs the QEMU-emulated arm64 build. The tarball ships the
-# `task` binary at its root; arch comes from dpkg (amd64/arm64). Latest release with
-# a pinned fallback if the GitHub API is unreachable/rate-limited at build time.
+# `task` binary at its root; arch comes from dpkg (amd64/arm64). The version is
+# PINNED and the tarball's sha256 is verified against the official per-arch checksum
+# BEFORE install — the build fails on any mismatch.
+ARG TASK_VERSION=3.51.1
 RUN set -eux; \
     arch="$(dpkg --print-architecture)"; \
-    ver="$(curl -fsSL https://api.github.com/repos/go-task/task/releases/latest 2>/dev/null | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p')"; \
-    [ -n "$ver" ] || ver="3.40.0"; \
-    curl -fsSL "https://github.com/go-task/task/releases/download/v${ver}/task_linux_${arch}.tar.gz" -o /tmp/task.tgz; \
+    case "$arch" in \
+        amd64) sha="da7e92f0ff961ef2aae7cfecbad8d1fd2a08d7b09ba968673adf7ff389b243b5" ;; \
+        arm64) sha="49c58bb00eff2449a5553f3b3e694fc424e0dc04d5c669d8831126daee1000f8" ;; \
+        *) echo "unsupported arch for task: $arch" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://github.com/go-task/task/releases/download/v${TASK_VERSION}/task_linux_${arch}.tar.gz" -o /tmp/task.tgz; \
+    echo "${sha}  /tmp/task.tgz" | sha256sum -c -; \
     tar -xzf /tmp/task.tgz -C /tmp task; \
     install -m 0755 /tmp/task /usr/local/bin/task; \
     rm -f /tmp/task.tgz /tmp/task
@@ -93,38 +110,43 @@ RUN set -eux; \
 # check`). Same tarball-not-apt rationale as `gh`/`task` above (arm64 OOM avoidance).
 # just's release assets are named by LLVM target triple, NOT dpkg arch, so we map
 # amd64 -> x86_64-unknown-linux-musl and arm64 -> aarch64-unknown-linux-musl; the
-# tag carries no leading `v`. The tarball ships the `just` binary at its root. Latest
-# release with a pinned fallback if the GitHub API is unreachable at build time.
+# tag carries no leading `v`. The tarball ships the `just` binary at its root. The
+# version is PINNED and the tarball's sha256 is verified against the official
+# per-arch checksum BEFORE install — the build fails on any mismatch.
+ARG JUST_VERSION=1.53.0
 RUN set -eux; \
     case "$(dpkg --print-architecture)" in \
-        amd64) triple="x86_64-unknown-linux-musl" ;; \
-        arm64) triple="aarch64-unknown-linux-musl" ;; \
+        amd64) triple="x86_64-unknown-linux-musl"; \
+               sha="7fedeb22c7e14d9ef1551e8b793700866d80f409f9884b0e80ebb65c11d4874d" ;; \
+        arm64) triple="aarch64-unknown-linux-musl"; \
+               sha="f29d8e72380bc144465f632c7d59da311205eef2923d57511708b05b82f2e64f" ;; \
         *) echo "unsupported arch for just: $(dpkg --print-architecture)" >&2; exit 1 ;; \
     esac; \
-    ver="$(curl -fsSL https://api.github.com/repos/casey/just/releases/latest 2>/dev/null | sed -n 's/.*"tag_name": *"v\{0,1\}\([^"]*\)".*/\1/p')"; \
-    [ -n "$ver" ] || ver="1.36.0"; \
-    curl -fsSL "https://github.com/casey/just/releases/download/${ver}/just-${ver}-${triple}.tar.gz" -o /tmp/just.tgz; \
+    curl -fsSL "https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-${triple}.tar.gz" -o /tmp/just.tgz; \
+    echo "${sha}  /tmp/just.tgz" | sha256sum -c -; \
     tar -xzf /tmp/just.tgz -C /tmp just; \
     install -m 0755 /tmp/just /usr/local/bin/just; \
     rm -f /tmp/just.tgz /tmp/just
 
 # `shot` screenshot helper: the Node implementation (driving system chromium via
-# puppeteer-core) lives at /opt/duck/shotter/shot.mjs; the thin wrapper goes on
-# PATH at /usr/local/bin/shot. puppeteer-core is installed as a LOCAL dependency in
-# the script's own directory (NOT global) because shot.mjs is an ES module, and ESM
+# puppeteer-core) lives at /opt/shotter/shot.mjs; the thin wrapper goes on PATH at
+# /usr/local/bin/shot. puppeteer-core is installed as a LOCAL dependency in the
+# script's own directory (NOT global) because shot.mjs is an ES module, and ESM
 # `import` resolution walks up from the script dir / ignores NODE_PATH — so the
-# package must live in /opt/duck/shotter/node_modules to resolve. Everything is
-# root-owned + world-readable/executable so the uid 1000 `claude` runtime user can
-# run it as a system tool. The COPY/npm run as root at build time; chromium runs as
-# the unprivileged user at runtime.
-COPY tools/shotter/shot.mjs tools/shotter/package.json tools/shotter/package-lock.json /opt/duck/shotter/
+# package must live in /opt/shotter/node_modules to resolve. It is installed UNDER
+# /opt/shotter (NOT /opt/duck) on purpose: the later `chown -R claude:claude
+# /opt/duck` re-owns the dev-team config to the runtime user, and the tooling must
+# NOT be re-owned — keeping it at /opt/shotter leaves it root-owned + world-readable
+# (chmod -R a+rX), so the uid 1000 `claude` runtime user can run it but cannot tamper
+# with its own tooling. The COPY/npm run as root at build time; chromium runs as the
+# unprivileged user at runtime.
+COPY tools/shotter/shot.mjs tools/shotter/package.json tools/shotter/package-lock.json /opt/shotter/
 COPY tools/shotter/shot /usr/local/bin/shot
 RUN set -eux; \
-    npm ci --omit=dev --prefix /opt/duck/shotter; \
+    npm ci --omit=dev --prefix /opt/shotter; \
     npm cache clean --force; \
     chmod 0755 /usr/local/bin/shot; \
-    chmod 0644 /opt/duck/shotter/shot.mjs; \
-    chmod -R a+rX /opt/duck/shotter
+    chmod -R a+rX /opt/shotter
 
 # Non-root runtime user; pre-create writable dirs so named volumes inherit uid 1000.
 # /app/data is kept for volume-layout parity with the previous image. The node base

--- a/adapters/vk/Dockerfile
+++ b/adapters/vk/Dockerfile
@@ -52,7 +52,7 @@ RUN set -eux; \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian $(. /etc/os-release && echo $VERSION_CODENAME) stable" > /etc/apt/sources.list.d/docker.list; \
     apt-get update; \
     apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin; \
-    npm install -g @anthropic-ai/claude-code puppeteer-core; \
+    npm install -g @anthropic-ai/claude-code; \
     npm cache clean --force; \
     apt-get clean; rm -rf /var/lib/apt/lists/*
 
@@ -73,11 +73,21 @@ RUN set -eux; \
 
 # `shot` screenshot helper: the Node implementation (driving system chromium via
 # puppeteer-core) lives at /opt/duck/shotter/shot.mjs; the thin wrapper goes on
-# PATH at /usr/local/bin/shot. Both are root-owned + world-executable/readable so
-# the uid 1000 `claude` runtime user can run them as a system tool.
-COPY tools/shotter/shot.mjs /opt/duck/shotter/shot.mjs
+# PATH at /usr/local/bin/shot. puppeteer-core is installed as a LOCAL dependency in
+# the script's own directory (NOT global) because shot.mjs is an ES module, and ESM
+# `import` resolution walks up from the script dir / ignores NODE_PATH — so the
+# package must live in /opt/duck/shotter/node_modules to resolve. Everything is
+# root-owned + world-readable/executable so the uid 1000 `claude` runtime user can
+# run it as a system tool. The COPY/npm run as root at build time; chromium runs as
+# the unprivileged user at runtime.
+COPY tools/shotter/shot.mjs tools/shotter/package.json tools/shotter/package-lock.json /opt/duck/shotter/
 COPY tools/shotter/shot /usr/local/bin/shot
-RUN chmod 0755 /usr/local/bin/shot; chmod 0644 /opt/duck/shotter/shot.mjs
+RUN set -eux; \
+    npm install --omit=dev --prefix /opt/duck/shotter; \
+    npm cache clean --force; \
+    chmod 0755 /usr/local/bin/shot; \
+    chmod 0644 /opt/duck/shotter/shot.mjs; \
+    chmod -R a+rX /opt/duck/shotter
 
 # Non-root runtime user; pre-create writable dirs so named volumes inherit uid 1000.
 # /app/data is kept for volume-layout parity with the previous image. The node base

--- a/core/workspace/workspace.go
+++ b/core/workspace/workspace.go
@@ -112,6 +112,25 @@ in ` + "`outbox/`" + ` is sent to the user as a Telegram document and archived
 under ` + "`outbox/sent/`" + `. Do not put files you want delivered inside a repo.
 `
 
+// shotConvention is appended to every rendered CLAUDE.md so the dev-team agents
+// know the runtime image ships a screenshot tool. Like outboxConvention it lives
+// here (not in the protected template) so the template file on disk stays
+// byte-identical.
+const shotConvention = `
+
+## Taking webpage screenshots
+
+The runtime image ships a ` + "`shot`" + ` command (on PATH) that screenshots a web
+page using the bundled system Chromium:
+
+    shot <url> <out.png> [--full] [--width=N] [--height=N] [--wait=ms]
+
+Use ` + "`--full`" + ` for a full-page capture (it autoscrolls first to load lazy
+content). Writing the PNG into ` + "`outbox/`" + ` delivers it to the user in chat
+(see the outbox convention above). Known limit: pages that require authentication —
+e.g. a Telegram Mini App that needs ` + "`initData`" + ` — will not render.
+`
+
 // renderClaudeMD reads the template, substitutes the three configured
 // placeholders, appends the outbox convention, drops any stale CLAUDE.md, and
 // writes the fresh file.
@@ -130,9 +149,10 @@ func (r *Renderer) renderClaudeMD(ws string) error {
 		"${GIT_HOST}", r.GitHost,
 	).Replace(string(raw))
 
-	// Append the outbox convention to the RENDERED output (after substitution),
-	// keeping the protected template file on disk byte-identical (AC6).
+	// Append the outbox + screenshot conventions to the RENDERED output (after
+	// substitution), keeping the protected template file on disk byte-identical.
 	rendered += outboxConvention
+	rendered += shotConvention
 
 	dst := filepath.Join(ws, "CLAUDE.md")
 	// Drop a possibly stale/root-owned stub so the write recreates it fresh,

--- a/core/workspace/workspace_test.go
+++ b/core/workspace/workspace_test.go
@@ -217,15 +217,18 @@ func TestRenderedClaudeMDHasOutboxSection(t *testing.T) {
 		t.Fatalf("read CLAUDE.md: %v", err)
 	}
 	got := string(body)
-	for _, want := range []string{"## Sending files to the user", "outbox/", "outbox/sent/"} {
+	for _, want := range []string{
+		"## Sending files to the user", "outbox/", "outbox/sent/",
+		"## Taking webpage screenshots", "shot <url> <out.png>", "--full",
+	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("rendered CLAUDE.md missing %q; got:\n%s", want, got)
 		}
 	}
 
 	// The template FILE on disk must be unchanged (byte-identical) and must NOT
-	// itself contain the outbox section — the append happens only to the rendered
-	// output.
+	// itself contain the appended sections — the append happens only to the
+	// rendered output.
 	after, err := os.ReadFile(r.TemplatePath)
 	if err != nil {
 		t.Fatalf("read template after: %v", err)
@@ -235,6 +238,9 @@ func TestRenderedClaudeMDHasOutboxSection(t *testing.T) {
 	}
 	if strings.Contains(string(after), "## Sending files to the user") {
 		t.Fatalf("template file must not contain the outbox section")
+	}
+	if strings.Contains(string(after), "## Taking webpage screenshots") {
+		t.Fatalf("template file must not contain the screenshot section")
 	}
 }
 

--- a/core/workspace/workspace_test.go
+++ b/core/workspace/workspace_test.go
@@ -219,7 +219,12 @@ func TestRenderedClaudeMDHasOutboxSection(t *testing.T) {
 	got := string(body)
 	for _, want := range []string{
 		"## Sending files to the user", "outbox/", "outbox/sent/",
+		// A fragment of the outbox-delivery sentence: a file dropped in outbox/ is
+		// sent to the user as a Telegram document.
+		"sent to the user as a Telegram document",
 		"## Taking webpage screenshots", "shot <url> <out.png>", "--full",
+		// The auth'd-page limitation must be documented (initData).
+		"initData",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("rendered CLAUDE.md missing %q; got:\n%s", want, got)

--- a/tools/shotter/package-lock.json
+++ b/tools/shotter/package-lock.json
@@ -1,0 +1,312 @@
+{
+  "name": "duck-shotter",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "duck-shotter",
+      "version": "1.0.0",
+      "dependencies": {
+        "puppeteer-core": "25.1.0"
+      }
+    },
+    "node_modules/@puppeteer/browsers": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.0.4.tgz",
+      "integrity": "sha512-HGM8iAmGTf+Y7t0373szVbTmt3d7vPkYL/1bpOkOFO0YUYLgSeuYBCzESklogNPvOBnZ/MRD5f07OkpqH1trtA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "modern-tar": "^0.7.6",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/main-cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "peerDependencies": {
+        "proxy-agent": ">=8.0.1"
+      },
+      "peerDependenciesMeta": {
+        "proxy-agent": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/chromium-bidi": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-16.0.1.tgz",
+      "integrity": "sha512-J63PGu/9PpeCwLIcKYyzWP6yaVL5pxuBc0shlYCYM8BaAkmlwiQboXO1iNbOgSDbVklEyYFfNEcHD8oOAWacUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=20.19.0 <22.0.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1624250",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1624250.tgz",
+      "integrity": "sha512-YFAat/lOiIk0ARmBweG+ygrEcbZrq5B9urRyUoeQKp53MlidHXE2TmTbxKcaXoQj7u/aX+jebDO4BW55rs0WwA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
+    "node_modules/modern-tar": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.6.tgz",
+      "integrity": "sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "25.1.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.1.0.tgz",
+      "integrity": "sha512-jKzy5y4WG6uNuFbTWgW1D7mqoT9o0nllc/6a1DGF775T1mPmgw3scdFEtEq67yVFikavQmbYq6NLfbTfxHSlqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "3.0.4",
+        "chromium-bidi": "16.0.1",
+        "devtools-protocol": "0.0.1624250",
+        "typed-query-selector": "^2.12.2",
+        "webdriver-bidi-protocol": "0.4.2",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
+      "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
+      "license": "MIT"
+    },
+    "node_modules/webdriver-bidi-protocol": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.2.tgz",
+      "integrity": "sha512-VSV+fzfChirL3e7jay2yUC7B4HQCGtEWEg/MSSQbK+qWbqeGlRLlXTzPpYr3XGUvbpDHumWZBJxgesg4N7dbtA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/tools/shotter/package.json
+++ b/tools/shotter/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "duck-shotter",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Local dependencies for the `shot` screenshot helper baked into the runtime images. puppeteer-core drives the apt-installed system Chromium (no bundled browser is downloaded).",
+  "type": "module",
+  "dependencies": {
+    "puppeteer-core": "25.1.0"
+  }
+}

--- a/tools/shotter/shot
+++ b/tools/shotter/shot
@@ -2,13 +2,14 @@
 # shot — on-PATH wrapper around the Node screenshot helper.
 #
 # Installed at /usr/local/bin/shot in the runtime images. The implementation lives
-# at /opt/duck/shotter/shot.mjs and drives the apt-installed system Chromium via
+# at /opt/shotter/shot.mjs and drives the apt-installed system Chromium via
 # puppeteer-core. puppeteer-core is installed as a LOCAL dependency in the script's
-# own directory (/opt/duck/shotter/node_modules), so the ES module `import` in
-# shot.mjs resolves by walking up from the script dir — no NODE_PATH needed (ESM
-# import resolution ignores NODE_PATH anyway).
+# own directory (/opt/shotter/node_modules), so the ES module `import` in shot.mjs
+# resolves by walking up from the script dir — no NODE_PATH needed (ESM import
+# resolution ignores NODE_PATH anyway). The tooling lives OUTSIDE /opt/duck so it
+# stays root-owned + world-readable and is never re-owned to the runtime user.
 set -eu
 
-SHOT_HOME="${SHOT_HOME:-/opt/duck/shotter}"
+SHOT_HOME="${SHOT_HOME:-/opt/shotter}"
 
 exec node "$SHOT_HOME/shot.mjs" "$@"

--- a/tools/shotter/shot
+++ b/tools/shotter/shot
@@ -1,0 +1,15 @@
+#!/bin/sh
+# shot — on-PATH wrapper around the Node screenshot helper.
+#
+# Installed at /usr/local/bin/shot in the runtime images. The implementation
+# lives at /opt/duck/shotter/shot.mjs and drives the apt-installed system
+# Chromium via puppeteer-core (installed globally). NODE_PATH points at the
+# global module dir so the script resolves puppeteer-core regardless of the
+# caller's cwd or uid.
+set -eu
+
+SHOT_HOME="${SHOT_HOME:-/opt/duck/shotter}"
+NODE_PATH="${NODE_PATH:-$(npm root -g)}"
+export NODE_PATH
+
+exec node "$SHOT_HOME/shot.mjs" "$@"

--- a/tools/shotter/shot
+++ b/tools/shotter/shot
@@ -1,15 +1,14 @@
 #!/bin/sh
 # shot — on-PATH wrapper around the Node screenshot helper.
 #
-# Installed at /usr/local/bin/shot in the runtime images. The implementation
-# lives at /opt/duck/shotter/shot.mjs and drives the apt-installed system
-# Chromium via puppeteer-core (installed globally). NODE_PATH points at the
-# global module dir so the script resolves puppeteer-core regardless of the
-# caller's cwd or uid.
+# Installed at /usr/local/bin/shot in the runtime images. The implementation lives
+# at /opt/duck/shotter/shot.mjs and drives the apt-installed system Chromium via
+# puppeteer-core. puppeteer-core is installed as a LOCAL dependency in the script's
+# own directory (/opt/duck/shotter/node_modules), so the ES module `import` in
+# shot.mjs resolves by walking up from the script dir — no NODE_PATH needed (ESM
+# import resolution ignores NODE_PATH anyway).
 set -eu
 
 SHOT_HOME="${SHOT_HOME:-/opt/duck/shotter}"
-NODE_PATH="${NODE_PATH:-$(npm root -g)}"
-export NODE_PATH
 
 exec node "$SHOT_HOME/shot.mjs" "$@"

--- a/tools/shotter/shot.mjs
+++ b/tools/shotter/shot.mjs
@@ -6,12 +6,15 @@
 // browser, which is why puppeteer-core (not full puppeteer) is used.
 //
 // CLI contract (committed):
-//   shot <url> <out.png> [--full] [--width=N] [--height=N] [--wait=ms]
+//   shot <url> <out.png> [--full] [--width=N] [--height=N] [--wait=ms] [--scale=N]
 //     --full        full-page capture, with a pre-capture autoscroll so lazy /
 //                   scroll-reveal content has loaded before the shot is taken.
 //     --width=N     viewport width  (default 1280)
 //     --height=N    viewport height (default 800)
-//     --wait=ms     extra settle time after load, in milliseconds (default 0)
+//     --wait=ms     extra settle time after load, in milliseconds (default 0,
+//                   clamped to a 60000 ms max)
+//     --scale=N     device scale factor / pixel density (default 1, clamped 1-3;
+//                   higher = sharper but larger PNGs)
 //
 // Behaviour: on any failure (bad URL, navigation timeout, write error) it prints a
 // clear message to stderr and exits non-zero. The PNG is written atomically — first
@@ -30,18 +33,78 @@ function fail(msg) {
 const [, , url, out, ...rest] = process.argv;
 if (!url || !out) {
   console.error(
-    'usage: shot <url> <out.png> [--full] [--width=N] [--height=N] [--wait=ms]',
+    'usage: shot <url> <out.png> [--full] [--width=N] [--height=N] [--wait=ms] [--scale=N]',
   );
   process.exit(1);
+}
+
+// Validate the URL before doing any work. We only ever drive Chromium at an
+// http(s) page, so:
+//   - a non-parseable URL fails fast with a clear message;
+//   - only http:/https: schemes are allowed — this refuses file:, chrome:,
+//     data:, etc., which would otherwise let a caller exfiltrate local files or
+//     reach browser-internal pages;
+//   - the cloud-metadata link-local range (169.254.0.0/16, incl. the well-known
+//     169.254.169.254 endpoint) is refused to block SSRF against instance
+//     metadata services.
+// We deliberately DO NOT block loopback/localhost or RFC1918 private ranges: the
+// dev team legitimately screenshots locally-running app servers (e.g.
+// http://localhost:3000), so only non-http(s) schemes and the link-local range
+// are rejected.
+let parsedURL;
+try {
+  parsedURL = new URL(url);
+} catch {
+  fail(`invalid URL: ${url}`);
+}
+if (parsedURL.protocol !== 'http:' && parsedURL.protocol !== 'https:') {
+  fail(`unsupported URL scheme "${parsedURL.protocol}": only http/https are allowed`);
+}
+{
+  // Strip IPv6 brackets if present; link-local check only applies to IPv4 here.
+  const host = parsedURL.hostname.replace(/^\[|\]$/g, '');
+  if (/^169\.254\.\d{1,3}\.\d{1,3}$/.test(host)) {
+    fail(`refusing link-local address ${host} (cloud-metadata SSRF guard)`);
+  }
 }
 
 const opt = Object.fromEntries(
   rest.map((a) => a.replace(/^--/, '').split('=')),
 );
-const width = Number(opt.width) || 1280;
-const height = Number(opt.height) || 800;
+
+// Parse a positive-integer option; fall back to `def` (with a stderr note) when
+// the value is missing, non-finite, or <= 0.
+function posIntOpt(name, value, def) {
+  if (value === undefined) return def;
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) {
+    console.error(`shot: ignoring invalid --${name}=${value}; using ${def}`);
+    return def;
+  }
+  return Math.trunc(n);
+}
+
+const width = posIntOpt('width', opt.width, 1280);
+const height = posIntOpt('height', opt.height, 800);
 const fullPage = 'full' in opt;
-const extraWait = Number(opt.wait) || 0;
+
+// Extra settle time: a non-negative integer, clamped to 60000 ms so an oversized
+// value cannot overflow setTimeout (TimeoutOverflowWarning) or hang the run.
+const WAIT_MAX = 60000;
+let extraWait = posIntOpt('wait', opt.wait, 0);
+if (extraWait > WAIT_MAX) {
+  console.error(`shot: clamping --wait=${opt.wait} to ${WAIT_MAX}`);
+  extraWait = WAIT_MAX;
+}
+
+// Device scale factor (pixel density): default 1 for smaller PNGs (less risk of
+// hitting the outbox size cap); clamp to 1-3.
+let scale = posIntOpt('scale', opt.scale, 1);
+if (scale < 1) scale = 1;
+if (scale > 3) {
+  console.error(`shot: clamping --scale=${opt.scale} to 3`);
+  scale = 3;
+}
 
 // Resolve the system Chromium; allow an explicit override for non-standard images.
 const executablePath = process.env.CHROMIUM_PATH || '/usr/bin/chromium';
@@ -56,36 +119,60 @@ try {
   browser = await puppeteer.launch({
     executablePath,
     headless: true,
+    // Cap individual CDP calls so a hung/wedged page cannot block the protocol
+    // connection indefinitely (default is 180s).
+    protocolTimeout: 90_000,
     // Container-safe flags: no sandbox (we run unprivileged in a container) and
     // do not rely on /dev/shm, which is tiny by default and crashes Chromium.
     args: ['--no-sandbox', '--disable-dev-shm-usage'],
   });
 
   const page = await browser.newPage();
-  await page.setViewport({ width, height, deviceScaleFactor: 2 });
+  await page.setViewport({ width, height, deviceScaleFactor: scale });
 
   // networkidle0-style wait: page is considered loaded once the network is quiet.
   await page.goto(url, { waitUntil: 'networkidle0', timeout: 60000 });
 
-  // Trigger scroll-reveal / lazy content before a full-page capture.
+  // Trigger scroll-reveal / lazy content before a full-page capture. The page-side
+  // promise is bounded so an infinite-scroll page cannot hang the run: it stops at
+  // a wall-clock deadline, a max-iteration cap, when it reaches the bottom, OR when
+  // scrollHeight stops growing across a couple of ticks (height has stabilised).
   if (fullPage) {
     await page.evaluate(
       () =>
         new Promise((resolve) => {
+          const TICK_MS = 280;
+          const DEADLINE_MS = 15000;
+          const MAX_ITERS = Math.ceil(DEADLINE_MS / TICK_MS) + 5;
+          const STABLE_TICKS = 2; // height unchanged this many ticks => stop
+          const start = Date.now();
           let y = 0;
+          let iters = 0;
+          let lastHeight = -1;
+          let stable = 0;
           const step = Math.round(window.innerHeight * 0.6);
+          const docHeight = () =>
+            document.body?.scrollHeight ??
+            document.documentElement.scrollHeight;
           const timer = setInterval(() => {
             window.scrollTo(0, y);
             y += step;
-            const docHeight =
-              document.body?.scrollHeight ??
-              document.documentElement.scrollHeight;
-            if (y >= docHeight + window.innerHeight) {
+            iters += 1;
+            const h = docHeight();
+            if (h === lastHeight) stable += 1;
+            else {
+              stable = 0;
+              lastHeight = h;
+            }
+            const reachedBottom = y >= h + window.innerHeight;
+            const timedOut = Date.now() - start >= DEADLINE_MS;
+            const tooMany = iters >= MAX_ITERS;
+            if (reachedBottom || timedOut || tooMany || stable >= STABLE_TICKS) {
               clearInterval(timer);
               window.scrollTo(0, 0);
               resolve();
             }
-          }, 280);
+          }, TICK_MS);
         }),
     );
     await new Promise((r) => setTimeout(r, 500));
@@ -96,8 +183,11 @@ try {
   // a partial PNG at the destination.
   await page.screenshot({ path: tmpPng, fullPage });
 
-  const title = await page.title();
+  // Commit the rendered PNG BEFORE reading the (cosmetic) title, so a title()
+  // throw after a successful capture can never delete a valid screenshot. The
+  // title is best-effort metadata only.
   await rename(tmpPng, outPath);
+  const title = await page.title().catch(() => '');
   console.log(JSON.stringify({ ok: true, url, out: outPath, title, fullPage }));
 } catch (err) {
   // Drop any partial temp file before exiting non-zero.

--- a/tools/shotter/shot.mjs
+++ b/tools/shotter/shot.mjs
@@ -1,0 +1,105 @@
+// shot — capture a PNG screenshot of a web page using the system Chromium.
+//
+// This is the implementation behind the on-PATH `shot` wrapper baked into the
+// runtime images (see adapters/*/Dockerfile). It drives the apt-installed system
+// Chromium via puppeteer-core's `executablePath` — there is NO bundled/downloaded
+// browser, which is why puppeteer-core (not full puppeteer) is used.
+//
+// CLI contract (committed):
+//   shot <url> <out.png> [--full] [--width=N] [--height=N] [--wait=ms]
+//     --full        full-page capture, with a pre-capture autoscroll so lazy /
+//                   scroll-reveal content has loaded before the shot is taken.
+//     --width=N     viewport width  (default 1280)
+//     --height=N    viewport height (default 800)
+//     --wait=ms     extra settle time after load, in milliseconds (default 0)
+//
+// Behaviour: on any failure (bad URL, navigation timeout, write error) it prints a
+// clear message to stderr and exits non-zero. The PNG is written atomically — first
+// to a temp file, then renamed into place — so a failed run never leaves a partial
+// or zero-byte file behind.
+
+import { rename, rm } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import puppeteer from 'puppeteer-core';
+
+function fail(msg) {
+  console.error(`shot: ${msg}`);
+  process.exit(1);
+}
+
+const [, , url, out, ...rest] = process.argv;
+if (!url || !out) {
+  console.error(
+    'usage: shot <url> <out.png> [--full] [--width=N] [--height=N] [--wait=ms]',
+  );
+  process.exit(1);
+}
+
+const opt = Object.fromEntries(
+  rest.map((a) => a.replace(/^--/, '').split('=')),
+);
+const width = Number(opt.width) || 1280;
+const height = Number(opt.height) || 800;
+const fullPage = 'full' in opt;
+const extraWait = Number(opt.wait) || 0;
+
+// Resolve the system Chromium; allow an explicit override for non-standard images.
+const executablePath = process.env.CHROMIUM_PATH || '/usr/bin/chromium';
+
+const outPath = resolve(out);
+// Keep the temp file on the SAME filesystem as the destination so the final
+// rename is atomic (a cross-device rename would fail with EXDEV).
+const tmpPng = join(dirname(outPath), `.shot-${process.pid}.tmp.png`);
+
+let browser;
+try {
+  browser = await puppeteer.launch({
+    executablePath,
+    headless: 'new',
+    // Container-safe flags: no sandbox (we run unprivileged in a container) and
+    // do not rely on /dev/shm, which is tiny by default and crashes Chromium.
+    args: ['--no-sandbox', '--disable-dev-shm-usage', '--headless=new'],
+  });
+
+  const page = await browser.newPage();
+  await page.setViewport({ width, height, deviceScaleFactor: 2 });
+
+  // networkidle0-style wait: page is considered loaded once the network is quiet.
+  await page.goto(url, { waitUntil: 'networkidle0', timeout: 60000 });
+
+  // Trigger scroll-reveal / lazy content before a full-page capture.
+  if (fullPage) {
+    await page.evaluate(
+      () =>
+        new Promise((resolve) => {
+          let y = 0;
+          const step = Math.round(window.innerHeight * 0.6);
+          const timer = setInterval(() => {
+            window.scrollTo(0, y);
+            y += step;
+            if (y >= document.body.scrollHeight + window.innerHeight) {
+              clearInterval(timer);
+              window.scrollTo(0, 0);
+              resolve();
+            }
+          }, 280);
+        }),
+    );
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  if (extraWait) await new Promise((r) => setTimeout(r, extraWait));
+
+  // Render to a temp file first, then rename into place so a failure never leaves
+  // a partial PNG at the destination.
+  await page.screenshot({ path: tmpPng, fullPage });
+
+  const title = await page.title();
+  await rename(tmpPng, outPath);
+  console.log(JSON.stringify({ ok: true, url, out: outPath, title, fullPage }));
+} catch (err) {
+  // Drop any partial temp file before exiting non-zero.
+  await rm(tmpPng, { force: true }).catch(() => {});
+  fail(err && err.message ? err.message : String(err));
+} finally {
+  if (browser) await browser.close().catch(() => {});
+}

--- a/tools/shotter/shot.mjs
+++ b/tools/shotter/shot.mjs
@@ -55,10 +55,10 @@ let browser;
 try {
   browser = await puppeteer.launch({
     executablePath,
-    headless: 'new',
+    headless: true,
     // Container-safe flags: no sandbox (we run unprivileged in a container) and
     // do not rely on /dev/shm, which is tiny by default and crashes Chromium.
-    args: ['--no-sandbox', '--disable-dev-shm-usage', '--headless=new'],
+    args: ['--no-sandbox', '--disable-dev-shm-usage'],
   });
 
   const page = await browser.newPage();
@@ -77,7 +77,10 @@ try {
           const timer = setInterval(() => {
             window.scrollTo(0, y);
             y += step;
-            if (y >= document.body.scrollHeight + window.innerHeight) {
+            const docHeight =
+              document.body?.scrollHeight ??
+              document.documentElement.scrollHeight;
+            if (y >= docHeight + window.innerHeight) {
               clearInterval(timer);
               window.scrollTo(0, 0);
               resolve();


### PR DESCRIPTION
## Summary

Bakes two developer-facing capabilities directly into the runtime images so a freshly deployed bot has them out of the box, the same way `git`/`ripgrep`/`ffmpeg`/`gh` are already provided — no per-workspace setup, no root at runtime.

1. **Webpage screenshots.** System Chromium (Debian package) plus an on-PATH `shot` helper. The agent can render any public page to PNG and deliver it to chat via `outbox/`.
2. **DX command runners.** `task` (go-task), `just`, and `make`, so the agent can invoke a project's own `Taskfile.yml` / `justfile` / `Makefile` to run linters and tests.

Both adapter images (`telegram` and `vk`) receive identical changes.

## What changed

- **`adapters/telegram/Dockerfile`, `adapters/vk/Dockerfile`** (identical edits):
  - `chromium` and `make` added to the **existing single** `apt-get install --no-install-recommends …` layer — no new apt source, no second `apt-get update`, cleanup stays in-layer (this is the constraint that previously OOM'd the QEMU arm64 build, hence why `gh`/`task`/`just` are tarballs, not apt repos).
  - `task` and `just` installed from official GitHub release tarballs, mirroring the established `gh` block (latest-via-API with a pinned fallback, arch-matched).
  - The `shot` helper copied to `/usr/local/bin/shot`; its implementation + pinned deps installed under `/opt/duck/shotter` via `npm ci --omit=dev`.
- **`tools/shotter/`** (new): `shot.mjs` (puppeteer-core driving **system** Chromium via `executablePath` — no second browser download), a POSIX-sh `shot` wrapper, and `package.json` + `package-lock.json` pinning `puppeteer-core`.
- **`core/workspace/workspace.go`**: a `shotConvention` string appended to the rendered per-chat `CLAUDE.md` (same render-time append pattern as `outboxConvention`) so the agent knows the capability exists. The template file `core/CLAUDE.workspace.md.tmpl` is intentionally left **byte-identical**.
- **`core/workspace/workspace_test.go`**: guard test extended to assert the rendered `CLAUDE.md` contains the screenshot doc while the template file does not.

## `shot` contract

```
shot <url> <out.png> [--full] [--width=N] [--height=N] [--wait=ms]
```

`--full` captures the whole page (auto-scrolls first to trigger lazy / scroll-reveal content). Runs headless with `--no-sandbox --disable-dev-shm-usage` (container-safe). Writes atomically (temp → rename); on failure it exits non-zero with a clear stderr message and never leaves a partial/zero-byte PNG.

## Acceptance criteria

- [x] **AC1** — Runtime image renders a public URL to a non-empty PNG as the non-root `claude` user (uid 1000): no root, no `sudo`, no `LD_LIBRARY_PATH` hack, no runtime browser download. Verified inside the built image on amd64.
- [x] **AC2** — Single stable on-PATH helper `shot` with the contract above; non-zero exit + stderr on failure (bad URL / nav timeout / write error); atomic write, no partial PNG.
- [x] **AC3** — Capability discoverable by the agent out of the box: rendered `CLAUDE.md` documents `shot` and `outbox/` delivery and the auth'd-page (`initData`) limitation; template file stays byte-identical (guard test passes).
- [x] **AC4** — Both adapter images gain the capability identically and build green on **both** arches (amd64 + arm64 via QEMU) with no OOM regression.
- [x] **AC5** — `gofmt` / `go vet` / `golangci-lint` clean; `go test -race ./...` green incl. `core/workspace`; binaries build.

## How it was verified

- `go vet`, `gofmt -l`, `golangci-lint run` — all clean (0 issues).
- `go test -race ./...` — all packages pass, including `core/workspace`.
- `go build` — both `flock-telegram` and `duck-vk` binaries.
- **Image builds**: `telegram` and `vk` built for **linux/amd64 and linux/arm64** via buildx. No OOM on either arch; the chromium apt layer and `npm ci` complete under QEMU arm64.
- **In-image runtime (uid 1000)**: `shot <url> out.png` and `--full` produce valid PNGs; failure path returns non-zero with stderr and no file; `task --version` / `make --version` / `just --version` / `chromium --version` all resolve.

## Pre-PR review

One internal review round on the local diff, then a clean re-derivation — **verdict APPROVE, risk low**. No blockers. Caught-and-fixed before this PR:
- puppeteer-core v25 rejects the `headless: 'new'` string → switched to `headless: true` and dropped the redundant explicit `--headless=new` flag.
- `--full` autoscroll could throw on body-less documents → guarded with `document.documentElement.scrollHeight` fallback.
- `npm install` → `npm ci` for a lockfile-faithful, reproducible install.

## Residual risks / needs a human eye

- **Unpinned Chromium / apt drift**: the image tracks Debian's `chromium` (and `make`) at build time, so rebuilds may pick up a newer Chromium. Accepted by the product owner; not pinned. If reproducible images are later required, pin the package version.
- **`task`/`just` resolve "latest" at build time** (pinned fallback only if the GitHub API is unreachable), so different image builds may ship slightly different runner versions.
- **Auth'd pages don't render**: anything behind Telegram Mini App `initData` (or any login) won't open without a real session — `shot` only captures public content. Documented, not a bug.
- **Outbox size cap**: a very large full-page PNG could exceed the existing outbox delivery cap and silently not send.
- **Live in-bot behaviour not exercised end-to-end**: verification was done by running `shot` and the runners directly inside the built images, not by driving a full Telegram round-trip; the agent-facing doc wiring is covered by the unit test but the live "agent screenshots a page and it arrives in chat" path is best confirmed once deployed.
