### PR TITLE
feat(schedule): bot-level /schedule command behind ENABLE_SCHEDULER

### DIFF
--- a/adapters/telegram/.env.example
+++ b/adapters/telegram/.env.example
@@ -74,7 +74,8 @@ MISTRAL_API_KEY=               # for VOICE_PROVIDER=mistral (console.mistral.ai)
 # OPENAI_API_KEY=              # for VOICE_PROVIDER=openai
 
 # ===== SCHEDULER (optional) — durable per-chat cron jobs =====
-# false (default) = off: no /schedule command, no background scheduler (a true no-op).
+# false (default) = off: no background scheduler (no store, no goroutine). /schedule
+# stays in the command menu but only replies that it is disabled.
 # true = enable /schedule (list/add/remove/pause/resume) and a background loop that
 # fires each due job's prompt into its chat, just like a user message. Cron is a
 # 5-field spec (min hour day-of-month month day-of-week) evaluated in the server's

--- a/adapters/telegram/.env.example
+++ b/adapters/telegram/.env.example
@@ -73,6 +73,15 @@ VOICE_PROVIDER=mistral         # mistral | openai | local
 MISTRAL_API_KEY=               # for VOICE_PROVIDER=mistral (console.mistral.ai)
 # OPENAI_API_KEY=              # for VOICE_PROVIDER=openai
 
+# ===== SCHEDULER (optional) — durable per-chat cron jobs =====
+# false (default) = off: no /schedule command, no background scheduler (a true no-op).
+# true = enable /schedule (list/add/remove/pause/resume) and a background loop that
+# fires each due job's prompt into its chat, just like a user message. Cron is a
+# 5-field spec (min hour day-of-month month day-of-week) evaluated in the server's
+# LOCAL timezone (UTC in the default container).
+ENABLE_SCHEDULER=false
+# SCHEDULE_STORE_PATH=          # JSON job store; default <APPROVED_DIRECTORY>/schedules.json
+
 # ===== DOCKER-IN-DOCKER (optional, with `--profile dind`) — dockerized linters/tests for the team =====
 # DOCKER_HOST=tcp://dind:2375
 

--- a/adapters/telegram/.env.example
+++ b/adapters/telegram/.env.example
@@ -76,10 +76,11 @@ MISTRAL_API_KEY=               # for VOICE_PROVIDER=mistral (console.mistral.ai)
 # ===== SCHEDULER (optional) — durable per-chat cron jobs =====
 # false (default) = off: no background scheduler (no store, no goroutine). /schedule
 # stays in the command menu but only replies that it is disabled.
-# true = enable /schedule (list/add/remove/pause/resume) and a background loop that
-# fires each due job's prompt into its chat, just like a user message. Cron is a
-# 5-field spec (min hour day-of-month month day-of-week) evaluated in the server's
-# LOCAL timezone (UTC in the default container).
+# true = enable /schedule (list/show/add/remove/pause/resume/tz) and a background loop
+# that fires each due job's prompt into its chat, just like a user message. Cron is a
+# 5-field spec (min hour day-of-month month day-of-week) evaluated in the chat's
+# timezone (/schedule tz <IANA>), else the server's LOCAL zone (UTC in the default
+# container).
 ENABLE_SCHEDULER=false
 # SCHEDULE_STORE_PATH=          # JSON job store; default <APPROVED_DIRECTORY>/schedules.json
 

--- a/adapters/telegram/commands.go
+++ b/adapters/telegram/commands.go
@@ -89,7 +89,8 @@ func StripCommandMention(text, botUsername string) string {
 const HelpText = "Flock Telegram assistant — available commands:\n\n" +
 	"/help — show this message\n" +
 	"/new — start a fresh session (forget the current conversation)\n" +
-	"/stop — stop the run currently in progress\n\n" +
+	"/stop — stop the run currently in progress\n" +
+	"/schedule — manage scheduled jobs (when enabled)\n\n" +
 	"Send any other message to run it through the assistant."
 
 // WelcomeText is the static usage message replied to an allowed user who sends

--- a/adapters/vk/.env.example
+++ b/adapters/vk/.env.example
@@ -61,7 +61,8 @@ MISTRAL_API_KEY=               # for VOICE_PROVIDER=mistral (console.mistral.ai)
 # OPENAI_API_KEY=              # for VOICE_PROVIDER=openai
 
 # ===== SCHEDULER (optional) — durable per-chat cron jobs =====
-# false (default) = off: no /schedule command, no background scheduler (a true no-op).
+# false (default) = off: no background scheduler (no store, no goroutine). /schedule
+# stays a bot command but only replies that it is disabled.
 # true = enable /schedule (list/add/remove/pause/resume) and a background loop that
 # fires each due job's prompt into its chat, just like a user message. Cron is a
 # 5-field spec (min hour day-of-month month day-of-week) evaluated in the server's

--- a/adapters/vk/.env.example
+++ b/adapters/vk/.env.example
@@ -60,6 +60,15 @@ VOICE_PROVIDER=mistral         # mistral | openai | local
 MISTRAL_API_KEY=               # for VOICE_PROVIDER=mistral (console.mistral.ai)
 # OPENAI_API_KEY=              # for VOICE_PROVIDER=openai
 
+# ===== SCHEDULER (optional) — durable per-chat cron jobs =====
+# false (default) = off: no /schedule command, no background scheduler (a true no-op).
+# true = enable /schedule (list/add/remove/pause/resume) and a background loop that
+# fires each due job's prompt into its chat, just like a user message. Cron is a
+# 5-field spec (min hour day-of-month month day-of-week) evaluated in the server's
+# LOCAL timezone (UTC in the default container).
+ENABLE_SCHEDULER=false
+# SCHEDULE_STORE_PATH=          # JSON job store; default <APPROVED_DIRECTORY>/schedules.json
+
 # ===== DOCKER-IN-DOCKER (optional, with `--profile dind`) — dockerized linters/tests for the team =====
 # DOCKER_HOST=tcp://dind:2375
 

--- a/adapters/vk/.env.example
+++ b/adapters/vk/.env.example
@@ -63,10 +63,11 @@ MISTRAL_API_KEY=               # for VOICE_PROVIDER=mistral (console.mistral.ai)
 # ===== SCHEDULER (optional) — durable per-chat cron jobs =====
 # false (default) = off: no background scheduler (no store, no goroutine). /schedule
 # stays a bot command but only replies that it is disabled.
-# true = enable /schedule (list/add/remove/pause/resume) and a background loop that
-# fires each due job's prompt into its chat, just like a user message. Cron is a
-# 5-field spec (min hour day-of-month month day-of-week) evaluated in the server's
-# LOCAL timezone (UTC in the default container).
+# true = enable /schedule (list/show/add/remove/pause/resume/tz) and a background loop
+# that fires each due job's prompt into its chat, just like a user message. Cron is a
+# 5-field spec (min hour day-of-month month day-of-week) evaluated in the chat's
+# timezone (/schedule tz <IANA>), else the server's LOCAL zone (UTC in the default
+# container).
 ENABLE_SCHEDULER=false
 # SCHEDULE_STORE_PATH=          # JSON job store; default <APPROVED_DIRECTORY>/schedules.json
 

--- a/adapters/vk/commands.go
+++ b/adapters/vk/commands.go
@@ -7,5 +7,6 @@ package vk
 const HelpText = "Flock VK assistant — available commands:\n\n" +
 	"/help — show this message\n" +
 	"/new — start a fresh session (forget the current conversation)\n" +
-	"/stop — stop the run currently in progress\n\n" +
+	"/stop — stop the run currently in progress\n" +
+	"/schedule — manage scheduled jobs (when enabled)\n\n" +
 	"Send any other message to run it through the assistant."

--- a/adapters/vk/receiver.go
+++ b/adapters/vk/receiver.go
@@ -11,7 +11,12 @@ import (
 
 	"github.com/duckbugio/flock/core/chat"
 	"github.com/duckbugio/flock/core/claude"
+	"github.com/duckbugio/flock/core/schedule"
 )
+
+// scheduleDisabledText is the reply when /schedule is used but the scheduler is
+// turned off (the default). It mirrors the Telegram adapter's notice.
+const scheduleDisabledText = "Scheduler is disabled. Set ENABLE_SCHEDULER=true to enable it."
 
 // welcomeText is the static reply to /start: a short greeting + the usage help,
 // mirroring the Telegram adapter's WelcomeText. It is an engineering artifact
@@ -104,6 +109,7 @@ type Receiver struct {
 	uploads        uploader
 	notices        NoticeSender
 	eventAck       eventAckFunc
+	sched          *schedule.Manager
 	logger         *slog.Logger
 }
 
@@ -120,7 +126,10 @@ type ReceiverConfig struct {
 	// EventAck acks a callback button press (messages.sendMessageEventAnswer) so VK
 	// clears the button spinner. May be nil (the ack is then skipped).
 	EventAck eventAckFunc
-	Logger   *slog.Logger
+	// Scheduler serves the /schedule command. Nil when ENABLE_SCHEDULER is off, in
+	// which case /schedule replies with the disabled notice.
+	Scheduler *schedule.Manager
+	Logger    *slog.Logger
 }
 
 // NewReceiver builds a Receiver from cfg. A nil logger defaults to slog.Default();
@@ -145,6 +154,7 @@ func NewReceiver(cfg ReceiverConfig) *Receiver {
 		uploads:        cfg.Uploads,
 		notices:        cfg.Notices,
 		eventAck:       cfg.EventAck,
+		sched:          cfg.Scheduler,
 		logger:         log,
 	}
 }
@@ -299,11 +309,11 @@ func (r *Receiver) onMessageNew(ctx context.Context, msg messageObject) {
 	isGroup := isGroupPeer(peerID)
 
 	// Reserved commands the bot handles itself (the single source of truth in
-	// core/chat). A leading /start, /help, /new or /stop is dispatched here and
+	// core/chat). A leading /start, /help, /new, /stop or /schedule is dispatched here and
 	// never reaches Claude; every OTHER slash command (e.g. /loop) is left to fall
 	// through with its full text so Claude Code's own slash-command system runs it.
 	if name := commandName(msg.Text); chat.IsReservedCommand(name) {
-		r.dispatchReserved(ctx, name, peerID)
+		r.dispatchReserved(ctx, name, msg)
 		return
 	}
 
@@ -350,12 +360,15 @@ func (r *Receiver) onMessageNew(ctx context.Context, msg messageObject) {
 	r.svc.Handle(ctx, chatIDStr(peerID), msg.FromID, msgIDStr(msg.ConversationMessageID), text)
 }
 
-// dispatchReserved acts on a reserved command (caller already confirmed name is
-// in the canonical set). /start and /help reply with the static notices; /new
-// resets the chat's session and confirms; /stop cancels the in-flight run. None
-// of these starts a Claude run. An unknown name (should not happen — the caller
-// gates on IsReservedCommand) is a no-op so the set stays the single authority.
-func (r *Receiver) dispatchReserved(ctx context.Context, name string, peerID int64) {
+// dispatchReserved acts on a reserved command (caller already confirmed the name
+// is in the canonical set). /start and /help reply with the static notices; /new
+// resets the chat's session and confirms; /stop cancels the in-flight run;
+// /schedule manages cron jobs via the shared Manager (or replies with the disabled
+// notice when the scheduler is off). None of these starts a Claude run. An unknown
+// name (should not happen — the caller gates on IsReservedCommand) is a no-op so
+// the set stays the single authority.
+func (r *Receiver) dispatchReserved(ctx context.Context, name string, msg messageObject) {
+	peerID := msg.PeerID
 	switch name {
 	case "start":
 		r.notify(ctx, peerID, welcomeText)
@@ -368,7 +381,23 @@ func (r *Receiver) dispatchReserved(ctx context.Context, name string, peerID int
 		r.notify(ctx, peerID, newSessionText)
 	case "stop":
 		r.svc.StopChat(chatIDStr(peerID))
+	case "schedule":
+		r.dispatchSchedule(ctx, msg)
 	}
+}
+
+// dispatchSchedule serves /schedule: when the scheduler is disabled it replies
+// with the disabled notice; otherwise it strips the leading /schedule token and
+// hands the remaining args, the chat id, and the sender's user id to the
+// transport-neutral Manager.Dispatch, replying with its result.
+func (r *Receiver) dispatchSchedule(ctx context.Context, msg messageObject) {
+	if r.sched == nil {
+		r.notify(ctx, msg.PeerID, scheduleDisabledText)
+		return
+	}
+	args := commandArgs(msg.Text)
+	reply := r.sched.Dispatch(chatIDStr(msg.PeerID), msg.FromID, args)
+	r.notify(ctx, msg.PeerID, reply)
 }
 
 // commandName parses the reserved-command name from a VK message: it trims the
@@ -392,6 +421,19 @@ func commandName(text string) string {
 // VK command token (space, tab, newline, carriage return).
 func isSpace(r rune) bool {
 	return r == ' ' || r == '\t' || r == '\n' || r == '\r'
+}
+
+// commandArgs returns the text following the leading "/command" token of a
+// slash-command message, i.e. the arguments. It drops the first whitespace-
+// delimited token (the command itself) and trims the surrounding whitespace, so
+// "/schedule add x" yields "add x" and a bare "/schedule" yields "". VK has no
+// @botname suffix to strip.
+func commandArgs(text string) string {
+	text = strings.TrimSpace(text)
+	if i := strings.IndexFunc(text, isSpace); i >= 0 {
+		return strings.TrimSpace(text[i+1:])
+	}
+	return ""
 }
 
 // handleVoice downloads + transcribes a voice attachment and submits the

--- a/adapters/vk/receiver_test.go
+++ b/adapters/vk/receiver_test.go
@@ -5,11 +5,14 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
 	"github.com/duckbugio/flock/core/chat"
 	"github.com/duckbugio/flock/core/claude"
+	"github.com/duckbugio/flock/core/schedule"
 )
 
 // fakeService records the Service calls the receiver makes.
@@ -306,6 +309,59 @@ func TestReceiverNewsNotTreatedAsNew(t *testing.T) {
 	}
 	if len(svc.handleCalls) != 1 || svc.handleCalls[0].prompt != "/news today" {
 		t.Errorf("/news should pass through to Handle with full text, got %+v", svc.handleCalls)
+	}
+}
+
+// TestReceiverScheduleDisabled: with no scheduler wired (ENABLE_SCHEDULER off),
+// "/schedule" replies with the disabled notice and is NOT forwarded to Claude.
+func TestReceiverScheduleDisabled(t *testing.T) {
+	svc := &fakeService{}
+	notices := &fakeNotice{}
+	r := newTestReceiver(svc, notices, false, nil) // no scheduler
+
+	r.dispatch(context.Background(), msgNewUpdate(t, messageObject{
+		FromID: 42, PeerID: 200, Text: "/schedule list", ConversationMessageID: 5,
+	}))
+
+	if len(svc.handleCalls) != 0 {
+		t.Errorf("/schedule must not reach Claude when disabled, got %d Handle calls", len(svc.handleCalls))
+	}
+	if len(notices.texts) != 1 || notices.texts[0] != scheduleDisabledText {
+		t.Errorf("notice texts = %v, want one disabled notice", notices.texts)
+	}
+}
+
+// TestReceiverScheduleEnabledReachesDispatch: with a scheduler wired, "/schedule
+// add ..." reaches Manager.Dispatch (the job is persisted) and the reply is sent
+// as a notice — never forwarded to Claude.
+func TestReceiverScheduleEnabledReachesDispatch(t *testing.T) {
+	svc := &fakeService{}
+	notices := &fakeNotice{}
+	store, err := schedule.Open(filepath.Join(t.TempDir(), "schedules.json"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	mgr := schedule.NewManager(store, func(string, string) {}, nil, nil)
+	r := NewReceiver(ReceiverConfig{
+		Service:   svc,
+		GroupID:   123,
+		IsAllowed: func(uid int64) bool { return uid == 42 },
+		Notices:   notices,
+		Scheduler: mgr,
+	})
+
+	r.dispatch(context.Background(), msgNewUpdate(t, messageObject{
+		FromID: 42, PeerID: 200, Text: "/schedule add job 0 9 * * 1 do the thing", ConversationMessageID: 6,
+	}))
+
+	if len(svc.handleCalls) != 0 {
+		t.Errorf("/schedule must not reach Claude when enabled, got %d Handle calls", len(svc.handleCalls))
+	}
+	if len(notices.texts) != 1 || !strings.Contains(notices.texts[0], "Added job #") {
+		t.Errorf("notice texts = %v, want one 'Added job #...' confirmation", notices.texts)
+	}
+	if got := store.List("200"); len(got) != 1 || got[0].Prompt != "do the thing" {
+		t.Errorf("store after add = %+v, want one job with prompt 'do the thing' for chat 200", got)
 	}
 }
 

--- a/cmd/duck-vk/main.go
+++ b/cmd/duck-vk/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/duckbugio/flock/core/nudge"
 	"github.com/duckbugio/flock/core/poller"
 	"github.com/duckbugio/flock/core/ratelimit"
+	"github.com/duckbugio/flock/core/schedule"
 	"github.com/duckbugio/flock/core/session"
 	"github.com/duckbugio/flock/core/voice"
 	"github.com/duckbugio/flock/core/workspace"
@@ -205,6 +206,13 @@ func run() int {
 		Logger:     logger,
 	})
 
+	// Background cron scheduler (OFF by default). When enabled, open the durable
+	// per-chat job store and start the scheduler loop, firing each due job into the
+	// same dispatch lane a user message uses (svc.Inject, sentinel user 0). A
+	// store-open failure is non-fatal: log and continue WITHOUT the scheduler (mgr
+	// stays nil). With the flag off no store is opened and no goroutine runs.
+	mgr := buildScheduler(ctx, cfg, svc, logger)
+
 	guards := chat.GuardConfig{CostCapUSD: cfg.ClaudeMaxCostPerUser}
 	receiver := vk.NewReceiver(vk.ReceiverConfig{
 		Service:        svc,
@@ -214,11 +222,12 @@ func run() int {
 		Guards: func(userID int64) (bool, string) {
 			return chat.CheckGuards(limiter, costs, guards, userID)
 		},
-		Voice:    voiceTranscriber(vt),
-		Uploads:  up,
-		Notices:  vk.NewNoticeSender(api, time.Now().UnixNano(), logger),
-		EventAck: api.SendMessageEventAnswer,
-		Logger:   logger,
+		Voice:     voiceTranscriber(vt),
+		Uploads:   up,
+		Notices:   vk.NewNoticeSender(api, time.Now().UnixNano(), logger),
+		EventAck:  api.SendMessageEventAnswer,
+		Scheduler: mgr,
+		Logger:    logger,
 	})
 
 	// PR poller (same as Telegram): relay PR review comments on a duck/<chatid>/… PR
@@ -277,6 +286,32 @@ func voiceTranscriber(vt *vk.VoiceTranscriber) vkTranscriber {
 // interface when voice is disabled.
 type vkTranscriber interface {
 	Transcribe(ctx context.Context, url string) (string, error)
+}
+
+// buildScheduler opens the durable cron-job store and starts the background
+// scheduler when ENABLE_SCHEDULER is set, returning the Manager the /schedule
+// command dispatches to. It returns nil when the feature is disabled OR when the
+// store cannot be opened (non-fatal: log and run without the scheduler), so
+// /schedule replies with the disabled notice rather than crashing. The scheduler
+// fires each due job via svc.Inject — the same serialized per-chat lane a normal
+// message uses. Mirrors cmd/flock-telegram.
+func buildScheduler(ctx context.Context, cfg config.Config, svc *chat.Service, logger *slog.Logger) *schedule.Manager {
+	if !cfg.SchedulerEnabled() {
+		return nil
+	}
+	store, err := schedule.Open(cfg.ScheduleStoreFile())
+	if err != nil {
+		logger.Error("open schedule store; scheduler disabled", "path", cfg.ScheduleStoreFile(), "error", err)
+		return nil
+	}
+	mgr := schedule.NewManager(store, svc.Inject, time.Now, logger)
+	go func() {
+		if err := mgr.Run(ctx); err != nil && ctx.Err() == nil {
+			logger.Error("scheduler stopped", "error", err)
+		}
+	}()
+	logger.Info("scheduler enabled", "store", cfg.ScheduleStoreFile())
+	return mgr
 }
 
 // buildStarNudge assembles the post-task star-nudge config (GitHub-only; disabled

--- a/cmd/duck-vk/main.go
+++ b/cmd/duck-vk/main.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"syscall"
 	"time"
+	_ "time/tzdata" // embed IANA tz database so /schedule per-chat timezones work without OS zoneinfo
 
 	"github.com/duckbugio/flock/adapters/vk"
 	"github.com/duckbugio/flock/core/chat"

--- a/cmd/duck-vk/main.go
+++ b/cmd/duck-vk/main.go
@@ -304,7 +304,11 @@ func buildScheduler(ctx context.Context, cfg config.Config, svc *chat.Service, l
 		logger.Error("open schedule store; scheduler disabled", "path", cfg.ScheduleStoreFile(), "error", err)
 		return nil
 	}
-	mgr := schedule.NewManager(store, svc.Inject, time.Now, logger)
+	// Fire each due job on its own goroutine so a blocked Inject (full dispatch
+	// buffer behind a long Claude run) never stalls the single scheduler goroutine
+	// and starves other chats' jobs. Mirrors cmd/flock-telegram.
+	fire := func(chatID, prompt string) { go svc.Inject(chatID, prompt) }
+	mgr := schedule.NewManager(store, fire, time.Now, logger)
 	go func() {
 		if err := mgr.Run(ctx); err != nil && ctx.Err() == nil {
 			logger.Error("scheduler stopped", "error", err)

--- a/cmd/flock-telegram/commands_test.go
+++ b/cmd/flock-telegram/commands_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -16,6 +17,7 @@ import (
 	"github.com/duckbugio/flock/core/chat"
 	"github.com/duckbugio/flock/core/claude"
 	"github.com/duckbugio/flock/core/dispatch"
+	"github.com/duckbugio/flock/core/schedule"
 	"github.com/duckbugio/flock/internal/config"
 )
 
@@ -141,9 +143,9 @@ func TestStartWelcomeText(t *testing.T) {
 // Claude as free text. Keying both off the same source and asserting equality makes
 // that impossible.
 func TestReservedHandlersMatchCanonicalSet(t *testing.T) {
-	// A nil *chat.Service is fine: we only inspect the map's key set, never invoke a
-	// handler closure.
-	handlers := reservedHandlers(config.Config{}, nil)
+	// A nil *chat.Service and nil *schedule.Manager are fine: we only inspect the
+	// map's key set, never invoke a handler closure.
+	handlers := reservedHandlers(config.Config{}, nil, nil)
 
 	if len(handlers) != len(chat.ReservedCommands) {
 		t.Fatalf("reservedHandlers has %d entries, want %d (chat.ReservedCommands)",
@@ -254,8 +256,9 @@ func newCommandTestBot(t *testing.T, cfg config.Config, svc messageSubmitter, re
 		t.Fatalf("build test bot: %v", err)
 	}
 	// Register the reserved-command handlers from the SAME canonical source main uses,
-	// so the routing (reserved handler vs default) is identical to production.
-	for name, h := range reservedHandlers(cfg, reservedSvc) {
+	// so the routing (reserved handler vs default) is identical to production. The
+	// scheduler is nil here (the pass-through tests do not exercise /schedule).
+	for name, h := range reservedHandlers(cfg, reservedSvc, nil) {
 		b.RegisterHandlerMatchFunc(commandMatch(name), h)
 	}
 	return b
@@ -302,6 +305,92 @@ func TestNativeCommandPassesThroughTelegram(t *testing.T) {
 
 	if got := svc.seen(); len(got) != 1 {
 		t.Fatalf("reserved /stop leaked to the run Service: Service saw %v, want only the native command", got)
+	}
+}
+
+// TestScheduleCommandDisabled: with no scheduler wired (mgr nil), /schedule is
+// routed to its own handler (never the default text/Claude path) and the handler
+// replies with the disabled notice. We assert routing by checking the pass-through
+// Service never sees the command.
+func TestScheduleCommandDisabled(t *testing.T) {
+	const userID = 42
+	cfg := config.Config{AllowedUsers: []int64{userID}}
+	svc := &recordingSubmitter{}
+	b := newCommandTestBot(t, cfg, svc, nil) // reservedSvc nil: /schedule needs no Service
+
+	b.ProcessUpdate(context.Background(), privateCommandUpdate(userID, 555, "/schedule list", len("/schedule")))
+
+	if got := svc.seen(); len(got) != 0 {
+		t.Fatalf("/schedule leaked to the run Service when disabled: saw %v", got)
+	}
+}
+
+// TestScheduleCommandEnabledReachesDispatch: with a scheduler wired into the
+// reserved handlers, "/schedule add ..." reaches Manager.Dispatch (the job is
+// persisted) and never reaches the pass-through Service.
+func TestScheduleCommandEnabledReachesDispatch(t *testing.T) {
+	const userID = 77 // a distinct sender so CreatedBy is asserted meaningfully
+	cfg := config.Config{AllowedUsers: []int64{userID}}
+	svc := &recordingSubmitter{}
+
+	store, err := schedule.Open(filepath.Join(t.TempDir(), "schedules.json"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	mgr := schedule.NewManager(store, func(string, string) {}, nil, nil)
+
+	defaultHandler := func(ctx context.Context, b *bot.Bot, update *models.Update) {
+		if msg := update.Message; msg != nil {
+			deps := messageDeps{cfg: cfg, service: svc}
+			handleMessage(ctx, deps, b, msg, false)
+		}
+	}
+	b, err := bot.New("123456:test-token",
+		bot.WithSkipGetMe(),
+		bot.WithNotAsyncHandlers(),
+		bot.WithHTTPClient(time.Minute, stubHTTPClient{}),
+		bot.WithDefaultHandler(defaultHandler),
+	)
+	if err != nil {
+		t.Fatalf("build test bot: %v", err)
+	}
+	for name, h := range reservedHandlers(cfg, nil, mgr) {
+		b.RegisterHandlerMatchFunc(commandMatch(name), h)
+	}
+
+	b.ProcessUpdate(context.Background(), privateCommandUpdate(
+		userID, 200, "/schedule add job 0 9 * * 1 do the thing", len("/schedule")))
+
+	if got := svc.seen(); len(got) != 0 {
+		t.Fatalf("/schedule leaked to the run Service when enabled: saw %v", got)
+	}
+	jobs := store.List("200")
+	if len(jobs) != 1 || jobs[0].Prompt != "do the thing" {
+		t.Fatalf("store after /schedule add = %+v, want one job with prompt 'do the thing'", jobs)
+	}
+	if jobs[0].CreatedBy != userID {
+		t.Errorf("job CreatedBy = %d, want the sender %d", jobs[0].CreatedBy, userID)
+	}
+}
+
+// TestCommandArgs asserts the /schedule arg extractor strips the leading command
+// token (with or without an @botname suffix) and trims surrounding whitespace.
+func TestCommandArgs(t *testing.T) {
+	tests := []struct {
+		text string
+		want string
+	}{
+		{"/schedule list", "list"},
+		{"/schedule add a 0 9 * * 1 do it", "add a 0 9 * * 1 do it"},
+		{"/schedule@duck_bot list", "list"},
+		{"/schedule", ""},
+		{"/schedule   ", ""},
+		{"  /schedule  list  ", "list"},
+	}
+	for _, tt := range tests {
+		if got := commandArgs(tt.text); got != tt.want {
+			t.Errorf("commandArgs(%q) = %q, want %q", tt.text, got, tt.want)
+		}
 	}
 }
 

--- a/cmd/flock-telegram/main.go
+++ b/cmd/flock-telegram/main.go
@@ -999,7 +999,14 @@ func buildScheduler(ctx context.Context, cfg config.Config, svc *chat.Service, l
 		logger.Error("open schedule store; scheduler disabled", "path", cfg.ScheduleStoreFile(), "error", err)
 		return nil
 	}
-	mgr := schedule.NewManager(store, svc.Inject, time.Now, logger)
+	// Fire each due job on its own goroutine: Inject blocks when a chat's dispatch
+	// buffer is full (a long-running Claude run holds the lane), and the scheduler
+	// runs a single goroutine — firing inline would stall every OTHER chat's due
+	// jobs and could skip a matching minute. Detaching keeps the tick loop free;
+	// at-most-once-per-minute still holds because TickOnce records the minute key
+	// synchronously before this returns.
+	fire := func(chatID, prompt string) { go svc.Inject(chatID, prompt) }
+	mgr := schedule.NewManager(store, fire, time.Now, logger)
 	go func() {
 		if err := mgr.Run(ctx); err != nil && ctx.Err() == nil {
 			logger.Error("scheduler stopped", "error", err)

--- a/cmd/flock-telegram/main.go
+++ b/cmd/flock-telegram/main.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"syscall"
 	"time"
+	_ "time/tzdata" // embed IANA tz database so /schedule per-chat timezones work without OS zoneinfo
 
 	"github.com/go-telegram/bot"
 	"github.com/go-telegram/bot/models"

--- a/cmd/flock-telegram/main.go
+++ b/cmd/flock-telegram/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/duckbugio/flock/core/pending"
 	"github.com/duckbugio/flock/core/poller"
 	"github.com/duckbugio/flock/core/ratelimit"
+	"github.com/duckbugio/flock/core/schedule"
 	"github.com/duckbugio/flock/core/session"
 	"github.com/duckbugio/flock/core/voice"
 	"github.com/duckbugio/flock/core/workspace"
@@ -277,6 +278,14 @@ func run() int {
 		Logger:     logger,
 	})
 
+	// Background cron scheduler (OFF by default). When enabled, open the durable
+	// per-chat job store and start the scheduler loop, firing each due job into the
+	// same dispatch lane a user message uses (svc.Inject, sentinel user 0). A
+	// store-open failure is non-fatal: log and continue WITHOUT the scheduler (mgr
+	// stays nil), like the rest of the best-effort startup wiring. With the flag off
+	// no store is opened and no goroutine runs — the path is a true no-op.
+	mgr := buildScheduler(ctx, cfg, svc, logger)
+
 	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, telegram.CallbackMatch(), bot.MatchTypePrefix, stopHandler(cfg, svc))
 	b.RegisterHandler(
 		bot.HandlerTypeCallbackQueryData, telegram.StarCallbackPrefix(), bot.MatchTypePrefix, starHandler(cfg, svc),
@@ -292,7 +301,7 @@ func run() int {
 	// explicit address). The set of names handled here is asserted, by test, to equal
 	// the canonical chat.ReservedCommands so a new reserved command can never be
 	// published in the menu yet leak to the model for lack of a handler.
-	handlers := reservedHandlers(cfg, svc)
+	handlers := reservedHandlers(cfg, svc, mgr)
 	for name, h := range handlers {
 		b.RegisterHandlerMatchFunc(commandMatch(name), h)
 	}
@@ -494,7 +503,7 @@ func handleMessage(ctx context.Context, deps messageDeps, b *bot.Bot, msg *model
 
 	// Normalize the group form of a forwarded slash command so an unknown command
 	// reaches Claude as a bare command: "/loop@duck_bot 5m" -> "/loop 5m". Reserved
-	// commands (/start /help /new /stop) are routed to their own handlers and never
+	// commands (/start /help /new /stop /schedule) are routed to their own handlers and never
 	// reach here, so this only ever touches Claude pass-through commands; it is a
 	// no-op when there is no leading "/command@botname".
 	text = telegram.StripCommandMention(text, cfg.TelegramBotUsername)
@@ -839,12 +848,13 @@ func reservedBotCommands() []models.BotCommand {
 // asserts this map's key set equals chat.ReservedCommands. Adding a reserved command
 // is therefore a two-line change here (plus the canonical entry); forgetting the
 // handler fails the test rather than silently leaking the command to Claude.
-func reservedHandlers(cfg config.Config, svc *chat.Service) map[string]bot.HandlerFunc {
+func reservedHandlers(cfg config.Config, svc *chat.Service, sched *schedule.Manager) map[string]bot.HandlerFunc {
 	return map[string]bot.HandlerFunc{
-		"start": startHandler(cfg),
-		"help":  helpHandler(cfg),
-		"new":   newHandler(cfg, svc),
-		"stop":  stopCommandHandler(cfg, svc),
+		"start":    startHandler(cfg),
+		"help":     helpHandler(cfg),
+		"new":      newHandler(cfg, svc),
+		"stop":     stopCommandHandler(cfg, svc),
+		"schedule": scheduleHandler(cfg, sched),
 	}
 }
 
@@ -930,6 +940,73 @@ func stopCommandHandler(cfg config.Config, svc *chat.Service) bot.HandlerFunc {
 		}
 		sendCommandReply(ctx, b, chatID, text)
 	}
+}
+
+// scheduleDisabledText is the reply when /schedule is used but the scheduler is
+// turned off (the default). It tells the operator exactly which flag enables it.
+const scheduleDisabledText = "Scheduler is disabled. Set ENABLE_SCHEDULER=true to enable it."
+
+// scheduleHandler serves /schedule from an allowed user. When the scheduler is
+// disabled (mgr == nil) it replies with the disabled notice; otherwise it strips
+// the leading /schedule token and hands the remaining args, the chat id, and the
+// sender's user id to the transport-neutral Manager.Dispatch, replying with its
+// result. Like the other reserved handlers it is allow-list gated (via
+// commandSender) and never starts a Claude run.
+func scheduleHandler(cfg config.Config, mgr *schedule.Manager) bot.HandlerFunc {
+	return func(ctx context.Context, b *bot.Bot, update *models.Update) {
+		chatID, ok := commandSender(cfg, update.Message)
+		if !ok {
+			return
+		}
+		if mgr == nil {
+			sendCommandReply(ctx, b, chatID, scheduleDisabledText)
+			return
+		}
+		args := commandArgs(update.Message.Text)
+		reply := mgr.Dispatch(chatIDStr(chatID), update.Message.From.ID, args)
+		sendCommandReply(ctx, b, chatID, reply)
+	}
+}
+
+// commandArgs returns the text following the leading "/command[@botname]" token of
+// a slash-command message, i.e. the arguments. It drops the first whitespace-
+// delimited token (the command itself, including any @botname suffix) and trims
+// the surrounding whitespace, so "/schedule add x" yields "add x" and a bare
+// "/schedule" yields "".
+func commandArgs(text string) string {
+	text = strings.TrimSpace(text)
+	if i := strings.IndexFunc(text, func(r rune) bool {
+		return r == ' ' || r == '\t' || r == '\n' || r == '\r'
+	}); i >= 0 {
+		return strings.TrimSpace(text[i+1:])
+	}
+	return ""
+}
+
+// buildScheduler opens the durable cron-job store and starts the background
+// scheduler when ENABLE_SCHEDULER is set, returning the Manager the /schedule
+// handler dispatches to. It returns nil when the feature is disabled OR when the
+// store cannot be opened (non-fatal: log and run without the scheduler), so the
+// handler replies with the disabled notice rather than crashing. The scheduler
+// fires each due job via svc.Inject — the same serialized per-chat lane a normal
+// message uses.
+func buildScheduler(ctx context.Context, cfg config.Config, svc *chat.Service, logger *slog.Logger) *schedule.Manager {
+	if !cfg.SchedulerEnabled() {
+		return nil
+	}
+	store, err := schedule.Open(cfg.ScheduleStoreFile())
+	if err != nil {
+		logger.Error("open schedule store; scheduler disabled", "path", cfg.ScheduleStoreFile(), "error", err)
+		return nil
+	}
+	mgr := schedule.NewManager(store, svc.Inject, time.Now, logger)
+	go func() {
+		if err := mgr.Run(ctx); err != nil && ctx.Err() == nil {
+			logger.Error("scheduler stopped", "error", err)
+		}
+	}()
+	logger.Info("scheduler enabled", "store", cfg.ScheduleStoreFile())
+	return mgr
 }
 
 // sendCommandReply posts a short command confirmation. Delivery failures are

--- a/core/chat/reserved.go
+++ b/core/chat/reserved.go
@@ -17,12 +17,13 @@ type ReservedCommand struct {
 // /security-review) is forwarded verbatim so Claude Code's own slash-command and
 // skill system runs it. Both adapters (Telegram, VK) decide what to intercept
 // from this list, and Telegram builds its command menu from it. The order here is
-// the order the menu presents: start, help, new, stop.
+// the order the menu presents: start, help, new, stop, schedule.
 var ReservedCommands = []ReservedCommand{
 	{Name: "start", Description: "Show a short welcome and usage"},
 	{Name: "help", Description: "List the bot's own commands"},
 	{Name: "new", Description: "Start a fresh session (forget the current conversation)"},
 	{Name: "stop", Description: "Stop the run currently in progress"},
+	{Name: "schedule", Description: "Manage scheduled jobs"},
 }
 
 // IsReservedCommand reports whether name is one of the bot's reserved commands.

--- a/core/chat/reserved_test.go
+++ b/core/chat/reserved_test.go
@@ -20,13 +20,14 @@ func TestIsReservedCommand(t *testing.T) {
 		{"help", true},
 		{"new", true},
 		{"stop", true},
+		{"schedule", true},
 		{"START", true},
 		{"Help", true},
 		{"NeW", true},
 		{"STOP", true},
+		{"Schedule", true},
 		{"loop", false},
 		{"goal", false},
-		{"schedule", false},
 		{"news", false},
 		{"", false},
 		{"new ", false},
@@ -44,9 +45,9 @@ func TestIsReservedCommand(t *testing.T) {
 
 // TestReservedCommandsShape guards the menu source: names are unique, lowercase,
 // non-empty, every command has a description, and the order is the documented
-// start, help, new, stop. "schedule" must NOT yet appear (a later PR adds it).
+// start, help, new, stop, schedule.
 func TestReservedCommandsShape(t *testing.T) {
-	wantOrder := []string{"start", "help", "new", "stop"}
+	wantOrder := []string{"start", "help", "new", "stop", "schedule"}
 	if len(chat.ReservedCommands) != len(wantOrder) {
 		t.Fatalf("ReservedCommands has %d entries, want %d", len(chat.ReservedCommands), len(wantOrder))
 	}
@@ -71,8 +72,8 @@ func TestReservedCommandsShape(t *testing.T) {
 		seen[c.Name] = true
 	}
 
-	if chat.IsReservedCommand("schedule") {
-		t.Error("schedule must not be reserved in this PR")
+	if !chat.IsReservedCommand("schedule") {
+		t.Error("schedule must be reserved (the bot owns /schedule)")
 	}
 }
 

--- a/core/schedule/cron.go
+++ b/core/schedule/cron.go
@@ -1,0 +1,183 @@
+package schedule
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// cronFields is the number of whitespace-separated fields a cron spec must have:
+// minute, hour, day-of-month, month, day-of-week.
+const cronFields = 5
+
+// fieldBounds is the inclusive [min,max] valid range for each of the five cron
+// fields, indexed by position. Day-of-week uses 0-6 with 0=Sunday (7 is NOT
+// accepted as an alias for Sunday — keep the surface minimal and predictable).
+var fieldBounds = [cronFields][2]int{
+	{0, 59}, // minute
+	{0, 23}, // hour
+	{1, 31}, // day-of-month
+	{1, 12}, // month
+	{0, 6},  // day-of-week (0=Sunday)
+}
+
+// fieldNames labels each field for error messages.
+var fieldNames = [cronFields]string{"minute", "hour", "day-of-month", "month", "day-of-week"}
+
+// Schedule is a parsed five-field cron specification. Each field is precomputed
+// into a set of the concrete integer values that satisfy it, so Matches is a few
+// map lookups with no re-parsing.
+//
+// Day-of-month and day-of-week are combined with AND-semantics like every other
+// field (NOT the standard cron OR-when-both-restricted rule): a job whose spec
+// restricts BOTH dom and dow fires only on a day that satisfies both. This is a
+// deliberate simplification for predictability and is documented in the package
+// doc — callers should restrict at most one of the two day fields.
+type Schedule struct {
+	minute     map[int]bool
+	hour       map[int]bool
+	dayOfMonth map[int]bool
+	month      map[int]bool
+	dayOfWeek  map[int]bool
+}
+
+// Parse parses a five-field cron spec (minute hour day-of-month month
+// day-of-week). Each field supports "*", a single value "n", an inclusive range
+// "a-b", a comma list "a,b,c", and a step "*/n", "a-b/n", or "n/step", and any
+// comma-combination of those (e.g. "1,2,4-6,*/10"). A bare value with a step,
+// "n/step", means "n through the field maximum, stepping by step" (e.g. minute
+// "5/15" -> {5,20,35,50}, "0/15" -> {0,15,30,45}), matching Vixie cron. Values
+// are validated against each field's range at parse time, so a malformed or
+// out-of-range spec returns an error and never persists.
+func Parse(spec string) (Schedule, error) {
+	parts := strings.Fields(strings.TrimSpace(spec))
+	if len(parts) != cronFields {
+		return Schedule{}, fmt.Errorf("cron spec must have %d fields, got %d", cronFields, len(parts))
+	}
+	sets := [cronFields]map[int]bool{}
+	for i := 0; i < cronFields; i++ {
+		set, err := parseField(parts[i], fieldBounds[i][0], fieldBounds[i][1])
+		if err != nil {
+			return Schedule{}, fmt.Errorf("%s field %q: %w", fieldNames[i], parts[i], err)
+		}
+		sets[i] = set
+	}
+	return Schedule{
+		minute:     sets[0],
+		hour:       sets[1],
+		dayOfMonth: sets[2],
+		month:      sets[3],
+		dayOfWeek:  sets[4],
+	}, nil
+}
+
+// parseField parses one comma-separated cron field into the set of integer values
+// it matches, validating every value against [min,max]. It supports "*", "n",
+// "a-b", "*/n", "a-b/n", and "n/step" terms.
+func parseField(field string, minVal, maxVal int) (map[int]bool, error) {
+	if field == "" {
+		return nil, errors.New("empty field")
+	}
+	out := map[int]bool{}
+	for _, term := range strings.Split(field, ",") {
+		if term == "" {
+			return nil, errors.New("empty list element")
+		}
+		if err := parseTerm(term, minVal, maxVal, out); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+// parseTerm parses one comma-list element (a "*", value, range, or stepped
+// variant) and adds every value it matches to out. A bare value carrying a step,
+// "n/step", expands to "n through the field maximum, stepping by step" (Vixie
+// cron semantics) rather than to the single value n.
+func parseTerm(term string, minVal, maxVal int, out map[int]bool) error {
+	rangePart := term
+	step := 1
+	hasStep := false
+	if slash := strings.IndexByte(term, '/'); slash >= 0 {
+		rangePart = term[:slash]
+		stepStr := term[slash+1:]
+		n, err := strconv.Atoi(stepStr)
+		if err != nil || n <= 0 {
+			return fmt.Errorf("invalid step %q", stepStr)
+		}
+		step = n
+		hasStep = true
+	}
+
+	lo, hi, single, err := termRange(rangePart, minVal, maxVal)
+	if err != nil {
+		return err
+	}
+	// "n/step" (a bare single value with a step) means "n through the field
+	// maximum", so extend the upper bound to maxVal. "*/n" and "a-b/n" already
+	// span an explicit range and keep their existing bounds.
+	if hasStep && single {
+		hi = maxVal
+	}
+	for v := lo; v <= hi; v += step {
+		out[v] = true
+	}
+	return nil
+}
+
+// termRange resolves the [lo,hi] inclusive bounds a term's range part covers: "*"
+// spans the whole field, "n" is the single value n (single=true), and "a-b" is
+// the explicit range. Every endpoint is validated against [minVal,maxVal] and
+// lo<=hi is enforced.
+func termRange(rangePart string, minVal, maxVal int) (lo, hi int, single bool, err error) {
+	if rangePart == "*" {
+		return minVal, maxVal, false, nil
+	}
+	if dash := strings.IndexByte(rangePart, '-'); dash >= 0 {
+		lo, err = parseBoundedInt(rangePart[:dash], minVal, maxVal)
+		if err != nil {
+			return 0, 0, false, err
+		}
+		hi, err = parseBoundedInt(rangePart[dash+1:], minVal, maxVal)
+		if err != nil {
+			return 0, 0, false, err
+		}
+		if lo > hi {
+			return 0, 0, false, fmt.Errorf("range %q is descending", rangePart)
+		}
+		return lo, hi, false, nil
+	}
+	v, err := parseBoundedInt(rangePart, minVal, maxVal)
+	if err != nil {
+		return 0, 0, false, err
+	}
+	return v, v, true, nil
+}
+
+// parseBoundedInt parses s as an integer and verifies it lies within
+// [minVal,maxVal], returning a clear error otherwise.
+func parseBoundedInt(s string, minVal, maxVal int) (int, error) {
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, fmt.Errorf("not a number: %q", s)
+	}
+	if v < minVal || v > maxVal {
+		return 0, fmt.Errorf("value %d out of range [%d,%d]", v, minVal, maxVal)
+	}
+	return v, nil
+}
+
+// Matches reports whether t satisfies the schedule. All five fields are combined
+// with AND-semantics — including day-of-month and day-of-week (see the Schedule
+// doc) — so the time matches only when every field matches. t is evaluated in its
+// own location (the Manager passes process-local time), at minute granularity.
+func (s Schedule) Matches(t time.Time) bool {
+	weekday := int(t.Weekday()) // time.Sunday == 0, matching the dow convention
+	return s.minute[t.Minute()] &&
+		s.hour[t.Hour()] &&
+		s.dayOfMonth[t.Day()] &&
+		s.month[int(t.Month())] &&
+		s.dayOfWeek[weekday]
+}

--- a/core/schedule/cron_test.go
+++ b/core/schedule/cron_test.go
@@ -1,0 +1,263 @@
+package schedule_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/duckbugio/flock/core/schedule"
+)
+
+// atYear is the fixed year the matcher tests use; the weekday assertions below
+// are pinned to dates in this year.
+const atYear = 2026
+
+// at builds a local time in atYear for the matcher tests. The matcher reads the
+// time's own fields (minute/hour/day/month/weekday), so the location only needs to
+// be consistent; UTC keeps the weekday deterministic across hosts.
+func at(month time.Month, day, hour, minute int) time.Time {
+	return time.Date(atYear, month, day, hour, minute, 0, 0, time.UTC)
+}
+
+// TestParseValid covers the accepted field grammar: "*", a single value, an
+// inclusive range, a comma list, a "*/n" step, an "a-b/n" stepped range, and a
+// combination of those in one field.
+func TestParseValid(t *testing.T) {
+	specs := []string{
+		"* * * * *",
+		"0 0 1 1 0",
+		"59 23 31 12 6",
+		"0-30 * * * *",
+		"0,15,30,45 * * * *",
+		"*/10 * * * *",
+		"0-20/5 * * * *",
+		"1,2,4-6,*/10 * * * *",
+		"5 9 * * 1-5",
+		"5/15 * * * *",  // n/step: minute 5 through max, step 15
+		"0/15 * * * *",  // n/step from 0
+		"59/30 * * * *", // n/step where n is the field max
+	}
+	for _, s := range specs {
+		if _, err := schedule.Parse(s); err != nil {
+			t.Errorf("Parse(%q) unexpected error: %v", s, err)
+		}
+	}
+}
+
+// TestParseInvalid asserts malformed or out-of-range specs are rejected at parse
+// time (so `add` can refuse without persisting).
+func TestParseInvalid(t *testing.T) {
+	specs := []string{
+		"",              // empty
+		"* * * *",       // too few fields
+		"* * * * * *",   // too many fields
+		"60 * * * *",    // minute out of range
+		"* 24 * * *",    // hour out of range
+		"* * 0 * *",     // day-of-month below 1
+		"* * 32 * *",    // day-of-month above 31
+		"* * * 0 *",     // month below 1
+		"* * * 13 *",    // month above 12
+		"* * * * 7",     // day-of-week above 6
+		"5-1 * * * *",   // descending range
+		"*/0 * * * *",   // zero step
+		"*/-1 * * * *",  // negative step
+		"a * * * *",     // non-numeric
+		"1,,2 * * * *",  // empty list element
+		"1- * * * *",    // incomplete range
+		"1-2-3 * * * *", // malformed range
+		"*/x * * * *",   // non-numeric step
+		"5/0 * * * *",   // n/step with zero step
+		"5/-1 * * * *",  // n/step with negative step
+		"60/5 * * * *",  // n/step with out-of-range base
+	}
+	for _, s := range specs {
+		if _, err := schedule.Parse(s); err == nil {
+			t.Errorf("Parse(%q) = nil error, want a rejection", s)
+		}
+	}
+}
+
+// TestMatches covers field semantics and boundary values: wildcards, single
+// values, ranges, lists, and steps each match exactly the expected minutes/hours.
+func TestMatches(t *testing.T) {
+	tests := []struct {
+		name string
+		spec string
+		t    time.Time
+		want bool
+	}{
+		{"every minute matches", "* * * * *", at(6, 18, 12, 34), true},
+		{"exact minute hit", "30 * * * *", at(6, 18, 12, 30), true},
+		{"exact minute miss", "30 * * * *", at(6, 18, 12, 31), false},
+		{"minute boundary 0", "0 * * * *", at(6, 18, 12, 0), true},
+		{"minute boundary 59", "59 * * * *", at(6, 18, 12, 59), true},
+		{"hour match", "* 9 * * *", at(6, 18, 9, 0), true},
+		{"hour miss", "* 9 * * *", at(6, 18, 10, 0), false},
+		{"hour boundary 23", "* 23 * * *", at(6, 18, 23, 0), true},
+		{"range hit lower", "0-30 * * * *", at(6, 18, 12, 0), true},
+		{"range hit upper", "0-30 * * * *", at(6, 18, 12, 30), true},
+		{"range miss above", "0-30 * * * *", at(6, 18, 12, 31), false},
+		{"list hit", "0,15,45 * * * *", at(6, 18, 12, 15), true},
+		{"list miss", "0,15,45 * * * *", at(6, 18, 12, 30), false},
+		{"step hit", "*/10 * * * *", at(6, 18, 12, 20), true},
+		{"step miss", "*/10 * * * *", at(6, 18, 12, 25), false},
+		{"step from base 0", "*/10 * * * *", at(6, 18, 12, 0), true},
+		{"stepped range hit", "0-20/5 * * * *", at(6, 18, 12, 15), true},
+		{"stepped range miss outside", "0-20/5 * * * *", at(6, 18, 12, 25), false},
+		{"combo list+step", "1,2,4-6,*/10 * * * *", at(6, 18, 12, 4), true},
+		{"combo step branch", "1,2,4-6,*/10 * * * *", at(6, 18, 12, 30), true},
+		{"combo miss", "1,2,4-6,*/10 * * * *", at(6, 18, 12, 7), false},
+		{"month match", "* * * 6 *", at(6, 18, 12, 0), true},
+		{"month miss", "* * * 6 *", at(7, 18, 12, 0), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sched, err := schedule.Parse(tt.spec)
+			if err != nil {
+				t.Fatalf("Parse(%q): %v", tt.spec, err)
+			}
+			if got := sched.Matches(tt.t); got != tt.want {
+				t.Fatalf("Parse(%q).Matches(%v) = %v, want %v", tt.spec, tt.t, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestValueStep pins the Vixie-cron "n/step" semantics: a bare value carrying a
+// step expands to "n through the field maximum, stepping by step" — distinct from
+// the single value n. Each case asserts the exact set of matched values for the
+// stepped field (every value in [fieldMin,fieldMax]) across all five fields,
+// including the boundaries 0/15 (from min) and 59/30 (where n is the field max, so
+// the set collapses to {n}).
+func TestValueStep(t *testing.T) {
+	tests := []struct {
+		name     string
+		field    int    // 0=minute 1=hour 2=dom 3=month 4=dow
+		spec     string // full five-field spec with the stepped term in `field`
+		matched  []int  // values the stepped field must match
+		fieldMax int    // upper bound of the field, for the exhaustive complement check
+		fieldMin int    // lower bound of the field
+	}{
+		{"minute 5/15", 0, "5/15 * * * *", []int{5, 20, 35, 50}, 59, 0},
+		{"minute 0/15", 0, "0/15 * * * *", []int{0, 15, 30, 45}, 59, 0},
+		{"minute 59/30 collapses to n", 0, "59/30 * * * *", []int{59}, 59, 0},
+		{"hour 1/6", 1, "* 1/6 * * *", []int{1, 7, 13, 19}, 23, 0},
+		{"hour 0/12", 1, "* 0/12 * * *", []int{0, 12}, 23, 0},
+		{"dom 1/10", 2, "* * 1/10 * *", []int{1, 11, 21, 31}, 31, 1},
+		{"month 1/4", 3, "* * * 1/4 *", []int{1, 5, 9}, 12, 1},
+		{"dow 0/2", 4, "* * * * 0/2", []int{0, 2, 4, 6}, 6, 0},
+		{"dow 1/3", 4, "* * * * 1/3", []int{1, 4}, 6, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sched, err := schedule.Parse(tt.spec)
+			if err != nil {
+				t.Fatalf("Parse(%q): %v", tt.spec, err)
+			}
+			want := map[int]bool{}
+			for _, v := range tt.matched {
+				want[v] = true
+			}
+			// Exhaustively check every value in the field's range: the listed values
+			// match and all others do not. fieldMatches probes the stepped field while
+			// holding the rest at a value the spec accepts.
+			for v := tt.fieldMin; v <= tt.fieldMax; v++ {
+				got := fieldMatches(sched, tt.field, v)
+				if got != want[v] {
+					t.Errorf("field %d value %d: matched=%v, want %v", tt.field, v, got, want[v])
+				}
+			}
+		})
+	}
+}
+
+// fieldMatches reports whether the stepped field index matches value v, holding
+// the other four fields at a fixed valid value (the stepped specs above leave the
+// other fields as "*", so any in-range time satisfies them). 2026 is used so the
+// constructed times are valid; weekday cases pin specific dates.
+func fieldMatches(s schedule.Schedule, field, v int) bool {
+	// Base time: 2026-06-21 is a Sunday (weekday 0), the 21st, in June.
+	month, day, hour, minute := time.June, 21, 9, 0
+	switch field {
+	case 0:
+		minute = v
+	case 1:
+		hour = v
+	case 2:
+		// January has 31 days, so probing dom=1..31 never overflows into the next
+		// month (June, the default, only has 30).
+		month = time.January
+		day = v
+	case 3:
+		month = time.Month(v)
+		day = 1 // day 1 is valid in every month
+	case 4:
+		// Map weekday v to a concrete June 2026 date: 2026-06-21 is a Sunday, so
+		// 21+v lands on weekday v for v in 0..6.
+		day = 21 + v
+	}
+	return s.Matches(time.Date(atYear, month, day, hour, minute, 0, 0, time.UTC))
+}
+
+// TestDayOfWeek pins the 0=Sunday convention and the weekday matching. 2026-06-18
+// is a Thursday (weekday 4); 2026-06-21 is a Sunday (weekday 0).
+func TestDayOfWeek(t *testing.T) {
+	thursday := at(6, 18, 9, 0) // weekday 4
+	sunday := at(6, 21, 9, 0)   // weekday 0
+
+	tests := []struct {
+		spec string
+		t    time.Time
+		want bool
+	}{
+		{"* * * * 4", thursday, true},
+		{"* * * * 4", sunday, false},
+		{"* * * * 0", sunday, true},
+		{"* * * * 0", thursday, false},
+		{"* * * * 1-5", thursday, true}, // weekday range Mon-Fri includes Thu
+		{"* * * * 1-5", sunday, false},  // Sunday excluded
+		{"* * * * 0,6", sunday, true},   // weekend list includes Sunday
+	}
+	for _, tt := range tests {
+		sched, err := schedule.Parse(tt.spec)
+		if err != nil {
+			t.Fatalf("Parse(%q): %v", tt.spec, err)
+		}
+		if got := sched.Matches(tt.t); got != tt.want {
+			t.Errorf("Parse(%q).Matches(%v) = %v, want %v", tt.spec, tt.t, got, tt.want)
+		}
+	}
+}
+
+// TestDayOfMonthAndWeekAndSemantics pins the documented AND-semantics: when BOTH
+// the day-of-month and day-of-week fields are restricted, a time matches only when
+// BOTH match (standard cron would OR them). 2026-06-18 is a Thursday (weekday 4).
+func TestDayOfMonthAndWeekAndSemantics(t *testing.T) {
+	// dom=18 AND dow=4(Thu): 2026-06-18 satisfies both.
+	bothMatch, err := schedule.Parse("0 9 18 * 4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bothMatch.Matches(at(6, 18, 9, 0)) {
+		t.Error("dom=18 dow=Thu should match 2026-06-18 09:00 (both match)")
+	}
+
+	// dom=18 AND dow=1(Mon): 2026-06-18 is the 18th but a Thursday, not Monday.
+	// Standard cron OR-semantics would fire (dom matches); AND-semantics must NOT.
+	domOnly, err := schedule.Parse("0 9 18 * 1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if domOnly.Matches(at(6, 18, 9, 0)) {
+		t.Error("dom=18 dow=Mon must NOT match a Thursday-the-18th under AND-semantics")
+	}
+
+	// dom=19 AND dow=4(Thu): 2026-06-18 is a Thursday but not the 19th. AND must not
+	// fire even though the weekday matches.
+	dowOnly, err := schedule.Parse("0 9 19 * 4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dowOnly.Matches(at(6, 18, 9, 0)) {
+		t.Error("dom=19 dow=Thu must NOT match the 18th under AND-semantics")
+	}
+}

--- a/core/schedule/manager.go
+++ b/core/schedule/manager.go
@@ -2,6 +2,7 @@ package schedule
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sort"
@@ -37,9 +38,11 @@ type Manager struct {
 }
 
 // NewManager builds a Manager. store is the durable job store; fire injects a
-// fired job's prompt into its chat (chat.Service.Inject); now supplies the current
-// time (time.Now in production, a stub in tests); a nil log defaults to
-// slog.Default().
+// fired job's prompt into its chat (chat.Service.Inject). fire MUST NOT block the
+// caller: TickOnce runs on the single scheduler goroutine, so a blocking fire
+// would stall every other chat's jobs — the production wiring runs Inject on its
+// own goroutine (see buildScheduler). now supplies the current time (time.Now in
+// production, a stub in tests); a nil log defaults to slog.Default().
 func NewManager(store *Store, fire func(chatID, prompt string), now func() time.Time, log *slog.Logger) *Manager {
 	if now == nil {
 		now = time.Now
@@ -190,6 +193,9 @@ func (m *Manager) dispatchAdd(chatID string, userID int64, args string, rest []s
 		CreatedAt: m.now().Unix(),
 	})
 	if err != nil {
+		if errors.Is(err, ErrTooManyJobs) {
+			return fmt.Sprintf("This chat already has the maximum of %d scheduled jobs. Remove one before adding another.", MaxJobsPerChat)
+		}
 		m.log.Error("schedule: add job failed", "chat", chatID, "error", err)
 		return "Failed to save the job. Please try again."
 	}

--- a/core/schedule/manager.go
+++ b/core/schedule/manager.go
@@ -1,0 +1,288 @@
+package schedule
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+)
+
+// minuteKeyLayout is the timestamp layout for a job's de-dup minute key. Two
+// times in the same minute (local zone) produce the same key, so a job fires at
+// most once per matching minute even with a sub-minute scheduler tick.
+const minuteKeyLayout = "2006-01-02T15:04"
+
+// tickInterval is the scheduler's polling period. It is sub-minute so the loop
+// never skips a matching minute on small clock drift; the per-job minute-key
+// de-dup guarantees at most one fire per matching minute regardless.
+const tickInterval = 30 * time.Second
+
+// addFields is the number of fixed leading tokens an `add` subcommand carries
+// before the prompt: name + the 5 cron fields.
+const addFields = 6
+
+// Manager runs the background scheduler and serves the transport-neutral
+// `/schedule` subcommands. It owns no transport state: a chat id is a plain
+// string and the fire callback (wired to chat.Service.Inject) is what couples a
+// due job to the dispatch lane.
+type Manager struct {
+	store *Store
+	fire  func(chatID, prompt string)
+	now   func() time.Time
+	log   *slog.Logger
+}
+
+// NewManager builds a Manager. store is the durable job store; fire injects a
+// fired job's prompt into its chat (chat.Service.Inject); now supplies the current
+// time (time.Now in production, a stub in tests); a nil log defaults to
+// slog.Default().
+func NewManager(store *Store, fire func(chatID, prompt string), now func() time.Time, log *slog.Logger) *Manager {
+	if now == nil {
+		now = time.Now
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Manager{store: store, fire: fire, now: now, log: log}
+}
+
+// Run drives the scheduler until ctx is cancelled: every tick it reads the LIVE
+// store (so a job added between ticks fires on its next match — hot reload with no
+// restart) and fires every due active job exactly once per matching minute. It
+// returns ctx.Err() on cancellation.
+func (m *Manager) Run(ctx context.Context) error {
+	m.log.Info("scheduler started", "tick", tickInterval)
+	for {
+		m.TickOnce()
+		select {
+		case <-time.After(tickInterval):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+// TickOnce performs one scheduling pass: for the current minute key, fire every
+// active job whose schedule matches now() and that has not already fired this
+// minute, then record the fire. Run calls it on every tick; it is exported so
+// tests can drive scheduling deterministically with a stepped now func instead of
+// waiting on real time. A spec that no longer parses is logged and skipped (never
+// fired).
+func (m *Manager) TickOnce() {
+	if m.store == nil || m.fire == nil {
+		return
+	}
+	now := m.now()
+	minuteKey := now.Format(minuteKeyLayout)
+	for _, job := range m.store.ActiveJobs() {
+		if job.LastFired == minuteKey {
+			continue
+		}
+		sched, err := Parse(job.Cron)
+		if err != nil {
+			m.log.Warn("scheduler: skipping job with invalid cron", "id", job.ID, "chat", job.ChatID, "cron", job.Cron, "error", err)
+			continue
+		}
+		if !sched.Matches(now) {
+			continue
+		}
+		m.fire(job.ChatID, job.Prompt)
+		if err := m.store.MarkFired(job.ChatID, job.ID, minuteKey); err != nil {
+			m.log.Warn("scheduler: mark fired failed", "id", job.ID, "chat", job.ChatID, "error", err)
+		}
+		m.log.Info("scheduler fired job", "id", job.ID, "chat", job.ChatID, "name", job.Name)
+	}
+}
+
+// usageText is the concise reply for an empty or unknown `/schedule` subcommand.
+const usageText = "Usage:\n" +
+	"/schedule list — list this chat's jobs\n" +
+	"/schedule add <name> <min> <hour> <dom> <mon> <dow> <prompt…> — add a cron job\n" +
+	"/schedule remove <id> — delete a job\n" +
+	"/schedule pause <id> — pause a job\n" +
+	"/schedule resume <id> — resume a paused job\n\n" +
+	"Cron fields: minute(0-59) hour(0-23) day-of-month(1-31) month(1-12) day-of-week(0-6, 0=Sun).\n" +
+	"Each field supports *, n, a-b, a,b lists and */n steps. Times are in the server's local zone.\n" +
+	"Note: when both day-of-month and day-of-week are restricted a job fires only when BOTH match."
+
+// Dispatch is the transport-neutral `/schedule` subcommand handler shared by both
+// adapters: it parses args, mutates the store, and returns the reply text to send.
+// chatID scopes every operation (a job is only ever read or mutated for its own
+// chat — an unknown or foreign id is reported as "not found"). userID is recorded
+// as the creator of an added job. An empty or unknown subcommand returns the usage
+// string.
+func (m *Manager) Dispatch(chatID string, userID int64, args string) string {
+	fields := strings.Fields(args)
+	if len(fields) == 0 {
+		return usageText
+	}
+	sub := strings.ToLower(fields[0])
+	rest := fields[1:]
+	switch sub {
+	case "list":
+		return m.dispatchList(chatID)
+	case "add":
+		return m.dispatchAdd(chatID, userID, args, rest)
+	case "remove":
+		return m.dispatchSetState(chatID, rest, stateRemove)
+	case "pause":
+		return m.dispatchSetState(chatID, rest, statePause)
+	case "resume":
+		return m.dispatchSetState(chatID, rest, stateResume)
+	default:
+		return usageText
+	}
+}
+
+// dispatchList renders this chat's jobs (active and paused), sorted by numeric id
+// for a stable display.
+func (m *Manager) dispatchList(chatID string) string {
+	jobs := m.store.List(chatID)
+	if len(jobs) == 0 {
+		return "No scheduled jobs in this chat."
+	}
+	sort.Slice(jobs, func(i, j int) bool { return idLess(jobs[i].ID, jobs[j].ID) })
+	lines := make([]string, 0, len(jobs)+1)
+	lines = append(lines, "Scheduled jobs:")
+	for _, j := range jobs {
+		state := "active"
+		if !j.Active {
+			state = "paused"
+		}
+		lines = append(lines, fmt.Sprintf("#%s %s — `%s` (%s)", j.ID, j.Name, j.Cron, state))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// dispatchAdd validates and persists a new job. The fixed leading tokens are the
+// name and the five cron fields; everything after them (preserving the original
+// spacing) is the prompt. An invalid cron, an empty name, or an empty prompt is
+// rejected WITHOUT persisting.
+func (m *Manager) dispatchAdd(chatID string, userID int64, args string, rest []string) string {
+	if len(rest) < addFields+1 {
+		return "Usage: /schedule add <name> <min> <hour> <dom> <mon> <dow> <prompt…>"
+	}
+	name := rest[0]
+	if strings.TrimSpace(name) == "" {
+		return "The job name cannot be empty."
+	}
+	cronSpec := strings.Join(rest[1:addFields], " ")
+	if _, err := Parse(cronSpec); err != nil {
+		return fmt.Sprintf("Invalid cron spec: %s", err)
+	}
+	// The prompt is everything after the "add" token, the name, and the 5 cron
+	// fields (1 + addFields tokens); keep its original internal spacing verbatim.
+	prompt := strings.TrimSpace(dropTokens(args, 1+addFields))
+	if prompt == "" {
+		return "The prompt cannot be empty."
+	}
+	id, err := m.store.Add(Job{
+		ChatID:    chatID,
+		Name:      name,
+		Cron:      cronSpec,
+		Prompt:    prompt,
+		CreatedBy: userID,
+		Active:    true,
+		CreatedAt: m.now().Unix(),
+	})
+	if err != nil {
+		m.log.Error("schedule: add job failed", "chat", chatID, "error", err)
+		return "Failed to save the job. Please try again."
+	}
+	return fmt.Sprintf("Added job #%s.", id)
+}
+
+// jobState is the target of a state-changing subcommand (remove/pause/resume).
+type jobState int
+
+const (
+	stateRemove jobState = iota
+	statePause
+	stateResume
+)
+
+// dispatchSetState applies a remove/pause/resume to a single job, scoped to
+// chatID. The job must belong to this chat: a foreign or unknown id is reported as
+// "not found" (never mutating another chat's job).
+func (m *Manager) dispatchSetState(chatID string, rest []string, state jobState) string {
+	if len(rest) < 1 {
+		return "Usage: /schedule " + stateVerb(state) + " <id>"
+	}
+	id := rest[0]
+	if !m.chatOwnsJob(chatID, id) {
+		return fmt.Sprintf("Job #%s not found in this chat.", id)
+	}
+	var err error
+	var ok string
+	switch state {
+	case stateRemove:
+		err = m.store.Remove(chatID, id)
+		ok = fmt.Sprintf("Removed job #%s.", id)
+	case statePause:
+		err = m.store.SetActive(chatID, id, false)
+		ok = fmt.Sprintf("Paused job #%s.", id)
+	case stateResume:
+		err = m.store.SetActive(chatID, id, true)
+		ok = fmt.Sprintf("Resumed job #%s.", id)
+	}
+	if err != nil {
+		m.log.Error("schedule: update job failed", "chat", chatID, "id", id, "error", err)
+		return "Failed to update the job. Please try again."
+	}
+	return ok
+}
+
+// chatOwnsJob reports whether chatID has a job with the given id, so a mutation
+// can be rejected before it touches the store when the id is unknown or foreign.
+func (m *Manager) chatOwnsJob(chatID, id string) bool {
+	for _, j := range m.store.List(chatID) {
+		if j.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+// stateVerb labels a jobState for a usage string.
+func stateVerb(state jobState) string {
+	switch state {
+	case statePause:
+		return "pause"
+	case stateResume:
+		return "resume"
+	default:
+		return "remove"
+	}
+}
+
+// dropTokens returns s with its first n whitespace-delimited tokens (and the
+// whitespace separating them) removed, preserving the remainder verbatim
+// (including any internal spacing of the surviving text). It treats the same
+// Unicode whitespace as strings.Fields so the token boundaries match how rest was
+// split, while keeping the prompt's own internal spacing intact.
+func dropTokens(s string, n int) string {
+	for i := 0; i < n; i++ {
+		s = strings.TrimLeftFunc(s, unicode.IsSpace)
+		j := strings.IndexFunc(s, unicode.IsSpace)
+		if j < 0 {
+			return ""
+		}
+		s = s[j:]
+	}
+	return strings.TrimLeftFunc(s, unicode.IsSpace)
+}
+
+// idLess orders two decimal job ids numerically (falling back to a string compare
+// for any non-numeric id, which Add never produces).
+func idLess(a, b string) bool {
+	ai, aerr := strconv.ParseUint(a, 10, 64)
+	bi, berr := strconv.ParseUint(b, 10, 64)
+	if aerr == nil && berr == nil {
+		return ai < bi
+	}
+	return a < b
+}

--- a/core/schedule/manager.go
+++ b/core/schedule/manager.go
@@ -22,10 +22,6 @@ const minuteKeyLayout = "2006-01-02T15:04"
 // de-dup guarantees at most one fire per matching minute regardless.
 const tickInterval = 30 * time.Second
 
-// addFields is the number of fixed leading tokens an `add` subcommand carries
-// before the prompt: name + the 5 cron fields.
-const addFields = 6
-
 // Manager runs the background scheduler and serves the transport-neutral
 // `/schedule` subcommands. It owns no transport state: a chat id is a plain
 // string and the fire callback (wired to chat.Service.Inject) is what couples a
@@ -69,19 +65,34 @@ func (m *Manager) Run(ctx context.Context) error {
 	}
 }
 
-// TickOnce performs one scheduling pass: for the current minute key, fire every
-// active job whose schedule matches now() and that has not already fired this
-// minute, then record the fire. Run calls it on every tick; it is exported so
-// tests can drive scheduling deterministically with a stepped now func instead of
-// waiting on real time. A spec that no longer parses is logged and skipped (never
-// fired).
+// TickOnce performs one scheduling pass: fire every active job whose schedule
+// matches the current wall-clock minute IN THAT CHAT'S TIMEZONE and that has not
+// already fired this minute, then record the fire. Run calls it on every tick; it
+// is exported so tests can drive scheduling deterministically with a stepped now
+// func instead of waiting on real time. A spec that no longer parses is logged and
+// skipped (never fired).
 func (m *Manager) TickOnce() {
 	if m.store == nil || m.fire == nil {
 		return
 	}
 	now := m.now()
-	minuteKey := now.Format(minuteKeyLayout)
+	locs := map[string]*time.Location{} // resolve each chat's zone once per tick
 	for _, job := range m.store.ActiveJobs() {
+		// Evaluate the job against the wall clock in its chat's timezone (a chat with
+		// no zone set falls back to process-local time). The de-dup minuteKey is in
+		// that same zone, so at-most-once-per-matching-minute holds per chat. A zone
+		// changed mid-fire is best-effort: the stored key was written in the old zone,
+		// so a job may fire once more under the new one — bounded and self-inflicted.
+		loc, ok := locs[job.ChatID]
+		if !ok {
+			loc = m.location(job.ChatID)
+			locs[job.ChatID] = loc
+		}
+		local := now
+		if loc != nil {
+			local = now.In(loc)
+		}
+		minuteKey := local.Format(minuteKeyLayout)
 		if job.LastFired == minuteKey {
 			continue
 		}
@@ -90,7 +101,7 @@ func (m *Manager) TickOnce() {
 			m.log.Warn("scheduler: skipping job with invalid cron", "id", job.ID, "chat", job.ChatID, "cron", job.Cron, "error", err)
 			continue
 		}
-		if !sched.Matches(now) {
+		if !sched.Matches(local) {
 			continue
 		}
 		m.fire(job.ChatID, job.Prompt)
@@ -101,15 +112,35 @@ func (m *Manager) TickOnce() {
 	}
 }
 
+// location resolves the IANA timezone a chat's jobs are evaluated in, or nil when
+// the chat has no zone set (or the stored name fails to load — logged once per
+// tick), in which case the caller uses the time as-is (the process-local default).
+func (m *Manager) location(chatID string) *time.Location {
+	name := m.store.Zone(chatID)
+	if name == "" {
+		return nil
+	}
+	loc, err := time.LoadLocation(name)
+	if err != nil {
+		m.log.Warn("scheduler: bad stored timezone; using process-local", "chat", chatID, "tz", name, "error", err)
+		return nil
+	}
+	return loc
+}
+
 // usageText is the concise reply for an empty or unknown `/schedule` subcommand.
 const usageText = "Usage:\n" +
 	"/schedule list — list this chat's jobs\n" +
+	"/schedule show <id> — show a job's full prompt\n" +
 	"/schedule add <name> <min> <hour> <dom> <mon> <dow> <prompt…> — add a cron job\n" +
 	"/schedule remove <id> — delete a job\n" +
 	"/schedule pause <id> — pause a job\n" +
-	"/schedule resume <id> — resume a paused job\n\n" +
+	"/schedule resume <id> — resume a paused job\n" +
+	"/schedule tz [IANA] — show or set this chat's timezone (e.g. Europe/Moscow)\n\n" +
 	"Cron fields: minute(0-59) hour(0-23) day-of-month(1-31) month(1-12) day-of-week(0-6, 0=Sun).\n" +
-	"Each field supports *, n, a-b, a,b lists and */n steps. Times are in the server's local zone.\n" +
+	"Each field supports *, n, a-b, a,b lists and */n steps.\n" +
+	"Quote a name with spaces: /schedule add \"daily report\" 0 9 * * 1 post the update\n" +
+	"Times use this chat's timezone (/schedule tz), else the server zone (UTC by default).\n" +
 	"Note: when both day-of-month and day-of-week are restricted a job fires only when BOTH match."
 
 // Dispatch is the transport-neutral `/schedule` subcommand handler shared by both
@@ -128,14 +159,18 @@ func (m *Manager) Dispatch(chatID string, userID int64, args string) string {
 	switch sub {
 	case "list":
 		return m.dispatchList(chatID)
+	case "show":
+		return m.dispatchShow(chatID, rest)
 	case "add":
-		return m.dispatchAdd(chatID, userID, args, rest)
+		return m.dispatchAdd(chatID, userID, args)
 	case "remove":
 		return m.dispatchSetState(chatID, rest, stateRemove)
 	case "pause":
 		return m.dispatchSetState(chatID, rest, statePause)
 	case "resume":
 		return m.dispatchSetState(chatID, rest, stateResume)
+	case "tz", "timezone":
+		return m.dispatchTz(chatID, rest)
 	default:
 		return usageText
 	}
@@ -149,38 +184,94 @@ func (m *Manager) dispatchList(chatID string) string {
 		return "No scheduled jobs in this chat."
 	}
 	sort.Slice(jobs, func(i, j int) bool { return idLess(jobs[i].ID, jobs[j].ID) })
-	lines := make([]string, 0, len(jobs)+1)
-	lines = append(lines, "Scheduled jobs:")
-	for _, j := range jobs {
-		state := "active"
-		if !j.Active {
-			state = "paused"
-		}
-		lines = append(lines, fmt.Sprintf("#%s %s — `%s` (%s)", j.ID, j.Name, j.Cron, state))
+	header := "Scheduled jobs:"
+	if z := m.store.Zone(chatID); z != "" {
+		header = fmt.Sprintf("Scheduled jobs (timezone %s):", z)
 	}
+	lines := make([]string, 0, len(jobs)+1)
+	lines = append(lines, header)
+	for _, j := range jobs {
+		preview := truncate(j.Prompt, promptPreviewRunes)
+		lines = append(lines, fmt.Sprintf("#%s %s — `%s` (%s) — %s", j.ID, j.Name, j.Cron, stateLabel(j.Active), preview))
+	}
+	lines = append(lines, "Use /schedule show <id> for a job's full prompt.")
 	return strings.Join(lines, "\n")
 }
 
-// dispatchAdd validates and persists a new job. The fixed leading tokens are the
-// name and the five cron fields; everything after them (preserving the original
-// spacing) is the prompt. An invalid cron, an empty name, or an empty prompt is
-// rejected WITHOUT persisting.
-func (m *Manager) dispatchAdd(chatID string, userID int64, args string, rest []string) string {
-	if len(rest) < addFields+1 {
-		return "Usage: /schedule add <name> <min> <hour> <dom> <mon> <dow> <prompt…>"
+// dispatchShow renders one job's full detail (including the complete prompt),
+// scoped to chatID. A foreign or unknown id is reported as "not found".
+func (m *Manager) dispatchShow(chatID string, rest []string) string {
+	if len(rest) < 1 {
+		return "Usage: /schedule show <id>"
+	}
+	id := rest[0]
+	for _, j := range m.store.List(chatID) {
+		if j.ID != id {
+			continue
+		}
+		zone := m.store.Zone(chatID)
+		if zone == "" {
+			zone = "server default"
+		}
+		return fmt.Sprintf(
+			"Job #%s — %s\nCron: `%s` (%s, timezone %s)\nPrompt:\n%s",
+			j.ID, j.Name, j.Cron, stateLabel(j.Active), zone, j.Prompt,
+		)
+	}
+	return notFound(id)
+}
+
+// dispatchTz shows or sets this chat's IANA timezone. With no argument it reports
+// the current zone; with one it validates the name (time.LoadLocation) and stores
+// it; "none"/"clear" reverts to the server default. The zone governs how every job
+// in this chat is matched against the wall clock.
+func (m *Manager) dispatchTz(chatID string, rest []string) string {
+	if len(rest) == 0 {
+		if z := m.store.Zone(chatID); z != "" {
+			return fmt.Sprintf("This chat's timezone is %s.", z)
+		}
+		return "This chat has no timezone set; schedules use the server zone (UTC by default).\n" +
+			"Set one with /schedule tz <IANA>, e.g. /schedule tz Europe/Moscow."
 	}
 	name := rest[0]
+	if strings.EqualFold(name, "none") || strings.EqualFold(name, "clear") {
+		if err := m.store.SetZone(chatID, ""); err != nil {
+			m.log.Error("schedule: clear timezone failed", "chat", chatID, "error", err)
+			return "Failed to update the timezone. Please try again."
+		}
+		return "Cleared this chat's timezone; schedules now use the server zone."
+	}
+	if _, err := time.LoadLocation(name); err != nil {
+		return fmt.Sprintf("Unknown timezone %q. Use an IANA name like Europe/Moscow or UTC.", name)
+	}
+	if err := m.store.SetZone(chatID, name); err != nil {
+		m.log.Error("schedule: set timezone failed", "chat", chatID, "error", err)
+		return "Failed to update the timezone. Please try again."
+	}
+	return fmt.Sprintf("Timezone set to %s. Existing and new jobs in this chat now use it.", name)
+}
+
+// addUsage is the one-line grammar reminder for a malformed `add`.
+const addUsage = "Usage: /schedule add <name> <min> <hour> <dom> <mon> <dow> <prompt…>\n" +
+	"Quote a name that contains spaces, e.g. /schedule add \"daily report\" 0 9 * * 1 post it."
+
+// dispatchAdd validates and persists a new job. The leading token is the name
+// (optionally a double-quoted multi-word string), the next five tokens are the
+// cron fields, and everything after them — internal spacing preserved — is the
+// prompt. An invalid cron, an empty name, or an empty prompt is rejected WITHOUT
+// persisting.
+func (m *Manager) dispatchAdd(chatID string, userID int64, args string) string {
+	name, cronSpec, prompt, err := parseAddArgs(afterFirstToken(args))
+	if err != nil {
+		return addUsage
+	}
 	if strings.TrimSpace(name) == "" {
 		return "The job name cannot be empty."
 	}
-	cronSpec := strings.Join(rest[1:addFields], " ")
-	if _, err := Parse(cronSpec); err != nil {
-		return fmt.Sprintf("Invalid cron spec: %s", err)
+	if _, perr := Parse(cronSpec); perr != nil {
+		return fmt.Sprintf("Invalid cron spec: %s", perr)
 	}
-	// The prompt is everything after the "add" token, the name, and the 5 cron
-	// fields (1 + addFields tokens); keep its original internal spacing verbatim.
-	prompt := strings.TrimSpace(dropTokens(args, 1+addFields))
-	if prompt == "" {
+	if strings.TrimSpace(prompt) == "" {
 		return "The prompt cannot be empty."
 	}
 	id, err := m.store.Add(Job{
@@ -220,7 +311,7 @@ func (m *Manager) dispatchSetState(chatID string, rest []string, state jobState)
 	}
 	id := rest[0]
 	if !m.chatOwnsJob(chatID, id) {
-		return fmt.Sprintf("Job #%s not found in this chat.", id)
+		return notFound(id)
 	}
 	var err error
 	var ok string
@@ -253,6 +344,19 @@ func (m *Manager) chatOwnsJob(chatID, id string) bool {
 	return false
 }
 
+// stateLabel renders a job's active/paused state for display.
+func stateLabel(active bool) string {
+	if active {
+		return "active"
+	}
+	return "paused"
+}
+
+// notFound is the reply for a job id that is unknown in (or foreign to) the chat.
+func notFound(id string) string {
+	return fmt.Sprintf("Job #%s not found in this chat.", id)
+}
+
 // stateVerb labels a jobState for a usage string.
 func stateVerb(state jobState) string {
 	switch state {
@@ -265,21 +369,89 @@ func stateVerb(state jobState) string {
 	}
 }
 
-// dropTokens returns s with its first n whitespace-delimited tokens (and the
-// whitespace separating them) removed, preserving the remainder verbatim
-// (including any internal spacing of the surviving text). It treats the same
-// Unicode whitespace as strings.Fields so the token boundaries match how rest was
-// split, while keeping the prompt's own internal spacing intact.
-func dropTokens(s string, n int) string {
-	for i := 0; i < n; i++ {
-		s = strings.TrimLeftFunc(s, unicode.IsSpace)
-		j := strings.IndexFunc(s, unicode.IsSpace)
-		if j < 0 {
-			return ""
-		}
-		s = s[j:]
+// promptPreviewRunes bounds the prompt preview shown in `/schedule list`; the full
+// prompt is available via `/schedule show <id>`.
+const promptPreviewRunes = 50
+
+// parseAddArgs parses the body of an `add` subcommand (everything after the "add"
+// token) into the job name, the five-field cron spec, and the prompt. The name is
+// either a single whitespace-delimited token or a double-quoted multi-word string
+// ("daily report"); the next five tokens are the cron fields; the remainder — with
+// its internal spacing preserved — is the prompt. It errors only when the name or
+// the five cron tokens are missing (an empty prompt is left for the caller to
+// reject with a clearer message).
+func parseAddArgs(body string) (name, cronSpec, prompt string, err error) {
+	name, rest, err := takeName(body)
+	if err != nil {
+		return "", "", "", err
 	}
-	return strings.TrimLeftFunc(s, unicode.IsSpace)
+	fields := make([]string, 0, cronFields)
+	for i := 0; i < cronFields; i++ {
+		var tok string
+		tok, rest = takeToken(rest)
+		if tok == "" {
+			return "", "", "", errors.New("missing cron fields")
+		}
+		fields = append(fields, tok)
+	}
+	cronSpec = strings.Join(fields, " ")
+	prompt = strings.TrimLeftFunc(rest, unicode.IsSpace)
+	return name, cronSpec, prompt, nil
+}
+
+// afterFirstToken returns s with its leading whitespace-delimited token (the
+// subcommand verb) removed, preserving the remainder.
+func afterFirstToken(s string) string {
+	_, rest := takeToken(s)
+	return rest
+}
+
+// takeToken splits off the first whitespace-delimited token of s (after trimming
+// leading whitespace) and returns it plus the remainder, which begins at the
+// whitespace before the next token (or "" when none remains).
+func takeToken(s string) (token, rest string) {
+	s = strings.TrimLeftFunc(s, unicode.IsSpace)
+	if s == "" {
+		return "", ""
+	}
+	if i := strings.IndexFunc(s, unicode.IsSpace); i >= 0 {
+		return s[:i], s[i:]
+	}
+	return s, ""
+}
+
+// takeName splits off the job name — a double-quoted "multi word" string or a
+// single whitespace-delimited token — and returns it plus the remainder. An empty
+// or unterminated-quote name is an error.
+func takeName(s string) (name, rest string, err error) {
+	s = strings.TrimLeftFunc(s, unicode.IsSpace)
+	if s == "" {
+		return "", "", errors.New("empty name")
+	}
+	if s[0] == '"' {
+		end := strings.IndexByte(s[1:], '"')
+		if end < 0 {
+			return "", "", errors.New("unterminated quoted name")
+		}
+		name = s[1 : 1+end]
+		if strings.TrimSpace(name) == "" {
+			return "", "", errors.New("empty name")
+		}
+		return name, s[1+end+1:], nil
+	}
+	name, rest = takeToken(s)
+	return name, rest, nil
+}
+
+// truncate collapses newlines and clips s to at most n runes (appending an
+// ellipsis when clipped), for a one-line job preview.
+func truncate(s string, n int) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n-1]) + "…"
 }
 
 // idLess orders two decimal job ids numerically (falling back to a string compare

--- a/core/schedule/manager_test.go
+++ b/core/schedule/manager_test.go
@@ -1,0 +1,306 @@
+package schedule_test
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/duckbugio/flock/core/schedule"
+)
+
+// recordingFire records every (chatID, prompt) the scheduler fires, race-safe so
+// it can be read while Run is ticking on another goroutine.
+type recordingFire struct {
+	mu    sync.Mutex
+	calls []fireCall
+}
+
+type fireCall struct{ chatID, prompt string }
+
+func (r *recordingFire) fire(chatID, prompt string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, fireCall{chatID, prompt})
+}
+
+func (r *recordingFire) seen() []fireCall {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]fireCall(nil), r.calls...)
+}
+
+// newManager builds a Manager over a fresh temp store with a stubbed clock and a
+// recording fire callback. The returned now pointer lets a test step time
+// deterministically (the Manager reads *now through the closure).
+func newManager(t *testing.T) (*schedule.Manager, *schedule.Store, *recordingFire, *time.Time) {
+	t.Helper()
+	store, err := schedule.Open(filepath.Join(t.TempDir(), "schedules.json"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	rec := &recordingFire{}
+	clock := time.Date(2026, 6, 18, 9, 0, 0, 0, time.UTC)
+	nowPtr := &clock
+	mgr := schedule.NewManager(store, rec.fire, func() time.Time { return *nowPtr }, nil)
+	return mgr, store, rec, nowPtr
+}
+
+// newDispatchManager builds a Manager + store for the Dispatch tests, which never
+// step the clock or fire jobs (a no-op fire, the real wall clock).
+func newDispatchManager(t *testing.T) (*schedule.Manager, *schedule.Store) {
+	t.Helper()
+	store, err := schedule.Open(filepath.Join(t.TempDir(), "schedules.json"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	return schedule.NewManager(store, func(string, string) {}, nil, nil), store
+}
+
+// --- Dispatch tests ---
+
+func TestDispatchUsage(t *testing.T) {
+	mgr, _ := newDispatchManager(t)
+	for _, args := range []string{"", "   ", "bogus", "wat now"} {
+		if got := mgr.Dispatch("100", 7, args); !strings.HasPrefix(got, "Usage:") {
+			t.Errorf("Dispatch(%q) = %q, want a usage string", args, got)
+		}
+	}
+}
+
+func TestDispatchAddValid(t *testing.T) {
+	mgr, store := newDispatchManager(t)
+	reply := mgr.Dispatch("100", 42, "add standup 0 9 * * 1 run the morning report")
+	if !strings.Contains(reply, "Added job #") {
+		t.Fatalf("add reply = %q, want 'Added job #...'", reply)
+	}
+	jobs := store.List("100")
+	if len(jobs) != 1 {
+		t.Fatalf("store has %d jobs, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.Name != "standup" || j.Cron != "0 9 * * 1" || j.Prompt != "run the morning report" {
+		t.Errorf("persisted job = %+v, want name=standup cron='0 9 * * 1' prompt='run the morning report'", j)
+	}
+	if j.CreatedBy != 42 || !j.Active {
+		t.Errorf("persisted job CreatedBy=%d Active=%v, want 42/true", j.CreatedBy, j.Active)
+	}
+}
+
+func TestDispatchAddInvalidCron(t *testing.T) {
+	mgr, store := newDispatchManager(t)
+	reply := mgr.Dispatch("100", 1, "add bad 99 9 * * 1 do it")
+	if !strings.Contains(strings.ToLower(reply), "invalid cron") {
+		t.Errorf("invalid-cron reply = %q, want an 'Invalid cron' rejection", reply)
+	}
+	if got := len(store.List("100")); got != 0 {
+		t.Errorf("invalid cron persisted %d jobs, want 0", got)
+	}
+}
+
+func TestDispatchAddEmptyPrompt(t *testing.T) {
+	mgr, store := newDispatchManager(t)
+	// Name + 5 cron fields but no prompt.
+	reply := mgr.Dispatch("100", 1, "add noprompt 0 9 * * 1")
+	if !strings.Contains(strings.ToLower(reply), "usage") && !strings.Contains(strings.ToLower(reply), "prompt") {
+		t.Errorf("empty-prompt reply = %q, want a prompt/usage rejection", reply)
+	}
+	if got := len(store.List("100")); got != 0 {
+		t.Errorf("empty prompt persisted %d jobs, want 0", got)
+	}
+}
+
+func TestDispatchListEmptyAndPopulated(t *testing.T) {
+	mgr, _ := newDispatchManager(t)
+	if got := mgr.Dispatch("100", 1, "list"); !strings.Contains(got, "No scheduled jobs") {
+		t.Errorf("empty list = %q, want a 'No scheduled jobs' notice", got)
+	}
+	mgr.Dispatch("100", 1, "add a 0 9 * * 1 prompt a")
+	mgr.Dispatch("100", 1, "add b 0 10 * * 1 prompt b")
+	got := mgr.Dispatch("100", 1, "list")
+	if !strings.Contains(got, "#1") || !strings.Contains(got, "#2") {
+		t.Errorf("populated list = %q, want both #1 and #2", got)
+	}
+	if !strings.Contains(got, "active") {
+		t.Errorf("populated list = %q, want the active state shown", got)
+	}
+}
+
+func TestDispatchRemovePauseResume(t *testing.T) {
+	mgr, store := newDispatchManager(t)
+	mgr.Dispatch("100", 1, "add a 0 9 * * 1 prompt a") // job #1
+
+	if got := mgr.Dispatch("100", 1, "pause 1"); !strings.Contains(got, "Paused job #1") {
+		t.Errorf("pause = %q, want 'Paused job #1'", got)
+	}
+	if jobs := store.List("100"); len(jobs) != 1 || jobs[0].Active {
+		t.Errorf("after pause job Active=%v, want false", jobs[0].Active)
+	}
+	if got := mgr.Dispatch("100", 1, "resume 1"); !strings.Contains(got, "Resumed job #1") {
+		t.Errorf("resume = %q, want 'Resumed job #1'", got)
+	}
+	if jobs := store.List("100"); !jobs[0].Active {
+		t.Errorf("after resume job Active=false, want true")
+	}
+	if got := mgr.Dispatch("100", 1, "remove 1"); !strings.Contains(got, "Removed job #1") {
+		t.Errorf("remove = %q, want 'Removed job #1'", got)
+	}
+	if got := store.List("100"); got != nil {
+		t.Errorf("after remove List = %+v, want nil", got)
+	}
+}
+
+func TestDispatchUnknownIDNotFound(t *testing.T) {
+	mgr, _ := newDispatchManager(t)
+	for _, sub := range []string{"remove 99", "pause 99", "resume 99"} {
+		if got := mgr.Dispatch("100", 1, sub); !strings.Contains(strings.ToLower(got), "not found") {
+			t.Errorf("Dispatch(%q) = %q, want a 'not found'", sub, got)
+		}
+	}
+}
+
+// TestDispatchForeignChatScoping asserts a chat can never mutate another chat's
+// job: an id that belongs to chat 200 is "not found" for chat 100, and the job
+// stays untouched.
+func TestDispatchForeignChatScoping(t *testing.T) {
+	mgr, store := newDispatchManager(t)
+	mgr.Dispatch("200", 1, "add a 0 9 * * 1 prompt a") // job #1 belongs to chat 200
+
+	if got := mgr.Dispatch("100", 1, "remove 1"); !strings.Contains(strings.ToLower(got), "not found") {
+		t.Errorf("foreign remove = %q, want 'not found'", got)
+	}
+	if got := mgr.Dispatch("100", 1, "pause 1"); !strings.Contains(strings.ToLower(got), "not found") {
+		t.Errorf("foreign pause = %q, want 'not found'", got)
+	}
+	// Chat 200's job is intact and still active.
+	if jobs := store.List("200"); len(jobs) != 1 || !jobs[0].Active {
+		t.Errorf("chat 200 job was disturbed: %+v", store.List("200"))
+	}
+}
+
+// TestDispatchAddPreservesPromptSpacing asserts the prompt keeps its internal
+// spacing rather than being re-joined with single spaces.
+func TestDispatchAddPreservesPromptSpacing(t *testing.T) {
+	mgr, store := newDispatchManager(t)
+	mgr.Dispatch("100", 1, "add a 0 9 * * 1 do  the   thing")
+	jobs := store.List("100")
+	if len(jobs) != 1 || jobs[0].Prompt != "do  the   thing" {
+		t.Errorf("prompt = %q, want 'do  the   thing' (internal spacing preserved)", jobs[0].Prompt)
+	}
+}
+
+// --- Scheduler firing (deterministic, no real time) ---
+
+// TestSchedulerFiresOncePerMatchingMinute drives tickOnce across several
+// sub-minute ticks within the same matching minute and asserts the job fires
+// exactly once (minute-key de-dup), then again on the next matching minute.
+func TestSchedulerFiresOncePerMatchingMinute(t *testing.T) {
+	mgr, store, rec, now := newManager(t)
+	// A job that matches at minute 0 of every hour.
+	if _, err := store.Add(schedule.Job{ChatID: "100", Name: "j", Cron: "0 * * * *", Prompt: "go", Active: true}); err != nil {
+		t.Fatal(err)
+	}
+
+	*now = time.Date(2026, 6, 18, 9, 0, 0, 0, time.UTC)
+	mgr.TickOnce()
+	*now = time.Date(2026, 6, 18, 9, 0, 30, 0, time.UTC) // same minute, sub-minute tick
+	mgr.TickOnce()
+	if got := rec.seen(); len(got) != 1 {
+		t.Fatalf("fired %d times in one matching minute, want exactly 1 (de-dup): %+v", len(got), got)
+	}
+	if rec.seen()[0] != (fireCall{"100", "go"}) {
+		t.Errorf("fired %+v, want {100, go}", rec.seen()[0])
+	}
+
+	// Advance to the next matching minute (10:00): it fires again.
+	*now = time.Date(2026, 6, 18, 10, 0, 0, 0, time.UTC)
+	mgr.TickOnce()
+	if got := rec.seen(); len(got) != 2 {
+		t.Fatalf("fired %d times across two matching minutes, want 2", len(got))
+	}
+}
+
+// TestSchedulerSkipsNonMatchingMinute asserts a tick during a minute the job does
+// not match fires nothing.
+func TestSchedulerSkipsNonMatchingMinute(t *testing.T) {
+	mgr, store, rec, now := newManager(t)
+	if _, err := store.Add(schedule.Job{ChatID: "100", Name: "j", Cron: "0 * * * *", Prompt: "go", Active: true}); err != nil {
+		t.Fatal(err)
+	}
+	*now = time.Date(2026, 6, 18, 9, 1, 0, 0, time.UTC) // minute 1, job wants minute 0
+	mgr.TickOnce()
+	if got := rec.seen(); len(got) != 0 {
+		t.Fatalf("fired %d times on a non-matching minute, want 0", len(got))
+	}
+}
+
+// TestSchedulerPausedNeverFires asserts a paused job is never fired even when its
+// schedule matches the current minute.
+func TestSchedulerPausedNeverFires(t *testing.T) {
+	mgr, store, rec, now := newManager(t)
+	if _, err := store.Add(schedule.Job{ChatID: "100", Name: "j", Cron: "* * * * *", Prompt: "go", Active: false}); err != nil {
+		t.Fatal(err)
+	}
+	*now = time.Date(2026, 6, 18, 9, 0, 0, 0, time.UTC)
+	mgr.TickOnce()
+	if got := rec.seen(); len(got) != 0 {
+		t.Fatalf("paused job fired %d times, want 0", len(got))
+	}
+}
+
+// TestSchedulerHotReload asserts a job added between ticks (the LIVE store is read
+// each tick) fires on its next matching minute with no restart.
+func TestSchedulerHotReload(t *testing.T) {
+	mgr, store, rec, now := newManager(t)
+	*now = time.Date(2026, 6, 18, 9, 0, 0, 0, time.UTC)
+	mgr.TickOnce() // nothing scheduled yet
+	if got := rec.seen(); len(got) != 0 {
+		t.Fatalf("fired %d before any job added, want 0", len(got))
+	}
+
+	// Add a job that matches the NEXT minute.
+	if _, err := store.Add(schedule.Job{ChatID: "100", Name: "j", Cron: "1 * * * *", Prompt: "go", Active: true}); err != nil {
+		t.Fatal(err)
+	}
+	*now = time.Date(2026, 6, 18, 9, 1, 0, 0, time.UTC)
+	mgr.TickOnce()
+	if got := rec.seen(); len(got) != 1 {
+		t.Fatalf("hot-reloaded job fired %d times, want 1", len(got))
+	}
+}
+
+// TestSchedulerInvalidCronSkipped asserts a stored job whose cron no longer parses
+// is skipped (logged, never fired) rather than panicking the tick.
+func TestSchedulerInvalidCronSkipped(t *testing.T) {
+	mgr, store, rec, now := newManager(t)
+	// Inject an unparseable cron directly (Dispatch would reject it, but a corrupt
+	// store or a future format change could carry one).
+	if _, err := store.Add(schedule.Job{ChatID: "100", Name: "j", Cron: "bogus", Prompt: "go", Active: true}); err != nil {
+		t.Fatal(err)
+	}
+	*now = time.Date(2026, 6, 18, 9, 0, 0, 0, time.UTC)
+	mgr.TickOnce()
+	if got := rec.seen(); len(got) != 0 {
+		t.Fatalf("invalid-cron job fired %d times, want 0", len(got))
+	}
+}
+
+// TestRunStopsOnContextCancel asserts Run exits when its context is cancelled
+// (the background loop is cancelable for clean shutdown).
+func TestRunStopsOnContextCancel(t *testing.T) {
+	mgr, _ := newDispatchManager(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- mgr.Run(ctx) }()
+	cancel()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Error("Run returned nil after cancel, want ctx.Err()")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return within 2s of cancel")
+	}
+}

--- a/core/schedule/manager_test.go
+++ b/core/schedule/manager_test.go
@@ -209,6 +209,113 @@ func TestDispatchAddRejectsPastCap(t *testing.T) {
 	}
 }
 
+// TestDispatchAddQuotedName asserts a double-quoted multi-word name is accepted
+// (and the cron/prompt after it still parse), while a bare single-word name keeps
+// working.
+func TestDispatchAddQuotedName(t *testing.T) {
+	mgr, store := newDispatchManager(t)
+	reply := mgr.Dispatch("100", 1, `add "daily report" 0 9 * * 1 post the summary`)
+	if !strings.Contains(reply, "Added job #") {
+		t.Fatalf("quoted-name add reply = %q, want 'Added job #...'", reply)
+	}
+	jobs := store.List("100")
+	if len(jobs) != 1 {
+		t.Fatalf("store has %d jobs, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.Name != "daily report" || j.Cron != "0 9 * * 1" || j.Prompt != "post the summary" {
+		t.Errorf("job = %+v, want name='daily report' cron='0 9 * * 1' prompt='post the summary'", j)
+	}
+}
+
+// TestDispatchShow asserts `show` returns the full prompt for an own job and
+// "not found" for an unknown/foreign id.
+func TestDispatchShow(t *testing.T) {
+	mgr, _ := newDispatchManager(t)
+	mgr.Dispatch("100", 1, "add a 0 9 * * 1 do the whole long thing in detail")
+
+	got := mgr.Dispatch("100", 1, "show 1")
+	if !strings.Contains(got, "do the whole long thing in detail") || !strings.Contains(got, "#1") {
+		t.Errorf("show = %q, want the full prompt and id", got)
+	}
+	if got := mgr.Dispatch("100", 1, "show 99"); !strings.Contains(strings.ToLower(got), "not found") {
+		t.Errorf("show unknown = %q, want 'not found'", got)
+	}
+	// A foreign chat cannot see the job.
+	if got := mgr.Dispatch("200", 1, "show 1"); !strings.Contains(strings.ToLower(got), "not found") {
+		t.Errorf("foreign show = %q, want 'not found'", got)
+	}
+}
+
+// TestDispatchListShowsPromptPreview asserts `list` includes a (truncated) prompt
+// preview so a user can tell jobs apart without `show`.
+func TestDispatchListShowsPromptPreview(t *testing.T) {
+	mgr, _ := newDispatchManager(t)
+	mgr.Dispatch("100", 1, "add a 0 9 * * 1 water the plants")
+	got := mgr.Dispatch("100", 1, "list")
+	if !strings.Contains(got, "water the plants") {
+		t.Errorf("list = %q, want the prompt preview", got)
+	}
+}
+
+// tzMoscow is a stable IANA zone (UTC+3, no DST since 2014) used by the timezone
+// tests.
+const tzMoscow = "Europe/Moscow"
+
+// TestDispatchTzShowSetClear drives the tz subcommand: show-when-unset, set with
+// validation, reject an unknown zone, and clear.
+func TestDispatchTzShowSetClear(t *testing.T) {
+	mgr, store := newDispatchManager(t)
+
+	if got := mgr.Dispatch("100", 1, "tz"); !strings.Contains(strings.ToLower(got), "no timezone") {
+		t.Errorf("tz show unset = %q, want a 'no timezone' notice", got)
+	}
+	if got := mgr.Dispatch("100", 1, "tz "+tzMoscow); !strings.Contains(got, tzMoscow) {
+		t.Errorf("tz set = %q, want confirmation of %s", got, tzMoscow)
+	}
+	if store.Zone("100") != tzMoscow {
+		t.Errorf("stored zone = %q, want %s", store.Zone("100"), tzMoscow)
+	}
+	if got := mgr.Dispatch("100", 1, "tz Not/AZone"); !strings.Contains(strings.ToLower(got), "unknown timezone") {
+		t.Errorf("tz invalid = %q, want an 'unknown timezone' rejection", got)
+	}
+	if store.Zone("100") != tzMoscow {
+		t.Errorf("invalid zone overwrote the stored one: %q", store.Zone("100"))
+	}
+	if got := mgr.Dispatch("100", 1, "tz none"); !strings.Contains(strings.ToLower(got), "cleared") {
+		t.Errorf("tz clear = %q, want a 'cleared' notice", got)
+	}
+	if store.Zone("100") != "" {
+		t.Errorf("zone not cleared: %q", store.Zone("100"))
+	}
+}
+
+// TestSchedulerHonorsChatTimezone asserts a job is matched against the wall clock
+// in its chat's timezone: with Europe/Moscow (UTC+3) set, a "0 9 * * *" job fires
+// at 06:00 UTC (09:00 Moscow) and not at 09:00 UTC.
+func TestSchedulerHonorsChatTimezone(t *testing.T) {
+	mgr, store, rec, now := newManager(t)
+	if err := store.SetZone("100", tzMoscow); err != nil {
+		t.Fatalf("SetZone: %v", err)
+	}
+	if _, err := store.Add(schedule.Job{ChatID: "100", Name: "j", Cron: "0 9 * * *", Prompt: "go", Active: true}); err != nil {
+		t.Fatal(err)
+	}
+
+	// 09:00 UTC is 12:00 in Moscow — must NOT fire.
+	*now = time.Date(2026, 6, 18, 9, 0, 0, 0, time.UTC)
+	mgr.TickOnce()
+	if got := rec.seen(); len(got) != 0 {
+		t.Fatalf("fired %d at 09:00 UTC (12:00 MSK), want 0", len(got))
+	}
+	// 06:00 UTC is 09:00 in Moscow — must fire.
+	*now = time.Date(2026, 6, 18, 6, 0, 0, 0, time.UTC)
+	mgr.TickOnce()
+	if got := rec.seen(); len(got) != 1 {
+		t.Fatalf("fired %d at 06:00 UTC (09:00 MSK), want 1", len(got))
+	}
+}
+
 // --- Scheduler firing (deterministic, no real time) ---
 
 // TestSchedulerFiresOncePerMatchingMinute drives tickOnce across several

--- a/core/schedule/manager_test.go
+++ b/core/schedule/manager_test.go
@@ -191,6 +191,24 @@ func TestDispatchAddPreservesPromptSpacing(t *testing.T) {
 	}
 }
 
+// TestDispatchAddRejectsPastCap asserts that once a chat holds MaxJobsPerChat
+// jobs, `add` is refused with a clear message and nothing extra is persisted.
+func TestDispatchAddRejectsPastCap(t *testing.T) {
+	mgr, store := newDispatchManager(t)
+	for i := 0; i < schedule.MaxJobsPerChat; i++ {
+		if reply := mgr.Dispatch("100", 1, "add j 0 9 * * 1 do it"); !strings.Contains(reply, "Added job #") {
+			t.Fatalf("add within cap reply = %q, want 'Added job #...'", reply)
+		}
+	}
+	reply := mgr.Dispatch("100", 1, "add over 0 9 * * 1 do it")
+	if !strings.Contains(strings.ToLower(reply), "maximum") {
+		t.Errorf("past-cap reply = %q, want a 'maximum' rejection", reply)
+	}
+	if got := len(store.List("100")); got != schedule.MaxJobsPerChat {
+		t.Errorf("chat has %d jobs after the rejected add, want the cap %d", got, schedule.MaxJobsPerChat)
+	}
+}
+
 // --- Scheduler firing (deterministic, no real time) ---
 
 // TestSchedulerFiresOncePerMatchingMinute drives tickOnce across several

--- a/core/schedule/store.go
+++ b/core/schedule/store.go
@@ -15,9 +15,9 @@
 // persisted id on load, so a new Add after a restart never collides with a
 // persisted job.
 //
-// Timezone: cron specs are evaluated in PROCESS-LOCAL time (the Manager passes
-// time.Now, which is local; the container defaults to UTC). A job's minute is
-// matched in whatever local zone the process runs in.
+// Timezone: each chat may set an IANA timezone (see SetZone / the /schedule tz
+// command) in which ITS jobs are evaluated. A chat with no zone set falls back to
+// the process-local zone (the container defaults to UTC).
 //
 // Day-of-month / day-of-week use AND-semantics (see cron.go): a job that
 // restricts BOTH day fields fires only when both match. Restrict at most one.
@@ -72,15 +72,23 @@ type Job struct {
 	LastFired string `json:"lastFired"`
 }
 
-// Store persists a per-chat slice of cron jobs durably and is safe for concurrent
-// use. The whole map is held in memory and the backing file is rewritten
-// atomically on every mutation.
+// Store persists a per-chat slice of cron jobs (and each chat's optional IANA
+// timezone) durably and is safe for concurrent use. The whole state is held in
+// memory and the backing file is rewritten atomically on every mutation.
 type Store struct {
 	path string
 
 	mu     sync.Mutex
 	jobs   map[string][]Job
-	nextID uint64 // monotonic ID counter, mutated only under mu
+	zones  map[string]string // chatID -> IANA timezone name (absent = process-local)
+	nextID uint64            // monotonic ID counter, mutated only under mu
+}
+
+// persisted is the on-disk JSON shape: the per-chat jobs plus each chat's optional
+// timezone, so a restart restores both.
+type persisted struct {
+	Jobs  map[string][]Job  `json:"jobs"`
+	Zones map[string]string `json:"zones,omitempty"`
 }
 
 // Open loads (or creates) a Store at path. A missing file yields an empty store;
@@ -94,7 +102,7 @@ func Open(path string) (*Store, error) {
 	if err := os.MkdirAll(filepath.Dir(path), dirPerm); err != nil {
 		return nil, fmt.Errorf("schedule: create store dir: %w", err)
 	}
-	s := &Store{path: path, jobs: map[string][]Job{}, nextID: 1}
+	s := &Store{path: path, jobs: map[string][]Job{}, zones: map[string]string{}, nextID: 1}
 	if err := s.load(); err != nil {
 		return nil, err
 	}
@@ -115,18 +123,21 @@ func (s *Store) load() error {
 	if len(data) == 0 {
 		return nil
 	}
-	raw := map[string][]Job{}
+	var raw persisted
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return fmt.Errorf("schedule: parse store %s: %w", s.path, err)
 	}
 	var maxID uint64
-	for k, v := range raw {
+	for k, v := range raw.Jobs {
 		s.jobs[k] = v
 		for _, j := range v {
 			if n, perr := strconv.ParseUint(j.ID, 10, 64); perr == nil && n > maxID {
 				maxID = n
 			}
 		}
+	}
+	for k, v := range raw.Zones {
+		s.zones[k] = v
 	}
 	s.nextID = maxID + 1
 	return nil
@@ -254,6 +265,36 @@ func (s *Store) ActiveJobs() []Job {
 	return out
 }
 
+// SetZone records the IANA timezone name (e.g. "Europe/Moscow") that chatID's
+// jobs are evaluated in and persists the change. An empty name clears the chat's
+// zone, reverting it to the process-local default. The caller is responsible for
+// validating the name (the Manager does, via time.LoadLocation). A nil store is a
+// no-op.
+func (s *Store) SetZone(chatID, iana string) error {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if iana == "" {
+		delete(s.zones, chatID)
+	} else {
+		s.zones[chatID] = iana
+	}
+	return s.persistLocked()
+}
+
+// Zone returns the IANA timezone name set for chatID, or "" when the chat has no
+// zone set (jobs then use the process-local zone). A nil store yields "".
+func (s *Store) Zone(chatID string) string {
+	if s == nil {
+		return ""
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.zones[chatID]
+}
+
 // indexOf returns the index of the job with id in jobs, or -1.
 func indexOf(jobs []Job, id string) int {
 	for i := range jobs {
@@ -268,7 +309,7 @@ func indexOf(jobs []Job, id string) int {
 // renames it over the target, so a crash mid-write never leaves a half-written or
 // corrupt store. The caller must hold s.mu.
 func (s *Store) persistLocked() error {
-	data, err := json.Marshal(s.jobs)
+	data, err := json.Marshal(persisted{Jobs: s.jobs, Zones: s.zones})
 	if err != nil {
 		return fmt.Errorf("schedule: encode store: %w", err)
 	}

--- a/core/schedule/store.go
+++ b/core/schedule/store.go
@@ -39,6 +39,18 @@ import (
 // core/pending).
 const dirPerm os.FileMode = 0o750
 
+// MaxJobsPerChat caps how many scheduled jobs a single chat may hold. Each active
+// job is an UNATTENDED, recurring run (its prompt can drive commits/PRs) that
+// fires outside the live per-message rate/cost guards, so an unbounded count is a
+// cost/autonomy amplifier. The cap bounds that blast radius while staying well
+// above any realistic per-chat schedule.
+const MaxJobsPerChat = 25
+
+// ErrTooManyJobs is returned by Add when a chat is already at MaxJobsPerChat, so
+// the caller can surface a clear "remove one first" message instead of a generic
+// failure.
+var ErrTooManyJobs = errors.New("schedule: chat has reached the maximum number of jobs")
+
 // Job is one scheduled cron job. ID is a process-unique decimal string assigned
 // at Add. ChatID is the transport's opaque string chat id the job (and its fired
 // prompt) belongs to. Name is a human label; Cron is the five-field spec; Prompt
@@ -122,14 +134,19 @@ func (s *Store) load() error {
 
 // Add assigns a fresh process-unique ID to job, appends it to its chat's slice,
 // persists the change atomically, and returns the assigned ID. job is passed in
-// WITHOUT an ID; its ChatID must already be set. A nil store is a no-op that
-// returns "" so callers stay nil-safe when the store failed to open.
+// WITHOUT an ID; its ChatID must already be set. It returns ErrTooManyJobs
+// (without persisting) when the chat already holds MaxJobsPerChat jobs. A nil
+// store is a no-op that returns "" so callers stay nil-safe when the store failed
+// to open.
 func (s *Store) Add(job Job) (string, error) {
 	if s == nil {
 		return "", nil
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if len(s.jobs[job.ChatID]) >= MaxJobsPerChat {
+		return "", ErrTooManyJobs
+	}
 	id := strconv.FormatUint(s.nextID, 10)
 	s.nextID++
 	job.ID = id

--- a/core/schedule/store.go
+++ b/core/schedule/store.go
@@ -1,0 +1,262 @@
+// Package schedule persists a durable per-chat set of cron JOBS and runs a
+// background scheduler that fires each due job into the same dispatch lane a
+// normal message uses (via a fire callback wired to chat.Service.Inject). It is
+// transport-neutral: a chat id is the transport's opaque string id and a user id
+// is a plain int64, so the package imports neither adapter nor core/chat (which
+// would create an import cycle).
+//
+// A Job records a process-unique id, the chat it belongs to, a human name, the
+// five-field cron spec, the prompt to inject, who created it, whether it is
+// active, when it was created, and the last minute key it fired (for de-dup). The
+// store mirrors core/pending.FileStore: a single JSON file keyed by chat id whose
+// value is that chat's ordered slice of jobs, loaded once on Open and rewritten
+// atomically (temp file + rename) on every mutation under a mutex, so concurrent
+// chats are race-safe. IDs come from a monotonic counter seeded above the max
+// persisted id on load, so a new Add after a restart never collides with a
+// persisted job.
+//
+// Timezone: cron specs are evaluated in PROCESS-LOCAL time (the Manager passes
+// time.Now, which is local; the container defaults to UTC). A job's minute is
+// matched in whatever local zone the process runs in.
+//
+// Day-of-month / day-of-week use AND-semantics (see cron.go): a job that
+// restricts BOTH day fields fires only when both match. Restrict at most one.
+package schedule
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+
+	"github.com/duckbugio/flock/internal/atomicfile"
+)
+
+// dirPerm is the owner-only permission for bot-created directories (mirrors
+// core/pending).
+const dirPerm os.FileMode = 0o750
+
+// Job is one scheduled cron job. ID is a process-unique decimal string assigned
+// at Add. ChatID is the transport's opaque string chat id the job (and its fired
+// prompt) belongs to. Name is a human label; Cron is the five-field spec; Prompt
+// is injected into the chat when the job fires. CreatedBy is the user id that
+// created it (a sentinel for accountability). Active toggles whether the
+// scheduler considers it (paused jobs are kept but skipped). CreatedAt is the
+// Unix-second creation time. LastFired is the minute key ("2006-01-02T15:04")
+// already fired, so a sub-minute scheduler tick fires a matching minute at most
+// once.
+type Job struct {
+	ID        string `json:"id"`
+	ChatID    string `json:"chatId"`
+	Name      string `json:"name"`
+	Cron      string `json:"cron"`
+	Prompt    string `json:"prompt"`
+	CreatedBy int64  `json:"createdBy"`
+	Active    bool   `json:"active"`
+	CreatedAt int64  `json:"createdAt"`
+	LastFired string `json:"lastFired"`
+}
+
+// Store persists a per-chat slice of cron jobs durably and is safe for concurrent
+// use. The whole map is held in memory and the backing file is rewritten
+// atomically on every mutation.
+type Store struct {
+	path string
+
+	mu     sync.Mutex
+	jobs   map[string][]Job
+	nextID uint64 // monotonic ID counter, mutated only under mu
+}
+
+// Open loads (or creates) a Store at path. A missing file yields an empty store;
+// a present file is parsed as the persisted per-chat job map. The parent
+// directory is created if needed. Reopening the SAME path returns whatever was
+// last persisted, which is how jobs survive a process restart.
+func Open(path string) (*Store, error) {
+	if path == "" {
+		return nil, errors.New("schedule: store path is empty")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), dirPerm); err != nil {
+		return nil, fmt.Errorf("schedule: create store dir: %w", err)
+	}
+	s := &Store{path: path, jobs: map[string][]Job{}, nextID: 1}
+	if err := s.load(); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// load reads and decodes the backing file. A non-existent or empty file is not an
+// error (a fresh store). The ID counter is seeded to max(parsed numeric id) + 1 so
+// a new Add after a restart never collides with a persisted job's id.
+func (s *Store) load() error {
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("schedule: read store: %w", err)
+	}
+	if len(data) == 0 {
+		return nil
+	}
+	raw := map[string][]Job{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return fmt.Errorf("schedule: parse store %s: %w", s.path, err)
+	}
+	var maxID uint64
+	for k, v := range raw {
+		s.jobs[k] = v
+		for _, j := range v {
+			if n, perr := strconv.ParseUint(j.ID, 10, 64); perr == nil && n > maxID {
+				maxID = n
+			}
+		}
+	}
+	s.nextID = maxID + 1
+	return nil
+}
+
+// Add assigns a fresh process-unique ID to job, appends it to its chat's slice,
+// persists the change atomically, and returns the assigned ID. job is passed in
+// WITHOUT an ID; its ChatID must already be set. A nil store is a no-op that
+// returns "" so callers stay nil-safe when the store failed to open.
+func (s *Store) Add(job Job) (string, error) {
+	if s == nil {
+		return "", nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	id := strconv.FormatUint(s.nextID, 10)
+	s.nextID++
+	job.ID = id
+	s.jobs[job.ChatID] = append(s.jobs[job.ChatID], job)
+	if err := s.persistLocked(); err != nil {
+		return "", err
+	}
+	return id, nil
+}
+
+// Remove hard-deletes the job with id from chatID's slice and rewrites the file;
+// if the slice becomes empty the chat key is dropped. Removing an absent chat/id
+// is a no-op (no needless rewrite). A nil store is a no-op.
+func (s *Store) Remove(chatID, id string) error {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	jobs, ok := s.jobs[chatID]
+	if !ok {
+		return nil
+	}
+	idx := indexOf(jobs, id)
+	if idx < 0 {
+		return nil
+	}
+	jobs = append(jobs[:idx], jobs[idx+1:]...)
+	if len(jobs) == 0 {
+		delete(s.jobs, chatID)
+	} else {
+		s.jobs[chatID] = jobs
+	}
+	return s.persistLocked()
+}
+
+// SetActive sets the Active flag of the job with id in chatID's slice and
+// persists the change. A missing chat/id is a no-op. A nil store is a no-op.
+func (s *Store) SetActive(chatID, id string, active bool) error {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	jobs := s.jobs[chatID]
+	idx := indexOf(jobs, id)
+	if idx < 0 {
+		return nil
+	}
+	jobs[idx].Active = active
+	return s.persistLocked()
+}
+
+// MarkFired records minuteKey as the last-fired minute of the job with id in
+// chatID's slice and persists the change, so the scheduler's de-dup skips it for
+// the rest of that minute. A missing chat/id is a no-op. A nil store is a no-op.
+func (s *Store) MarkFired(chatID, id, minuteKey string) error {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	jobs := s.jobs[chatID]
+	idx := indexOf(jobs, id)
+	if idx < 0 {
+		return nil
+	}
+	jobs[idx].LastFired = minuteKey
+	return s.persistLocked()
+}
+
+// List returns a copy of chatID's jobs in stable order (active and paused alike),
+// so a caller can render the chat's schedule without racing a concurrent mutation.
+// A nil store yields nil.
+func (s *Store) List(chatID string) []Job {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	jobs := s.jobs[chatID]
+	if len(jobs) == 0 {
+		return nil
+	}
+	return append([]Job(nil), jobs...)
+}
+
+// ActiveJobs returns a copy of every chat's ACTIVE jobs (paused jobs excluded),
+// which is what the scheduler reads each tick to decide what is due. A nil store
+// yields nil.
+func (s *Store) ActiveJobs() []Job {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []Job
+	for _, jobs := range s.jobs {
+		for _, j := range jobs {
+			if j.Active {
+				out = append(out, j)
+			}
+		}
+	}
+	return out
+}
+
+// indexOf returns the index of the job with id in jobs, or -1.
+func indexOf(jobs []Job, id string) int {
+	for i := range jobs {
+		if jobs[i].ID == id {
+			return i
+		}
+	}
+	return -1
+}
+
+// persistLocked writes the current map to a temp file in the same directory and
+// renames it over the target, so a crash mid-write never leaves a half-written or
+// corrupt store. The caller must hold s.mu.
+func (s *Store) persistLocked() error {
+	data, err := json.Marshal(s.jobs)
+	if err != nil {
+		return fmt.Errorf("schedule: encode store: %w", err)
+	}
+	if err := atomicfile.Write(s.path, data, ".schedule-*.tmp"); err != nil {
+		return fmt.Errorf("schedule: %w", err)
+	}
+	return nil
+}

--- a/core/schedule/store_test.go
+++ b/core/schedule/store_test.go
@@ -1,6 +1,7 @@
 package schedule_test
 
 import (
+	"errors"
 	"path/filepath"
 	"testing"
 
@@ -143,6 +144,29 @@ func TestStoreMarkFiredDeDup(t *testing.T) {
 	jobs := s.ActiveJobs()
 	if len(jobs) != 1 || jobs[0].LastFired != key {
 		t.Fatalf("ActiveJobs after MarkFired = %+v, want LastFired=%q", jobs, key)
+	}
+}
+
+// TestStoreAddCapPerChat asserts Add enforces MaxJobsPerChat: filling a chat to
+// the cap succeeds, the next Add is rejected with ErrTooManyJobs and not
+// persisted, and a DIFFERENT chat is unaffected (the cap is per-chat).
+func TestStoreAddCapPerChat(t *testing.T) {
+	s, _ := newStore(t)
+	for i := 0; i < schedule.MaxJobsPerChat; i++ {
+		if _, err := s.Add(schedule.Job{ChatID: "100", Name: "j", Cron: "* * * * *", Prompt: "p", Active: true}); err != nil {
+			t.Fatalf("Add #%d within cap: %v", i, err)
+		}
+	}
+	_, err := s.Add(schedule.Job{ChatID: "100", Name: "over", Cron: "* * * * *", Prompt: "p", Active: true})
+	if !errors.Is(err, schedule.ErrTooManyJobs) {
+		t.Fatalf("Add past cap err = %v, want ErrTooManyJobs", err)
+	}
+	if got := len(s.List("100")); got != schedule.MaxJobsPerChat {
+		t.Errorf("chat 100 has %d jobs, want the cap %d (rejected add not persisted)", got, schedule.MaxJobsPerChat)
+	}
+	// The cap is per-chat: a different chat can still add.
+	if _, err := s.Add(schedule.Job{ChatID: "200", Name: "ok", Cron: "* * * * *", Prompt: "p", Active: true}); err != nil {
+		t.Errorf("Add to a different chat err = %v, want nil (cap is per-chat)", err)
 	}
 }
 

--- a/core/schedule/store_test.go
+++ b/core/schedule/store_test.go
@@ -1,0 +1,171 @@
+package schedule_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/duckbugio/flock/core/schedule"
+)
+
+// newStore opens a fresh store in a temp dir.
+func newStore(t *testing.T) (*schedule.Store, string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "schedules.json")
+	s, err := schedule.Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	return s, path
+}
+
+// addJob is a small helper to add an active job and return its id.
+func addJob(t *testing.T, s *schedule.Store, chatID, name, cron, prompt string) string {
+	t.Helper()
+	id, err := s.Add(schedule.Job{ChatID: chatID, Name: name, Cron: cron, Prompt: prompt, Active: true})
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	return id
+}
+
+// TestStoreRoundTrip asserts a job persists across an Open→Add→reopen→List cycle
+// with all fields intact.
+func TestStoreRoundTrip(t *testing.T) {
+	s, path := newStore(t)
+	id := addJob(t, s, "100", "morning", "0 9 * * *", "stand up")
+
+	// Reopen the same path: the persisted job must come back.
+	s2, err := schedule.Open(path)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	jobs := s2.List("100")
+	if len(jobs) != 1 {
+		t.Fatalf("after reopen List(100) = %d jobs, want 1", len(jobs))
+	}
+	got := jobs[0]
+	if got.ID != id || got.Name != "morning" || got.Cron != "0 9 * * *" || got.Prompt != "stand up" || !got.Active {
+		t.Errorf("round-tripped job = %+v, want id=%s morning/cron/prompt active", got, id)
+	}
+}
+
+// TestStoreIDsMonotonicAcrossReopen asserts a new Add after a reopen never reuses
+// a persisted id (the counter is seeded above the max persisted id on load).
+func TestStoreIDsMonotonicAcrossReopen(t *testing.T) {
+	s, path := newStore(t)
+	id1 := addJob(t, s, "1", "a", "* * * * *", "p1")
+
+	s2, err := schedule.Open(path)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	id2 := addJob(t, s2, "1", "b", "* * * * *", "p2")
+	if id1 == id2 {
+		t.Fatalf("id reused after reopen: %s == %s", id1, id2)
+	}
+}
+
+// TestStorePerChatIsolation asserts List only returns the queried chat's jobs.
+func TestStorePerChatIsolation(t *testing.T) {
+	s, _ := newStore(t)
+	addJob(t, s, "100", "a", "* * * * *", "for 100")
+	addJob(t, s, "200", "b", "* * * * *", "for 200")
+
+	if got := s.List("100"); len(got) != 1 || got[0].ChatID != "100" {
+		t.Errorf("List(100) = %+v, want one job for chat 100", got)
+	}
+	if got := s.List("200"); len(got) != 1 || got[0].ChatID != "200" {
+		t.Errorf("List(200) = %+v, want one job for chat 200", got)
+	}
+	if got := s.List("999"); got != nil {
+		t.Errorf("List(999) = %+v, want nil for an unknown chat", got)
+	}
+}
+
+// TestStorePauseResume asserts SetActive toggles Active and ActiveJobs reflects it.
+func TestStorePauseResume(t *testing.T) {
+	s, _ := newStore(t)
+	id := addJob(t, s, "100", "a", "* * * * *", "p")
+
+	if got := len(s.ActiveJobs()); got != 1 {
+		t.Fatalf("ActiveJobs = %d before pause, want 1", got)
+	}
+	if err := s.SetActive("100", id, false); err != nil {
+		t.Fatalf("SetActive(false): %v", err)
+	}
+	if got := s.ActiveJobs(); len(got) != 0 {
+		t.Errorf("ActiveJobs = %d after pause, want 0", len(got))
+	}
+	// List still shows the paused job.
+	if got := s.List("100"); len(got) != 1 || got[0].Active {
+		t.Errorf("List after pause = %+v, want one paused job", got)
+	}
+	if err := s.SetActive("100", id, true); err != nil {
+		t.Fatalf("SetActive(true): %v", err)
+	}
+	if got := len(s.ActiveJobs()); got != 1 {
+		t.Errorf("ActiveJobs = %d after resume, want 1", got)
+	}
+}
+
+// TestStoreRemove asserts Remove hard-deletes the job and drops an emptied chat
+// key, and that removing an absent id is a harmless no-op.
+func TestStoreRemove(t *testing.T) {
+	s, _ := newStore(t)
+	id := addJob(t, s, "100", "a", "* * * * *", "p")
+
+	// Removing an absent id is a no-op.
+	if err := s.Remove("100", "999"); err != nil {
+		t.Fatalf("Remove(absent): %v", err)
+	}
+	if got := len(s.List("100")); got != 1 {
+		t.Fatalf("List after no-op remove = %d, want 1", got)
+	}
+
+	if err := s.Remove("100", id); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if got := s.List("100"); got != nil {
+		t.Errorf("List after remove = %+v, want nil (chat key dropped)", got)
+	}
+}
+
+// TestStoreMarkFiredDeDup asserts MarkFired records the minute key so a re-check
+// for the same minute is suppressed (the scheduler reads LastFired to de-dup).
+func TestStoreMarkFiredDeDup(t *testing.T) {
+	s, _ := newStore(t)
+	id := addJob(t, s, "100", "a", "* * * * *", "p")
+
+	const key = "2026-06-18T09:00"
+	if err := s.MarkFired("100", id, key); err != nil {
+		t.Fatalf("MarkFired: %v", err)
+	}
+	jobs := s.ActiveJobs()
+	if len(jobs) != 1 || jobs[0].LastFired != key {
+		t.Fatalf("ActiveJobs after MarkFired = %+v, want LastFired=%q", jobs, key)
+	}
+}
+
+// TestStoreNilSafe asserts a nil store's mutators are no-ops and its readers
+// return empty, matching the core/pending nil-safety contract.
+func TestStoreNilSafe(t *testing.T) {
+	var s *schedule.Store
+	if id, err := s.Add(schedule.Job{ChatID: "1"}); id != "" || err != nil {
+		t.Errorf("nil Add = (%q,%v), want ('',nil)", id, err)
+	}
+	if err := s.Remove("1", "1"); err != nil {
+		t.Errorf("nil Remove err = %v", err)
+	}
+	if err := s.SetActive("1", "1", true); err != nil {
+		t.Errorf("nil SetActive err = %v", err)
+	}
+	if err := s.MarkFired("1", "1", "k"); err != nil {
+		t.Errorf("nil MarkFired err = %v", err)
+	}
+	if got := s.List("1"); got != nil {
+		t.Errorf("nil List = %+v, want nil", got)
+	}
+	if got := s.ActiveJobs(); got != nil {
+		t.Errorf("nil ActiveJobs = %+v, want nil", got)
+	}
+}

--- a/core/schedule/store_test.go
+++ b/core/schedule/store_test.go
@@ -170,6 +170,58 @@ func TestStoreAddCapPerChat(t *testing.T) {
 	}
 }
 
+// TestStoreZoneRoundTrip asserts a chat's timezone is persisted across a reopen,
+// is per-chat, and that an empty SetZone clears it.
+func TestStoreZoneRoundTrip(t *testing.T) {
+	s, path := newStore(t)
+	if err := s.SetZone("100", tzMoscow); err != nil {
+		t.Fatalf("SetZone: %v", err)
+	}
+	if got := s.Zone("100"); got != tzMoscow {
+		t.Errorf("Zone(100) = %q, want Europe/Moscow", got)
+	}
+	if got := s.Zone("200"); got != "" {
+		t.Errorf("Zone(200) = %q, want empty (per-chat)", got)
+	}
+
+	// Persisted across reopen.
+	s2, err := schedule.Open(path)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	if got := s2.Zone("100"); got != tzMoscow {
+		t.Errorf("after reopen Zone(100) = %q, want Europe/Moscow", got)
+	}
+
+	// Clearing reverts to empty.
+	if err := s2.SetZone("100", ""); err != nil {
+		t.Fatalf("clear SetZone: %v", err)
+	}
+	if got := s2.Zone("100"); got != "" {
+		t.Errorf("after clear Zone(100) = %q, want empty", got)
+	}
+}
+
+// TestStoreZoneSurvivesAlongsideJobs asserts jobs and zones round-trip together
+// (the persisted format carries both).
+func TestStoreZoneSurvivesAlongsideJobs(t *testing.T) {
+	s, path := newStore(t)
+	addJob(t, s, "100", "a", "0 9 * * 1", "p")
+	if err := s.SetZone("100", "UTC"); err != nil {
+		t.Fatalf("SetZone: %v", err)
+	}
+	s2, err := schedule.Open(path)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	if got := len(s2.List("100")); got != 1 {
+		t.Errorf("after reopen jobs = %d, want 1", got)
+	}
+	if got := s2.Zone("100"); got != "UTC" {
+		t.Errorf("after reopen zone = %q, want UTC", got)
+	}
+}
+
 // TestStoreNilSafe asserts a nil store's mutators are no-ops and its readers
 // return empty, matching the core/pending nil-safety contract.
 func TestStoreNilSafe(t *testing.T) {
@@ -185,6 +237,12 @@ func TestStoreNilSafe(t *testing.T) {
 	}
 	if err := s.MarkFired("1", "1", "k"); err != nil {
 		t.Errorf("nil MarkFired err = %v", err)
+	}
+	if err := s.SetZone("1", "UTC"); err != nil {
+		t.Errorf("nil SetZone err = %v", err)
+	}
+	if got := s.Zone("1"); got != "" {
+		t.Errorf("nil Zone = %q, want empty", got)
 	}
 	if got := s.List("1"); got != nil {
 		t.Errorf("nil List = %+v, want nil", got)

--- a/core/schedule/tzdata_test.go
+++ b/core/schedule/tzdata_test.go
@@ -1,0 +1,7 @@
+package schedule_test
+
+// Embed the IANA timezone database in the test binary so the per-chat timezone
+// tests resolve names like Europe/Moscow via time.LoadLocation regardless of
+// whether the host (or CI container) ships OS zoneinfo. Production binaries embed
+// it via their own blank import in package main.
+import _ "time/tzdata"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,6 +98,20 @@ type Config struct {
 	// lives under the workspace data dir, never inside a repo.
 	SessionStorePath string `env:"SESSION_STORE_PATH"`
 
+	// EnableScheduler gates the /schedule command and its background cron
+	// scheduler. OFF by default: with the flag off no schedule store is opened, no
+	// scheduler goroutine runs, and /schedule replies with a "disabled" notice, so
+	// behavior is byte-identical to a deployment without the feature. Set
+	// ENABLE_SCHEDULER=true to enable durable per-chat cron jobs (see SchedulerEnabled).
+	EnableScheduler bool `env:"ENABLE_SCHEDULER" envDefault:"false"`
+
+	// ScheduleStorePath is the JSON file persisting chatID -> the chat's cron jobs,
+	// reloaded on startup so scheduled jobs survive a restart. When empty it
+	// defaults to <APPROVED_DIRECTORY>/schedules.json (see ScheduleStoreFile), which
+	// lives under the workspace data dir alongside the session/pending stores, never
+	// inside a repo.
+	ScheduleStorePath string `env:"SCHEDULE_STORE_PATH"`
+
 	// Guardrails (Stage 9b). A per-user fixed-window RATE LIMIT and a per-user
 	// cumulative COST CAP enforced on the inbound message path. The defaults
 	// mirror adapters/telegram/.env.example.
@@ -312,6 +326,24 @@ func (c Config) PendingStoreFile() string {
 		return c.PendingStorePath
 	}
 	return filepath.Join(c.ApprovedDirectory, "pending.json")
+}
+
+// ScheduleStoreFile returns the path to the JSON cron-job store, defaulting to
+// <ApprovedDirectory>/schedules.json when SCHEDULE_STORE_PATH is unset so it lives
+// under the workspace data dir alongside the session/pending stores, never inside
+// any repo.
+func (c Config) ScheduleStoreFile() string {
+	if strings.TrimSpace(c.ScheduleStorePath) != "" {
+		return c.ScheduleStorePath
+	}
+	return filepath.Join(c.ApprovedDirectory, "schedules.json")
+}
+
+// SchedulerEnabled reports whether the /schedule command and its background cron
+// scheduler are active (ENABLE_SCHEDULER=true). When false the feature is a true
+// no-op: no store, no goroutine, and /schedule replies with a disabled notice.
+func (c Config) SchedulerEnabled() bool {
+	return c.EnableScheduler
 }
 
 // RateLimitWindow returns the per-user rate-limit window as a Duration, or 0

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -99,10 +99,12 @@ type Config struct {
 	SessionStorePath string `env:"SESSION_STORE_PATH"`
 
 	// EnableScheduler gates the /schedule command and its background cron
-	// scheduler. OFF by default: with the flag off no schedule store is opened, no
-	// scheduler goroutine runs, and /schedule replies with a "disabled" notice, so
-	// behavior is byte-identical to a deployment without the feature. Set
-	// ENABLE_SCHEDULER=true to enable durable per-chat cron jobs (see SchedulerEnabled).
+	// scheduler. OFF by default: with the flag off no schedule store is opened and
+	// no scheduler goroutine runs (the background side is a true no-op). /schedule
+	// itself stays a reserved, bot-owned command — it remains in the command menu
+	// and replies with a "disabled" notice rather than being forwarded to the model.
+	// Set ENABLE_SCHEDULER=true to enable durable per-chat cron jobs (see
+	// SchedulerEnabled).
 	EnableScheduler bool `env:"ENABLE_SCHEDULER" envDefault:"false"`
 
 	// ScheduleStorePath is the JSON file persisting chatID -> the chat's cron jobs,
@@ -340,8 +342,9 @@ func (c Config) ScheduleStoreFile() string {
 }
 
 // SchedulerEnabled reports whether the /schedule command and its background cron
-// scheduler are active (ENABLE_SCHEDULER=true). When false the feature is a true
-// no-op: no store, no goroutine, and /schedule replies with a disabled notice.
+// scheduler are active (ENABLE_SCHEDULER=true). When false the background side is
+// a no-op (no store, no goroutine); /schedule stays bot-owned and replies with a
+// disabled notice instead of running.
 func (c Config) SchedulerEnabled() bool {
 	return c.EnableScheduler
 }


### PR DESCRIPTION
## Summary

Part B of the three-part feature. Adds a user-facing `/schedule` command so you can schedule recurring prompts from chat; a background scheduler fires each job into the same per-chat dispatch lane a normal message uses. **Gated behind `ENABLE_SCHEDULER` (default off)** — flag off ⇒ no store, no goroutine, byte-identical behavior.

**Stacked on PR #41** (`duck/-5164159101/native-commands`) — base is that branch, not `main`. Merge PR #41 first.

### What changed
- **`core/schedule` (new, transport-neutral):**
  - **Store** — durable per-chat job store (JSON + `internal/atomicfile`, mutex, monotonic id), cloned from `core/pending`. At `<APPROVED_DIRECTORY>/schedules.json` (sibling of repos, never committed). Survives restart.
  - **Cron matcher** — hand-rolled 5-field (`*`, `n`, `a-b`, `a,b`, `*/n`, `a-b/n`, and `n/step` with Vixie "n through max" semantics). Malformed specs rejected at parse. **AND-semantics** across all fields incl. day-of-month/day-of-week (documented). No new dependency.
  - **Manager** — sub-minute scheduler loop with **per-minute de-dup** (persisted `LastFired` key) so a job fires at most once per matching minute and isn't missed on drift; reads the **live store** each tick → **hot-reload** (a job added via `/schedule add` fires next match, no restart). Plus a transport-neutral subcommand dispatcher.
- **`/schedule` is bot-owned** (reserved on both adapters) so it never leaks to Claude; disabled ⇒ short notice. Subcommands `list` / `add <name> <min> <hour> <dom> <mon> <dow> <prompt…>` / `remove <id>` / `pause <id>` / `resume <id>` — all **scoped to the calling chat** and allow-list gated.
- **Both mains** (`flock-telegram`, `duck-vk`) start the scheduler behind the flag; firing uses `svc.Inject` (sentinel user 0) on the serialized lane.
- **config**: `ENABLE_SCHEDULER`, `SCHEDULE_STORE_PATH` (+ `ScheduleStoreFile`/`SchedulerEnabled`); both `.env.example` updated.

## Acceptance criteria
- [x] **AC-B1** — `/schedule` reserved on both adapters; disabled ⇒ notice, never reaches Claude; enabled ⇒ all subcommands; allow-list gated; unknown/empty subcommand ⇒ usage.
- [x] **AC-B2** — durable JSON store, survives restart (round-trip + monotonic-id-across-reopen tests).
- [x] **AC-B3** — scheduler matches 5-field cron and fires via `svc.Inject`, at most once per matching minute.
- [x] **AC-B4** — hot-reload (live-store read each tick; `TestSchedulerHotReload`).
- [x] **AC-B5** — wired into both mains behind the flag; flag-off path is a true no-op.

## How it was verified
- `gofmt` clean, `go build`/`go vet` clean, `golangci-lint` 0 issues, **`go test -race ./...` green** twice (incl. PR #41's tests + full regression). New tests: cron table (valid/invalid/`n/step` exhaustive per-field), store round-trip + per-chat isolation + de-dup, Manager.Dispatch subcommands incl. foreign-chat scoping, scheduler firing/de-dup/hot-reload (injected clock, recording fire), adapter disabled/enabled.

## Pre-PR review (internal)
coder → reviewer (APPROVE, risk medium) → coder → focused reviewer (CLEAN). Round 1 caught a cron `n/step` semantic gap (`5/15` silently yielded `{5}` instead of `{5,20,35,50}`) — fixed to Vixie semantics with exhaustive tests — plus two stale comments. Final: clean.

### Residual risks — needs a human eyeball
- **Autonomy:** a scheduled job injects a prompt that can drive commits/PRs unattended. Mitigated by default-off flag + allow-list + per-chat isolation + serialized lane, but **the operator must opt in per deployment and trust the scheduled prompts**.
- **Timezone** is process-local (UTC in the default container) — schedule cron specs accordingly.
- Not exercised live here: a real wall-clock firing in a deployed bot (tests use an injected clock). Flip `ENABLE_SCHEDULER=true` and verify one job fires before relying on it.
- `MarkFired` rewrites the store file per fired job per minute — fine at per-chat scale; revisit if job counts grow large.

## Stack
Part B of three. **Merge bottom-up:** PR #41 (native commands) → **this** → PR for anti-silence (Part C). Once PR #41 merges, GitHub retargets this PR to `main`.
