### PR TITLE
fix(telegram): wrap Send error with call-site context

### DIFF
--- a/adapters/telegram/bot.go
+++ b/adapters/telegram/bot.go
@@ -10,6 +10,7 @@ package telegram
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"strconv"
@@ -127,7 +128,7 @@ func (c *botChat) Send(ctx context.Context, chatID chat.ChatID, text, stopRunID 
 		msg, err = c.b.SendMessage(ctx, params)
 	}
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("send telegram message: %w", err)
 	}
 	return strconv.Itoa(msg.ID), nil
 }


### PR DESCRIPTION
## Summary

`botChat.Send` returned Telegram's `SendMessage` error verbatim (`return "", err`), losing the call-site context in logs. This wraps it with `fmt.Errorf("send telegram message: %w", err)` so the underlying error is preserved for `errors.Is`/`errors.As` while logs point at the send path.

This supersedes #44 and #45, which proposed the same idea but:
- did **not compile** — they called `fmt.Errorf` without importing `fmt`;
- violated the repo's own linters (`revive: error-strings` / staticcheck ST1005) — the error string was capitalized mid-message and ended with a period;
- baked a misleading hint ("Check your Telegram bot token.") into **every** send failure, when send errors are overwhelmingly rate-limits (429, already classified), blocked-by-user, chat-not-found or message-too-long — not token problems.

## Changes
- `adapters/telegram/bot.go`: import `fmt`; wrap the `Send` failure with `%w`.

## Acceptance
- **AC1** — the `Send` error carries call-site context and preserves the wrapped error (`%w`). ✅
- **AC2** — lint-clean under the repo's `.golangci.yml` (no ST1005/error-strings violation). ✅
- **AC3** — no behavioural change to the happy path or the rich→plain fallback. ✅

## How it was verified
Run through the repo's CI runner (`task` → dockerized dev-tools):
- `task vet` — clean
- `task lint` — `0 issues`
- `task build` — ok
- `task tests` — all packages green, incl. `adapters/telegram`

## Pre-PR review
One clean pass (trivial change). Caught-and-fixed vs the superseded PRs: missing `fmt` import (compile break), lint violation, misleading token hint.

**Residual risks / needs a human eyeball:** none material. The change is a pure error-wrap; it does not alter control flow or the user-visible message text sent to chats. The wrapped string surfaces only in server-side logs.