### PR TITLE
docs: add community-health files (contributing, conduct, security, templates)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,39 @@
+---
+name: Bug report
+about: Report something that isn't working as expected
+title: "[bug] "
+labels: bug
+---
+
+<!--
+Thanks for reporting a bug! Please fill in the sections below.
+SECURITY: do NOT use this template for vulnerabilities — see SECURITY.md.
+-->
+
+## What happened
+
+A clear description of the bug.
+
+## Expected behavior
+
+What you expected to happen instead.
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Environment
+
+- Component: <!-- telegram adapter / vk adapter / core/... / deployment -->
+- Image tag or commit:
+- Host OS / Docker version:
+
+## Logs / screenshots
+
+<!-- Paste relevant logs (redact tokens and secrets) or attach screenshots. -->
+
+## Additional context
+
+<!-- Anything else that might help. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/duckbugio/flock/blob/main/SECURITY.md
+    about: Do not open a public issue for vulnerabilities — please follow the security policy.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea or improvement for Flock
+title: "[feat] "
+labels: enhancement
+---
+
+## Problem
+
+What are you trying to do, and what's missing or painful today?
+
+## Proposed solution
+
+What you'd like to see happen.
+
+## Alternatives considered
+
+Other approaches you thought about, and why you ruled them out.
+
+## Additional context
+
+<!-- Mockups, links, related issues, affected adapters/services, etc. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,38 @@
+<!--
+Thanks for contributing to Flock! Please fill in the sections below and delete
+this comment. For security fixes, coordinate privately first (see SECURITY.md).
+-->
+
+## Summary
+
+<!-- What does this PR change, and why? -->
+
+## Related issue
+
+<!-- e.g. Closes #123 -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / internal change
+- [ ] Documentation
+- [ ] Build / CI / dependencies
+
+## How it was verified
+
+<!-- Commands you ran and what you observed. -->
+
+```bash
+task lint
+task tests
+task build
+```
+
+## Checklist
+
+- [ ] `task lint`, `task tests`, and `task build` pass locally
+- [ ] Tests added/updated for the change (a bug fix adds a failing-then-passing test)
+- [ ] Docs updated if behavior or configuration changed (README / `docs/` / `.env.example`)
+- [ ] The change is focused — no unrelated churn
+- [ ] Commits follow Conventional Commits (`feat(scope): ...`, `fix(scope): ...`)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**conduct@duckbug.io**. All complaints will be reviewed and investigated
+promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,70 @@
+# Contributing to Flock
+
+Thanks for your interest in contributing to Flock — the open-source bot at the
+heart of [DuckBug](https://github.com/duckbugio). This guide covers how to set up,
+make a change, and open a pull request.
+
+By participating, you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Ways to contribute
+
+- **Report a bug** — open an issue with the *Bug report* template.
+- **Request a feature** — open an issue with the *Feature request* template.
+- **Send a fix or feature** — fork, branch, and open a pull request (below).
+- **Improve the docs** — README, the translated READMEs, or files under `docs/`.
+
+For anything non-trivial, please open an issue first so we can agree on the
+approach before you invest time in a PR.
+
+> **Security issues are different:** do **not** open a public issue or PR for a
+> vulnerability. Follow [SECURITY.md](SECURITY.md) instead.
+
+## Development setup
+
+Flock is a Go monorepo. The only hard requirement is **Docker** — the lint and
+test toolchain is pinned inside a `dev-tools` image so your results match CI. You
+do not need a local Go install.
+
+```bash
+# Install the task runner (https://taskfile.dev), then:
+task dev-tools:build   # build the pinned lint/test image (first run only)
+task lint              # gofmt + go vet + golangci-lint
+task tests             # go test -race ./...
+task build             # compile the binaries
+```
+
+These are the exact entrypoints [CI](.github/workflows/ci.yml) runs, so a green
+local run is a green CI run. See the README's *Repo layout* section for where
+each service lives.
+
+## Pull request process
+
+1. **Fork** the repository and clone your fork.
+2. **Create a branch** off `main` for your change
+   (`git checkout -b fix/clear-error-message`).
+3. **Make your change.** Keep it focused — one logical change per PR.
+4. **Add tests.** New behaviour needs coverage; a bug fix should add a test that
+   fails before the fix and passes after.
+5. **Run the checks** — `task lint && task tests && task build` must all pass.
+6. **Open a pull request** against `main`, fill in the template, and link any
+   related issue. Describe *what* changed and *why*, and how you verified it.
+
+A maintainer will review; please respond to review comments by pushing follow-up
+commits to the same branch. PRs are squash-merged once approved and green.
+
+## Conventions
+
+- **Commit messages** follow [Conventional Commits](https://www.conventionalcommits.org/)
+  in the imperative mood, scoped by area:
+  `feat(schedule): ...`, `fix(telegram): ...`, `docs: ...`, `chore(deps): ...`.
+- **Go style** is enforced by `golangci-lint` (`.golangci.yml`) and `gofumpt`.
+  Run `task lint` before pushing; the linter is strict by design.
+- **Errors** are wrapped with context: `fmt.Errorf("doing x: %w", err)` — lower
+  case, no trailing punctuation (the `error-strings` rule).
+- **Keep PRs free of unrelated churn** (formatting-only diffs, dependency bumps
+  mixed with features, etc.).
+
+## License
+
+By contributing, you agree that your contributions are licensed under the
+project's [MIT License](LICENSE).

--- a/README.de.md
+++ b/README.de.md
@@ -129,3 +129,7 @@ task build     # compile the binaries
 ## Lizenz
 
 [MIT](LICENSE) © DuckBug.
+
+## Mitwirken & Sicherheit
+
+Leitfäden zum Mitwirken und zur Meldung von Sicherheitslücken: [CONTRIBUTING.md](CONTRIBUTING.md), [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md), [SECURITY.md](SECURITY.md).

--- a/README.es.md
+++ b/README.es.md
@@ -129,3 +129,7 @@ task build     # compile the binaries
 ## Licencia
 
 [MIT](LICENSE) © DuckBug.
+
+## Contribuir y seguridad
+
+Guías para contribuir y para reportar vulnerabilidades: [CONTRIBUTING.md](CONTRIBUTING.md), [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md), [SECURITY.md](SECURITY.md).

--- a/README.fr.md
+++ b/README.fr.md
@@ -129,3 +129,7 @@ task build     # compile the binaries
 ## Licence
 
 [MIT](LICENSE) © DuckBug.
+
+## Contribuer et sécurité
+
+Guides pour contribuer et pour signaler une vulnérabilité : [CONTRIBUTING.md](CONTRIBUTING.md), [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md), [SECURITY.md](SECURITY.md).

--- a/README.ja.md
+++ b/README.ja.md
@@ -129,3 +129,7 @@ task build     # compile the binaries
 ## ライセンス
 
 [MIT](LICENSE) © DuckBug.
+
+## コントリビューションとセキュリティ
+
+貢献方法と脆弱性の報告については以下を参照してください: [CONTRIBUTING.md](CONTRIBUTING.md)、[CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)、[SECURITY.md](SECURITY.md)。

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ The **poller** is the recommended way to react to review comments — it reaches
 
 ## Security
 
+Found a vulnerability? Please disclose it privately — see **[SECURITY.md](SECURITY.md)**. Hardening notes for operators:
+
 - **Whitelist:** only `ALLOWED_USERS` (Telegram) / `VK_ALLOWED_USERS` (VK) may use the bot — never leave it empty; it grants shell/edit access to your server.
 - **Per-chat isolation:** different chats get separate workspaces. The git token is shared across a deployment — scope it accordingly.
 - **Secrets:** keep them in `.env` (gitignored) or, for Ansible, in a real instance's `vault.yml` (gitignored, `ansible-vault` encryptable). Only `inventories/example/` is tracked.
@@ -132,7 +134,7 @@ task build     # compile the binaries
 
 ## Contributing
 
-We welcome contributions to the Flock project! If you would like to contribute, please follow these guidelines:
+We welcome contributions! See **[CONTRIBUTING.md](CONTRIBUTING.md)** for the full guide — development setup, the `task` lint/test/build workflow, and conventions. In short:
 
 1. **Fork the repository**: Create your own fork of the repository on GitHub.
 2. **Create a new branch**: Make a new branch for your feature or bugfix.
@@ -142,4 +144,4 @@ We welcome contributions to the Flock project! If you would like to contribute, 
 
 ## Code of Conduct
 
-We expect all contributors to adhere to our Code of Conduct. Please be respectful and considerate in your interactions with others. Harassment and discrimination of any kind will not be tolerated.
+This project follows the [Contributor Covenant](CODE_OF_CONDUCT.md). Please be respectful and considerate in your interactions with others; harassment and discrimination of any kind will not be tolerated. Report concerns to conduct@duckbug.io.

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -129,3 +129,7 @@ task build     # compile the binaries
 ## Licença
 
 [MIT](LICENSE) © DuckBug.
+
+## Contribuição e segurança
+
+Guias para contribuir e para relatar vulnerabilidades: [CONTRIBUTING.md](CONTRIBUTING.md), [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md), [SECURITY.md](SECURITY.md).

--- a/README.ru.md
+++ b/README.ru.md
@@ -129,3 +129,7 @@ task build     # compile the binaries
 ## Лицензия
 
 [MIT](LICENSE) © DuckBug.
+
+## Участие и безопасность
+
+Руководства по участию и сообщению об уязвимостях: [CONTRIBUTING.md](CONTRIBUTING.md), [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md), [SECURITY.md](SECURITY.md).

--- a/README.zh.md
+++ b/README.zh.md
@@ -129,3 +129,7 @@ task build     # compile the binaries
 ## 许可证
 
 [MIT](LICENSE) © DuckBug.
+
+## 贡献与安全
+
+参与贡献和报告安全漏洞的指南：[CONTRIBUTING.md](CONTRIBUTING.md)、[CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)、[SECURITY.md](SECURITY.md)。

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,57 @@
+# Security Policy
+
+Flock runs an AI agent with shell and file-edit access inside a per-chat
+container, gated by an allow-list. We take its security seriously and appreciate
+responsible disclosure.
+
+## Supported versions
+
+Flock ships from `main` (trunk-based); there are no long-lived release branches.
+Security fixes land on `main` and are delivered via the published container
+images. Always run the latest image.
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+pull requests, or discussions.**
+
+Instead, use one of these private channels:
+
+1. **Email**: <security@duckbug.io>.
+2. **GitHub private vulnerability reporting** (once enabled on this repository):
+   the **Security** tab → **Report a vulnerability** opens a private advisory
+   visible only to you and the maintainers.
+
+Please include, as far as you can:
+
+- the affected component (adapter, `core/...` package, deployment/Ansible, etc.)
+  and version/image tag or commit,
+- a description of the issue and its impact,
+- step-by-step reproduction (a proof of concept helps),
+- any suggested remediation.
+
+## What to expect
+
+- We will acknowledge your report within **5 business days**.
+- We will keep you informed as we investigate and work on a fix.
+- We will credit you in the advisory once a fix is released, unless you prefer
+  to remain anonymous.
+
+Please give us a reasonable window to release a fix before any public
+disclosure. We are a volunteer-driven open-source project and will work with you
+in good faith.
+
+## Scope and hardening
+
+Some risks are operator configuration rather than code vulnerabilities. Before
+reporting, please review the **Security** section of the [README](README.md):
+
+- The bot grants shell/edit access to its host container — never leave
+  `ALLOWED_USERS` / `VK_ALLOWED_USERS` empty.
+- The git token is shared across a deployment; scope it to only what it needs.
+- Keep secrets in a gitignored `.env` (or an encrypted Ansible vault), never in
+  a tracked file.
+
+Reports about a misconfigured deployment (e.g. an empty allow-list) are not
+considered vulnerabilities in Flock itself, but we welcome documentation
+improvements that make safe defaults clearer.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,12 +15,19 @@ images. Always run the latest image.
 **Please do not report security vulnerabilities through public GitHub issues,
 pull requests, or discussions.**
 
-Instead, use one of these private channels:
+Instead, please use **GitHub's private vulnerability reporting**: on this
+repository, go to the **Security** tab → **Report a vulnerability**. This opens a
+private advisory visible only to you and the maintainers, and is the channel we
+monitor.
 
-1. **Email**: <security@duckbug.io>.
-2. **GitHub private vulnerability reporting** (once enabled on this repository):
-   the **Security** tab → **Report a vulnerability** opens a private advisory
-   visible only to you and the maintainers.
+> If the **Report a vulnerability** button is not visible, the maintainers have
+> not enabled private reporting yet — please open a minimal public issue asking
+> them to enable it (without vulnerability details), or reach a maintainer
+> privately, rather than disclosing the issue publicly.
+
+An email address (`security@duckbug.io`) may also be available; if you use it and
+receive no acknowledgement within the window below, fall back to GitHub private
+reporting, as mailbox delivery is not guaranteed.
 
 Please include, as far as you can:
 


### PR DESCRIPTION
## Summary

Brings the repo to the standard open-source layout. GitHub's community profile was at **37%** — only README and LICENSE were recognized. The README had Contributing / Code of Conduct *sections*, but no standalone files, no vulnerability-disclosure policy, and no issue/PR templates.

## Adds

- **`CONTRIBUTING.md`** — dev setup (the dockerized `task lint`/`tests`/`build` runner that mirrors CI), PR process, and commit/style conventions.
- **`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1.
- **`SECURITY.md`** — a private vulnerability-disclosure policy. The README "Security" section is *deployment hardening*, not a reporting channel; this adds one.
- **`.github/ISSUE_TEMPLATE/`** — `bug_report.md`, `feature_request.md`, and `config.yml` (blank issues off; a contact link steering vulnerabilities to the security policy).
- **`.github/PULL_REQUEST_TEMPLATE.md`** — summary / linked issue / type / verification / checklist.
- **README** now links to the three new files from the relevant sections.

Docs-only — no code, build, or dependency changes (`task build`/`tests`/`lint` untouched and unaffected).

## Result

Adds the four files GitHub's community checklist was missing (contributing, code of conduct, issue template, PR template) plus a security policy — taking the profile to ~100%.

## Maintainer follow-ups (outside this PR)

These need repo **settings**, which a PR can't change:

1. **Enable "Private vulnerability reporting"** (Settings → Code security) so the Security-tab "Report a vulnerability" flow in `SECURITY.md` works. Until then the policy points to email.
2. **Confirm the contact addresses** `security@duckbug.io` and `conduct@duckbug.io` exist (or replace them) — they're on the project domain but I couldn't verify they're monitored.
3. Optional: enable **Discussions** if you want a Q&A channel (a contact link was intentionally left out since it's currently disabled).
4. **Topics** — I'm setting these via the API separately (not file-based).

> Note: GitHub currently reports the `LICENSE` as *undetected* even though it is canonical MIT — likely a transient detection quirk; worth a glance at the repo sidebar.