### PR TITLE
fix(schedule): harden autonomous fires (non-blocking, allow-list at fire time, cost cap)

### DIFF
--- a/adapters/vk/receiver_test.go
+++ b/adapters/vk/receiver_test.go
@@ -341,7 +341,7 @@ func TestReceiverScheduleEnabledReachesDispatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open store: %v", err)
 	}
-	mgr := schedule.NewManager(store, func(string, string) {}, nil, nil)
+	mgr := schedule.NewManager(store, func(string, string, int64) bool { return true }, nil, nil, nil)
 	r := NewReceiver(ReceiverConfig{
 		Service:   svc,
 		GroupID:   123,

--- a/cmd/duck-vk/main.go
+++ b/cmd/duck-vk/main.go
@@ -199,6 +199,7 @@ func run() int {
 		Workspace:  ws,
 		Sessions:   sessions,
 		Costs:      costs,
+		CostCapUSD: cfg.EffectiveCostCapUSD(),
 		Outbox:     outbox,
 		StarNudge:  starNudge,
 		Opts:       opts,
@@ -209,9 +210,10 @@ func run() int {
 
 	// Background cron scheduler (OFF by default). When enabled, open the durable
 	// per-chat job store and start the scheduler loop, firing each due job into the
-	// same dispatch lane a user message uses (svc.Inject, sentinel user 0). A
-	// store-open failure is non-fatal: log and continue WITHOUT the scheduler (mgr
-	// stays nil). With the flag off no store is opened and no goroutine runs.
+	// same dispatch lane a user message uses (svc.InjectScheduled, non-blocking +
+	// ephemeral, attributed to the job's creator). A store-open failure is non-fatal:
+	// log and continue WITHOUT the scheduler (mgr stays nil). With the flag off no
+	// store is opened and no goroutine runs.
 	mgr := buildScheduler(ctx, cfg, svc, logger)
 
 	guards := chat.GuardConfig{CostCapUSD: cfg.EffectiveCostCapUSD()}
@@ -294,8 +296,9 @@ type vkTranscriber interface {
 // command dispatches to. It returns nil when the feature is disabled OR when the
 // store cannot be opened (non-fatal: log and run without the scheduler), so
 // /schedule replies with the disabled notice rather than crashing. The scheduler
-// fires each due job via svc.Inject — the same serialized per-chat lane a normal
-// message uses. Mirrors cmd/flock-telegram.
+// fires each due job via svc.InjectScheduled — the same serialized per-chat lane a
+// normal message uses, but non-blocking, ephemeral, and re-validated against the VK
+// allow-list at fire time. Mirrors cmd/flock-telegram.
 func buildScheduler(ctx context.Context, cfg config.Config, svc *chat.Service, logger *slog.Logger) *schedule.Manager {
 	if !cfg.SchedulerEnabled() {
 		return nil
@@ -305,11 +308,13 @@ func buildScheduler(ctx context.Context, cfg config.Config, svc *chat.Service, l
 		logger.Error("open schedule store; scheduler disabled", "path", cfg.ScheduleStoreFile(), "error", err)
 		return nil
 	}
-	// Fire each due job on its own goroutine so a blocked Inject (full dispatch
-	// buffer behind a long Claude run) never stalls the single scheduler goroutine
-	// and starves other chats' jobs. Mirrors cmd/flock-telegram.
-	fire := func(chatID, prompt string) { go svc.Inject(chatID, prompt) }
-	mgr := schedule.NewManager(store, fire, time.Now, logger)
+	// Fire each due job directly via InjectScheduled: it is non-blocking (drops the
+	// fire when the chat's lane is full) and ephemeral (no auto-resume marker), so
+	// the single scheduler goroutine is never stalled and a frequent cron cannot
+	// accumulate detached goroutines or durable markers. The creator is re-validated
+	// against the live VK allow-list at fire time (cfg.IsVKAllowed) so a de-listed
+	// user's stored jobs stop running and are pruned. Mirrors cmd/flock-telegram.
+	mgr := schedule.NewManager(store, svc.InjectScheduled, cfg.IsVKAllowed, time.Now, logger)
 	go func() {
 		if err := mgr.Run(ctx); err != nil && ctx.Err() == nil {
 			logger.Error("scheduler stopped", "error", err)

--- a/cmd/flock-telegram/commands_test.go
+++ b/cmd/flock-telegram/commands_test.go
@@ -337,7 +337,7 @@ func TestScheduleCommandEnabledReachesDispatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open store: %v", err)
 	}
-	mgr := schedule.NewManager(store, func(string, string) {}, nil, nil)
+	mgr := schedule.NewManager(store, func(string, string, int64) bool { return true }, nil, nil, nil)
 
 	defaultHandler := func(ctx context.Context, b *bot.Bot, update *models.Update) {
 		if msg := update.Message; msg != nil {

--- a/cmd/flock-telegram/main.go
+++ b/cmd/flock-telegram/main.go
@@ -271,6 +271,7 @@ func run() int {
 		Sessions:   sessions,
 		Pending:    pendings,
 		Costs:      costs,
+		CostCapUSD: cfg.EffectiveCostCapUSD(),
 		Outbox:     outbox,
 		StarNudge:  starNudge,
 		Opts:       opts,
@@ -281,10 +282,11 @@ func run() int {
 
 	// Background cron scheduler (OFF by default). When enabled, open the durable
 	// per-chat job store and start the scheduler loop, firing each due job into the
-	// same dispatch lane a user message uses (svc.Inject, sentinel user 0). A
-	// store-open failure is non-fatal: log and continue WITHOUT the scheduler (mgr
-	// stays nil), like the rest of the best-effort startup wiring. With the flag off
-	// no store is opened and no goroutine runs — the path is a true no-op.
+	// same dispatch lane a user message uses (svc.InjectScheduled, non-blocking +
+	// ephemeral, attributed to the job's creator). A store-open failure is non-fatal:
+	// log and continue WITHOUT the scheduler (mgr stays nil), like the rest of the
+	// best-effort startup wiring. With the flag off no store is opened and no
+	// goroutine runs — the path is a true no-op.
 	mgr := buildScheduler(ctx, cfg, svc, logger)
 
 	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, telegram.CallbackMatch(), bot.MatchTypePrefix, stopHandler(cfg, svc))
@@ -989,8 +991,9 @@ func commandArgs(text string) string {
 // handler dispatches to. It returns nil when the feature is disabled OR when the
 // store cannot be opened (non-fatal: log and run without the scheduler), so the
 // handler replies with the disabled notice rather than crashing. The scheduler
-// fires each due job via svc.Inject — the same serialized per-chat lane a normal
-// message uses.
+// fires each due job via svc.InjectScheduled — the same serialized per-chat lane a
+// normal message uses, but non-blocking, ephemeral, and re-validated against the
+// allow-list at fire time.
 func buildScheduler(ctx context.Context, cfg config.Config, svc *chat.Service, logger *slog.Logger) *schedule.Manager {
 	if !cfg.SchedulerEnabled() {
 		return nil
@@ -1000,14 +1003,13 @@ func buildScheduler(ctx context.Context, cfg config.Config, svc *chat.Service, l
 		logger.Error("open schedule store; scheduler disabled", "path", cfg.ScheduleStoreFile(), "error", err)
 		return nil
 	}
-	// Fire each due job on its own goroutine: Inject blocks when a chat's dispatch
-	// buffer is full (a long-running Claude run holds the lane), and the scheduler
-	// runs a single goroutine — firing inline would stall every OTHER chat's due
-	// jobs and could skip a matching minute. Detaching keeps the tick loop free;
-	// at-most-once-per-minute still holds because TickOnce records the minute key
-	// synchronously before this returns.
-	fire := func(chatID, prompt string) { go svc.Inject(chatID, prompt) }
-	mgr := schedule.NewManager(store, fire, time.Now, logger)
+	// Fire each due job directly via InjectScheduled: it is non-blocking (drops the
+	// fire when the chat's lane is full) and ephemeral (no auto-resume marker), so
+	// the single scheduler goroutine is never stalled by a busy lane and a frequent
+	// cron cannot accumulate detached goroutines or durable markers. The creator is
+	// re-validated against the live allow-list at fire time (cfg.IsAllowed) so a
+	// de-listed user's stored jobs stop running and are pruned.
+	mgr := schedule.NewManager(store, svc.InjectScheduled, cfg.IsAllowed, time.Now, logger)
 	go func() {
 		if err := mgr.Run(ctx); err != nil && ctx.Err() == nil {
 			logger.Error("scheduler stopped", "error", err)

--- a/core/chat/commands_test.go
+++ b/core/chat/commands_test.go
@@ -23,6 +23,13 @@ func (d *fakeDispatcher) Submit(chatID ChatID, _ func(ctx context.Context)) {
 	d.submitted = append(d.submitted, chatID)
 }
 
+func (d *fakeDispatcher) TrySubmit(chatID ChatID, _ func(ctx context.Context)) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.submitted = append(d.submitted, chatID)
+	return true
+}
+
 func (d *fakeDispatcher) Cancel(chatID ChatID) {
 	d.mu.Lock()
 	defer d.mu.Unlock()

--- a/core/chat/cost_record_test.go
+++ b/core/chat/cost_record_test.go
@@ -87,3 +87,95 @@ func TestRunRecordsZeroCostOnError(t *testing.T) {
 		t.Fatal("an error run must record zero cost (no Result)")
 	}
 }
+
+// newScheduledTestService builds a Service wired to a cost store (with the given
+// per-user cap), a fake pending store, and a real Dispatcher — the harness for the
+// InjectScheduled tests, which assert the cost gate and the ephemeral (no-marker)
+// behavior together.
+func newScheduledTestService(
+	t *testing.T, r claude.Runner, c Transport, costs *cost.Store, capUSD float64, p pendingStore,
+) (*Service, *dispatch.Dispatcher) {
+	t.Helper()
+	d := dispatch.New(4)
+	s := New(Config{
+		Runner:     r,
+		Transport:  c,
+		Dispatcher: d,
+		Workspace:  &fakeWorkspace{},
+		Costs:      costs,
+		CostCapUSD: capUSD,
+		Pending:    p,
+		Logger:     slog.New(slog.DiscardHandler),
+	})
+	s.tick = 5 * time.Millisecond
+	return s, d
+}
+
+// TestInjectScheduledUnderCapRunsEphemerally asserts a scheduled fire under the
+// cost cap is accepted (returns true), actually runs, and — unlike Inject — writes
+// NO pending marker (it must never auto-resume on restart).
+func TestInjectScheduledUnderCapRunsEphemerally(t *testing.T) {
+	fc := newFakeChat()
+	fr := &fakeRunner{events: []claude.Event{
+		{Type: claude.Result, Result: &claude.RunResult{Text: "scheduled done", CostUSD: 0.1}},
+	}}
+	costs, err := cost.Open(t.TempDir() + "/costs.json")
+	if err != nil {
+		t.Fatalf("open cost store: %v", err)
+	}
+	pend := newFakePending()
+	svc, d := newScheduledTestService(t, fr, fc, costs, 5.0, pend)
+	defer d.Close()
+
+	const creator int64 = 42
+	if !svc.InjectScheduled("100", "go", creator) {
+		t.Fatal("InjectScheduled returned false under the cap, want true")
+	}
+	// The run reaches its terminal and delivers its answer.
+	waitUntil(t, func() bool {
+		text, _ := fc.snapshot()
+		return strings.Contains(text, "scheduled done")
+	})
+	// EPHEMERAL: no pending marker may ever exist for this chat (Inject would have
+	// enqueued one). Poll briefly so a late stray enqueue would still be caught.
+	for i := 0; i < 10; i++ {
+		if pend.count() != 0 {
+			t.Fatalf("a scheduled fire wrote %d pending markers, want 0 (ephemeral)", pend.count())
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+}
+
+// TestInjectScheduledOverCapDropsRun asserts a scheduled fire for a creator already
+// over the cost cap is denied (returns false), runs nothing, and writes no marker.
+func TestInjectScheduledOverCapDropsRun(t *testing.T) {
+	fc := newFakeChat()
+	fr := &fakeRunner{events: []claude.Event{
+		{Type: claude.Result, Result: &claude.RunResult{Text: "must not run", CostUSD: 0.1}},
+	}}
+	costs, err := cost.Open(t.TempDir() + "/costs.json")
+	if err != nil {
+		t.Fatalf("open cost store: %v", err)
+	}
+	const creator int64 = 42
+	// Push the creator over a tiny cap before the fire.
+	if err := costs.Add(creator, 1.0); err != nil {
+		t.Fatalf("seed cost: %v", err)
+	}
+	pend := newFakePending()
+	svc, d := newScheduledTestService(t, fr, fc, costs, 0.5, pend)
+	defer d.Close()
+
+	if svc.InjectScheduled("100", "go", creator) {
+		t.Fatal("InjectScheduled returned true for a creator over the cap, want false")
+	}
+	// Nothing was submitted: no run delivers, and no marker is written. Give a (would-
+	// be) run ample time to wrongly start.
+	time.Sleep(50 * time.Millisecond)
+	if text, _ := fc.snapshot(); strings.Contains(text, "must not run") {
+		t.Fatal("an over-cap scheduled fire ran a job")
+	}
+	if pend.count() != 0 {
+		t.Fatalf("an over-cap scheduled fire wrote %d markers, want 0", pend.count())
+	}
+}

--- a/core/chat/service.go
+++ b/core/chat/service.go
@@ -57,6 +57,10 @@ type workspaceEnsurer interface {
 // capped) and cancels a chat's in-flight job. *dispatch.Dispatcher satisfies it.
 type dispatcher interface {
 	Submit(chatID ChatID, run func(ctx context.Context))
+	// TrySubmit is the non-blocking Submit: it returns false (instead of blocking)
+	// when the chat's lane is full or the dispatcher is closed, used by the
+	// best-effort scheduled-fire path that must never stall on a busy lane.
+	TrySubmit(chatID ChatID, run func(ctx context.Context)) bool
 	Cancel(chatID ChatID)
 }
 
@@ -114,6 +118,7 @@ type Service struct {
 	sessions   sessionStore
 	pending    pendingStore
 	costs      *cost.Store
+	costCapUSD float64
 	outbox     *Sweeper
 	nudge      *starNudge
 	opts       claude.Options
@@ -145,6 +150,11 @@ type Config struct {
 	// May be nil (cost tracking disabled: runs record nothing). A nil *cost.Store
 	// is itself a no-op, so either a nil interface value or a nil store is safe.
 	Costs *cost.Store
+	// CostCapUSD is the cumulative per-user USD cap applied to scheduled fires
+	// (InjectScheduled): a creator whose accrued cost is at/over this cap has their
+	// due jobs skipped. A non-positive value disables the gate (every scheduled fire
+	// is allowed). It does NOT affect the inbound message path, which gates earlier.
+	CostCapUSD float64
 	// Outbox, when non-nil, sweeps the per-chat outbox directory after each run
 	// and delivers any files a run produced as Telegram documents. Nil disables
 	// the feature: the text-only finish path stays byte-identical.
@@ -193,6 +203,7 @@ func New(cfg Config) *Service {
 		sessions:   cfg.Sessions,
 		pending:    cfg.Pending,
 		costs:      cfg.Costs,
+		costCapUSD: cfg.CostCapUSD,
 		outbox:     cfg.Outbox,
 		nudge:      newStarNudge(cfg.StarNudge, cfg.Transport, log),
 		opts:       cfg.Opts,
@@ -256,6 +267,31 @@ func (s *Service) Inject(chatID ChatID, prompt string) {
 	id := s.enqueuePending(chatID, prompt)
 	s.dispatch.Submit(chatID, func(ctx context.Context) {
 		s.run(ctx, chatID, 0, prompt, nil, id)
+	})
+}
+
+// InjectScheduled submits a scheduled (cron) job's prompt into chatID, attributing
+// the run to its creator (userID) so the cost accrues to them. It differs from
+// Inject (the poller path) on the two axes that matter for an UNATTENDED, recurring
+// fire:
+//
+//   - EPHEMERAL: it does NOT enqueue a pending marker, so a scheduled fire is never
+//     auto-resumed on restart. A missed fire is acceptable; a durable marker that
+//     replays a stale scheduled prompt after a deploy is the bug we are avoiding.
+//   - NON-BLOCKING + cost-gated: it gates on the creator's cumulative cost cap and
+//     submits via the non-blocking lane, so a frequent cron behind a long-held lane
+//     can neither accumulate detached goroutines nor stall the scheduler.
+//
+// It returns false (the fire is dropped, best-effort) when the creator is at/over
+// the cost cap or when the chat's lane is busy (full buffer / dispatcher closed),
+// and true when the run was enqueued. Inject, by contrast, runs as the sentinel
+// user 0, is durable (enqueues a marker), and blocks on a full buffer.
+func (s *Service) InjectScheduled(chatID ChatID, prompt string, userID int64) bool {
+	if s.costs != nil && !s.costs.Allowed(userID, s.costCapUSD) {
+		return false
+	}
+	return s.dispatch.TrySubmit(chatID, func(ctx context.Context) {
+		s.run(ctx, chatID, userID, prompt, nil, "")
 	})
 }
 

--- a/core/dispatch/dispatch.go
+++ b/core/dispatch/dispatch.go
@@ -108,19 +108,10 @@ func New(maxConcurrent int) *Dispatcher {
 // initial fast-path check and the enqueue itself bail out on rootCtx.Done(), so
 // Submit can never send on a queue whose worker has gone away.
 func (d *Dispatcher) Submit(chatID string, run func(ctx context.Context)) {
-	d.mu.Lock()
-	if d.closed {
-		d.mu.Unlock()
+	q := d.queueFor(chatID)
+	if q == nil {
 		return
 	}
-	q := d.chats[chatID]
-	if q == nil {
-		q = &chatQueue{ch: make(chan job, d.bufSize)}
-		d.chats[chatID] = q
-		d.wg.Add(1)
-		go d.worker(q)
-	}
-	d.mu.Unlock()
 
 	// Derive each job's ctx from the dispatcher root so Shutdown can cancel
 	// everything; Cancel swaps in a fresh cancel just before the job runs.
@@ -133,6 +124,53 @@ func (d *Dispatcher) Submit(chatID string, run func(ctx context.Context)) {
 	case q.ch <- job{ctx: d.rootCtx, run: run}:
 	case <-d.rootCtx.Done():
 	}
+}
+
+// TrySubmit is the non-blocking variant of Submit: it enqueues run for chatID and
+// returns true, but returns false instead of blocking when the chat's per-chat
+// buffer is full (back-pressure surfaces as a dropped job, not a stalled caller)
+// or when the dispatcher is (or becomes) closed. Within-chat serialization and the
+// global cap are identical to Submit; only the full-buffer behavior differs. It is
+// the path for best-effort fires (e.g. the scheduler) that must never block on a
+// busy lane.
+func (d *Dispatcher) TrySubmit(chatID string, run func(ctx context.Context)) bool {
+	q := d.queueFor(chatID)
+	if q == nil {
+		return false
+	}
+
+	// Identical to Submit's send EXCEPT for the default arm: a full buffer (or a
+	// shutdown-cancelled rootCtx) makes the send fail fast and report false rather
+	// than blocking. The channel is never closed, so this select only enqueues,
+	// drops on shutdown, or drops on a full buffer.
+	select {
+	case q.ch <- job{ctx: d.rootCtx, run: run}:
+		return true
+	case <-d.rootCtx.Done():
+		return false
+	default:
+		return false
+	}
+}
+
+// queueFor returns chatID's queue, lazily creating it (and starting its worker) on
+// first use. It returns nil when the dispatcher is closed, so the caller drops the
+// job rather than sending on an abandoned queue. Shared by Submit and TrySubmit so
+// the get-or-create-and-start logic lives in exactly one place.
+func (d *Dispatcher) queueFor(chatID string) *chatQueue {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.closed {
+		return nil
+	}
+	q := d.chats[chatID]
+	if q == nil {
+		q = &chatQueue{ch: make(chan job, d.bufSize)}
+		d.chats[chatID] = q
+		d.wg.Add(1)
+		go d.worker(q)
+	}
+	return q
 }
 
 // worker drains a single chat's queue, running one job at a time. Serial

--- a/core/dispatch/dispatch_test.go
+++ b/core/dispatch/dispatch_test.go
@@ -125,6 +125,45 @@ func TestGlobalCap(t *testing.T) {
 	}
 }
 
+// TestTrySubmitDropsWhenFull asserts TrySubmit is non-blocking: it returns true
+// while the chat's lane has room, but false (a dropped job, not a blocked caller)
+// once the in-flight job plus the buffer are full. A single-slot dispatcher with a
+// blocked in-flight job lets us fill the buffer deterministically.
+func TestTrySubmitDropsWhenFull(t *testing.T) {
+	d := New(1)
+	defer d.Close()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	// Occupy the single global slot with a job that blocks until released, so nothing
+	// drains the buffer while we fill it.
+	if !d.TrySubmit("1", func(_ context.Context) {
+		close(started)
+		<-release
+	}) {
+		t.Fatal("first TrySubmit returned false on an empty lane")
+	}
+	recv(t, started, "the in-flight job did not start")
+
+	// Fill the per-chat buffer; every one of these must be accepted (queued).
+	for i := 0; i < queueBuffer; i++ {
+		if !d.TrySubmit("1", func(context.Context) {}) {
+			t.Fatalf("TrySubmit #%d returned false while the buffer still had room", i)
+		}
+	}
+	// The buffer is now full and the worker is busy on the blocked job: the next
+	// TrySubmit must drop (return false) instead of blocking.
+	if d.TrySubmit("1", func(context.Context) { t.Fatal("dropped job ran") }) {
+		t.Fatal("TrySubmit returned true on a full lane, want false (dropped)")
+	}
+	// A different chat (its own empty lane) is unaffected and still accepts.
+	if !d.TrySubmit("2", func(context.Context) {}) {
+		t.Fatal("TrySubmit on a separate idle chat returned false")
+	}
+
+	close(release)
+}
+
 // TestCancelStopsInFlight asserts Cancel(chatID) cancels the running job's ctx,
 // which the job observes via ctx.Done() (AC2d).
 func TestCancelStopsInFlight(t *testing.T) {

--- a/core/schedule/manager.go
+++ b/core/schedule/manager.go
@@ -24,29 +24,40 @@ const tickInterval = 30 * time.Second
 
 // Manager runs the background scheduler and serves the transport-neutral
 // `/schedule` subcommands. It owns no transport state: a chat id is a plain
-// string and the fire callback (wired to chat.Service.Inject) is what couples a
-// due job to the dispatch lane.
+// string and the fire callback (wired to chat.Service.InjectScheduled) is what
+// couples a due job to the dispatch lane.
 type Manager struct {
-	store *Store
-	fire  func(chatID, prompt string)
-	now   func() time.Time
-	log   *slog.Logger
+	store   *Store
+	fire    func(chatID, prompt string, userID int64) bool
+	allowed func(userID int64) bool
+	now     func() time.Time
+	log     *slog.Logger
 }
 
 // NewManager builds a Manager. store is the durable job store; fire injects a
-// fired job's prompt into its chat (chat.Service.Inject). fire MUST NOT block the
-// caller: TickOnce runs on the single scheduler goroutine, so a blocking fire
-// would stall every other chat's jobs — the production wiring runs Inject on its
-// own goroutine (see buildScheduler). now supplies the current time (time.Now in
-// production, a stub in tests); a nil log defaults to slog.Default().
-func NewManager(store *Store, fire func(chatID, prompt string), now func() time.Time, log *slog.Logger) *Manager {
+// fired job's prompt into its chat (chat.Service.InjectScheduled), returning
+// whether the run was submitted. fire is NON-BLOCKING and BEST-EFFORT: it may drop
+// a fire (returning false) when the chat's lane is busy or the creator is over the
+// cost cap, and TickOnce records the matching minute regardless (at-most-one-fire-
+// attempt per matching minute). allowed re-validates a job's creator against the
+// live allow-list at fire time, so a de-listed user's stored jobs stop running and
+// are pruned; a nil allowed allows every creator (no fire-time check). now supplies
+// the current time (time.Now in production, a stub in tests); a nil log defaults to
+// slog.Default().
+func NewManager(
+	store *Store,
+	fire func(chatID, prompt string, userID int64) bool,
+	allowed func(userID int64) bool,
+	now func() time.Time,
+	log *slog.Logger,
+) *Manager {
 	if now == nil {
 		now = time.Now
 	}
 	if log == nil {
 		log = slog.Default()
 	}
-	return &Manager{store: store, fire: fire, now: now, log: log}
+	return &Manager{store: store, fire: fire, allowed: allowed, now: now, log: log}
 }
 
 // Run drives the scheduler until ctx is cancelled: every tick it reads the LIVE
@@ -78,6 +89,19 @@ func (m *Manager) TickOnce() {
 	now := m.now()
 	locs := map[string]*time.Location{} // resolve each chat's zone once per tick
 	for _, job := range m.store.ActiveJobs() {
+		// Re-validate the creator against the LIVE allow-list at fire time: a stored
+		// job whose creator was de-listed must stop running unattended, so prune it
+		// (drop it from the store) instead of firing. This is checked before the
+		// minute match so a de-listed user's job is removed on the next tick that sees
+		// it, regardless of whether this minute matches.
+		if m.allowed != nil && !m.allowed(job.CreatedBy) {
+			if err := m.store.Remove(job.ChatID, job.ID); err != nil {
+				m.log.Warn("scheduler: prune de-listed job failed", "id", job.ID, "chat", job.ChatID, "error", err)
+			}
+			m.log.Warn("scheduler: pruning job; creator no longer allowed",
+				"id", job.ID, "chat", job.ChatID, "createdBy", job.CreatedBy)
+			continue
+		}
 		// Evaluate the job against the wall clock in its chat's timezone (a chat with
 		// no zone set falls back to process-local time). The de-dup minuteKey is in
 		// that same zone, so at-most-once-per-matching-minute holds per chat. A zone
@@ -104,7 +128,15 @@ func (m *Manager) TickOnce() {
 		if !sched.Matches(local) {
 			continue
 		}
-		m.fire(job.ChatID, job.Prompt)
+		// fire is synchronous but non-blocking: it submits the run on the chat's
+		// dispatch lane and returns whether it was accepted. A false means the lane
+		// was busy or the creator is over the cost cap — the fire is dropped (best
+		// effort). We MarkFired regardless so a dropped fire is not retried for the
+		// rest of this minute (at-most-one-attempt per matching minute).
+		submitted := m.fire(job.ChatID, job.Prompt, job.CreatedBy)
+		if !submitted {
+			m.log.Info("scheduler: fire skipped (chat busy or over cost cap)", "id", job.ID, "chat", job.ChatID)
+		}
 		if err := m.store.MarkFired(job.ChatID, job.ID, minuteKey); err != nil {
 			m.log.Warn("scheduler: mark fired failed", "id", job.ID, "chat", job.ChatID, "error", err)
 		}

--- a/core/schedule/manager_test.go
+++ b/core/schedule/manager_test.go
@@ -20,10 +20,11 @@ type recordingFire struct {
 
 type fireCall struct{ chatID, prompt string }
 
-func (r *recordingFire) fire(chatID, prompt string) {
+func (r *recordingFire) fire(chatID, prompt string, _ int64) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.calls = append(r.calls, fireCall{chatID, prompt})
+	return true
 }
 
 func (r *recordingFire) seen() []fireCall {
@@ -44,7 +45,7 @@ func newManager(t *testing.T) (*schedule.Manager, *schedule.Store, *recordingFir
 	rec := &recordingFire{}
 	clock := time.Date(2026, 6, 18, 9, 0, 0, 0, time.UTC)
 	nowPtr := &clock
-	mgr := schedule.NewManager(store, rec.fire, func() time.Time { return *nowPtr }, nil)
+	mgr := schedule.NewManager(store, rec.fire, nil, func() time.Time { return *nowPtr }, nil)
 	return mgr, store, rec, nowPtr
 }
 
@@ -56,7 +57,7 @@ func newDispatchManager(t *testing.T) (*schedule.Manager, *schedule.Store) {
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
-	return schedule.NewManager(store, func(string, string) {}, nil, nil), store
+	return schedule.NewManager(store, func(string, string, int64) bool { return true }, nil, nil, nil), store
 }
 
 // --- Dispatch tests ---
@@ -409,6 +410,88 @@ func TestSchedulerInvalidCronSkipped(t *testing.T) {
 	mgr.TickOnce()
 	if got := rec.seen(); len(got) != 0 {
 		t.Fatalf("invalid-cron job fired %d times, want 0", len(got))
+	}
+}
+
+// openStore opens a fresh temp-file store for a test, failing on error.
+func openStore(t *testing.T) *schedule.Store {
+	t.Helper()
+	store, err := schedule.Open(filepath.Join(t.TempDir(), "schedules.json"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	return store
+}
+
+// TestSchedulerPrunesJobOfDelistedCreator asserts that when the live allow-list no
+// longer admits a job's creator, the scheduler PRUNES the job (removes it from the
+// store) on the next tick and never fires it — privilege does not persist past a
+// de-list.
+func TestSchedulerPrunesJobOfDelistedCreator(t *testing.T) {
+	store := openStore(t)
+	rec := &recordingFire{}
+	// allowed denies the creator (id 42) of the job below.
+	allowed := func(userID int64) bool { return userID != 42 }
+	clock := time.Date(2026, 6, 18, 9, 0, 0, 0, time.UTC)
+	mgr := schedule.NewManager(store, rec.fire, allowed, func() time.Time { return clock }, nil)
+
+	// A job whose schedule matches right now (every minute) but whose creator is
+	// de-listed.
+	if _, err := store.Add(schedule.Job{
+		ChatID: "100", Name: "j", Cron: "* * * * *", Prompt: "go", CreatedBy: 42, Active: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr.TickOnce()
+
+	if got := rec.seen(); len(got) != 0 {
+		t.Fatalf("a de-listed creator's job fired %d times, want 0", len(got))
+	}
+	if got := store.List("100"); got != nil {
+		t.Fatalf("de-listed creator's job was not pruned: %+v", got)
+	}
+}
+
+// TestSchedulerSkipsBusyFireButMarksMinute asserts that when fire reports the run
+// was dropped (chat busy / over cost cap) the minute is still de-duped: a second
+// tick in the same matching minute does not call fire again, and the job is NOT
+// pruned (it remains for a future minute).
+func TestSchedulerSkipsBusyFireButMarksMinute(t *testing.T) {
+	store := openStore(t)
+	var calls int
+	var mu sync.Mutex
+	// fire always reports "not submitted" (busy lane / over cap).
+	fire := func(string, string, int64) bool {
+		mu.Lock()
+		defer mu.Unlock()
+		calls++
+		return false
+	}
+	clock := time.Date(2026, 6, 18, 9, 0, 0, 0, time.UTC)
+	now := clock
+	mgr := schedule.NewManager(store, fire, nil, func() time.Time { return now }, nil)
+
+	if _, err := store.Add(schedule.Job{
+		ChatID: "100", Name: "j", Cron: "0 * * * *", Prompt: "go", CreatedBy: 7, Active: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	now = time.Date(2026, 6, 18, 9, 0, 0, 0, time.UTC)
+	mgr.TickOnce()
+	now = time.Date(2026, 6, 18, 9, 0, 30, 0, time.UTC) // same matching minute
+	mgr.TickOnce()
+
+	mu.Lock()
+	got := calls
+	mu.Unlock()
+	if got != 1 {
+		t.Fatalf("fire called %d times in one matching minute despite a dropped fire, want 1 (minute de-duped)", got)
+	}
+	// The job is best-effort dropped, not pruned: it must still be in the store.
+	if jobs := store.List("100"); len(jobs) != 1 {
+		t.Fatalf("job count = %d after a dropped fire, want 1 (not pruned)", len(jobs))
 	}
 }
 


### PR DESCRIPTION
## Summary

Hardens the `/schedule` scheduler (behind `ENABLE_SCHEDULER`, default **off**) against three issues an **independent review** surfaced after the feature merged. A scheduled job runs an *unattended* prompt that can drive commits/PRs, so these are about bounding its blast radius.

## Findings fixed

1. **🔴 Unbounded duplicate-run accumulation (major).** The previous fire wrapper `go svc.Inject(...)` wrote a **durable pending marker** and then **blocked** on a full per-chat dispatch buffer. With a frequent cron (`* * * * *`) behind a chat whose lane is held by a long Claude run, each matching minute spawned a detached goroutine that persisted a marker and parked — accumulating unboundedly. On drain: a thundering herd of identical unattended runs; on restart: **every** accumulated marker auto-resumed. The 25-job cap did not bound this (it caps distinct jobs, not re-fires).
   **Fix:** `dispatch.TrySubmit` (non-blocking — drops when the buffer is full) + `chat.Service.InjectScheduled` (no pending marker — ephemeral/best-effort). The Manager fires **synchronously and non-blocking**, and `MarkFired`s the minute regardless, so a busy minute is dropped, not queued. A missed scheduled occurrence is acceptable; an auto-replaying backlog is not.

2. **🟡 Privilege persistence (security).** The allow-list was only checked when a job was *created*, never when it *fired* — so removing a user from `ALLOWED_USERS` left their stored jobs running unattended forever.
   **Fix:** the Manager re-validates each job's creator against the **live** allow-list at fire time (`cfg.IsAllowed` for Telegram, `cfg.IsVKAllowed` for VK) and **prunes** a de-listed creator's jobs from the store.

3. **🟡 Cost cap bypassed (security).** Scheduled fires ran as sentinel user 0 and skipped the per-user cost cap entirely.
   **Fix:** `InjectScheduled` gates on the creator's cumulative cost cap and records the run's cost **against the creator**, so the existing `CLAUDE_MAX_COST_PER_USER` now applies to scheduled runs too.

## How it was verified
Repo CI runner (dockerized `dev-tools`): `task lint` (0 issues), `task build`, `task vet`, `task tests` (`go test -race ./...`) — all green, incl. new tests: `TrySubmit` drop-when-full, prune-de-listed-creator, busy-skip-still-marks-minute, and `InjectScheduled` cost-gate + ephemeral (no marker written).

## Pre-PR review
Coder implemented to a fixed design; then an **independent adversarial reviewer** re-derived the diff from scratch (Submit→queueFor equivalence, no worker leak, cost-gate polarity, prune-loop iterator safety, per-transport allow-lists, test reality) → **APPROVE, no findings**.

### Residual risks / needs a human eyeball
- The unrelated **PR-comment poller** still uses the durable `svc.Inject` (sentinel user 0) — intentionally unchanged; only the scheduler moved to the ephemeral path.
- Behavior change for operators: scheduled runs now **count against the creator's cost cap** and stop when it's reached — desirable, but verify your cap is set as intended before enabling.
- Not exercised live (tests use an injected clock / fakes): confirm one real scheduled fire under load before relying on it.

Follow-up to the merged #49.