### PR TITLE
feat(progress): live pipeline-stage header + completion notice with total time

### DIFF
--- a/core/chat/progress.go
+++ b/core/chat/progress.go
@@ -133,7 +133,7 @@ const elidedFormat = "🕓 +%d earlier"
 // which strips markdown metacharacters from the free-text label CONTENT — guarantees
 // the rendered stage line is markdown-safe regardless of label content OR length.
 const (
-	stagePrefix       = "🎏 "
+	stagePrefix       = "🧭 "
 	stageSeparator    = " → "
 	stageActiveLeft   = "▸ "
 	stageActiveRight  = " ◂"
@@ -161,19 +161,20 @@ const stageLabelMax = 40
 // trail can in principle list arbitrarily many DISTINCT labels, so the line is
 // bounded BY CONSTRUCTION here — the line is assembled ATOM-FIRST around the ACTIVE
 // stage's marked unit (added first so it is guaranteed kept and fully marked), then
-// older/newer neighbours are added only while the line stays under stageLineMax (with
-// a leading "first … " when earlier stages were dropped) — so the final truncateRunes
-// is a pure no-op safety net that can never shear off the active marker. The header
-// the line rides in therefore stays bounded regardless of how many stages were
-// observed. It is sized to comfortably hold the active label plus a few neighbours at
-// stageLabelMax.
+// older/newer neighbours are added only while the line stays under stageLineMax (the
+// first stage's label followed by an ellipsis leads the trail when earlier stages were
+// dropped) — so the final truncateRunes is a pure no-op safety net that can never
+// shear off the active marker. The header the line rides in therefore stays bounded
+// regardless of how many stages were observed. It is sized to comfortably hold the
+// active label plus a few neighbours at stageLabelMax.
 const stageLineMax = 120
 
 // stageWindowMax is how many labels the elided trail aims to keep around the active
 // stage, subject to stageLineMax. When more labels fall outside that window the trail
-// is rendered with a leading "first … " so the user still sees where the run began and
-// where it is now without an unbounded list. The active stage's marked unit is always
-// the first label taken when assembling, so it is never the one dropped to make room.
+// leads with the first stage's label and an ellipsis so the user still sees where the
+// run began and where it is now without an unbounded list. The active stage's marked
+// unit is always the first label taken when assembling, so it is never the one dropped
+// to make room.
 const stageWindowMax = 4
 
 // stageElision is the marker shown in place of the labels skipped between the first
@@ -594,8 +595,9 @@ func formatElapsed(secs int64) string {
 //     short case, byte-identical to listing every marked label joined by an arrow).
 //   - Otherwise the line is elided: the active stage's MARKED UNIT is placed first as
 //     an atomic unit (so it is always present and fully marked), neighbours are added
-//     around it in first-seen order only while the line stays under stageLineMax, and a
-//     leading "first … " / trailing " … " elision marks the gaps to the unshown ends.
+//     around it in first-seen order only while the line stays under stageLineMax, and
+//     the first stage's label + an ellipsis (leading) / a trailing ellipsis mark the
+//     gaps to the unshown ends.
 //
 // Because the line is already <= stageLineMax after assembly, the final truncateRunes
 // is a pure no-op safety net that can never cut the active marker. Each label is itself

--- a/core/chat/progress.go
+++ b/core/chat/progress.go
@@ -118,6 +118,68 @@ func buildActivityPrefixes() []string {
 // the indicator reads as part of the ring instead of a bare stray line.
 const elidedFormat = "🕓 +%d earlier"
 
+// Stage-line markup. The header above the activity ring shows which dev-team
+// subagents (planner/coder/tester/…) the run has launched, in first-seen order,
+// with the currently active one wrapped in stageActiveLeft/stageActiveRight so the
+// user can tell which stage is running now. The whole line is prefixed with
+// stagePrefix to match the emoji-led style of every other frame line, and the
+// labels are joined by stageSeparator.
+//
+// The active markers are PLAIN-TEXT arrows, not markdown emphasis: the stage line
+// ships inside a frame sent with asMarkdown=true (the Telegram Rich Markdown path,
+// where a single "*" is italic), and the active marker must never depend on a pair
+// of "*" staying balanced. A markdown-neutral "▸ … ◂" can never desync the parser
+// no matter where the line is clamped, and — together with sanitizeStageLabel,
+// which strips markdown metacharacters from the free-text label CONTENT — guarantees
+// the rendered stage line is markdown-safe regardless of label content OR length.
+const (
+	stagePrefix       = "🎏 "
+	stageSeparator    = " → "
+	stageActiveLeft   = "▸ "
+	stageActiveRight  = " ◂"
+	stageLabelFallbck = "subagent"
+)
+
+// stageLabelMeta is the set of markdown metacharacters stripped from a subagent
+// label's free-text CONTENT (subagent_type/description are model-controlled) before
+// it is placed in the stage line. The rich path treats "*" "_" "~" "`" "|" "=" "["
+// "]" as inline-markup delimiters; an odd one left in a label would desync the
+// parser and break the whole frame. Stripping them (the label is purely cosmetic)
+// keeps the line markdown-safe by CONSTRUCTION, complementing the plain-text active
+// markers. "<" ">" are dropped too so a label can never look like an HTML tag on the
+// legacy MarkdownToHTML path either.
+const stageLabelMeta = "*_~`|=[]<>"
+
+// stageLabelMax bounds a single subagent label in the stage line so an unexpected
+// long subagent_type/description can't blow up the header; the whole stage line is
+// itself hard-capped at stageLineMax (see stageLine) so the always-kept header can
+// never push a frame past frameBudgetMax.
+const stageLabelMax = 40
+
+// stageLineMax hard-caps the WHOLE assembled stage line (prefix + elided trail) in
+// runes. subagent_type/description are model/stream-controlled free text and the
+// trail can in principle list arbitrarily many DISTINCT labels, so the line is
+// bounded BY CONSTRUCTION here — the line is assembled ATOM-FIRST around the ACTIVE
+// stage's marked unit (added first so it is guaranteed kept and fully marked), then
+// older/newer neighbours are added only while the line stays under stageLineMax (with
+// a leading "first … " when earlier stages were dropped) — so the final truncateRunes
+// is a pure no-op safety net that can never shear off the active marker. The header
+// the line rides in therefore stays bounded regardless of how many stages were
+// observed. It is sized to comfortably hold the active label plus a few neighbours at
+// stageLabelMax.
+const stageLineMax = 120
+
+// stageWindowMax is how many labels the elided trail aims to keep around the active
+// stage, subject to stageLineMax. When more labels fall outside that window the trail
+// is rendered with a leading "first … " so the user still sees where the run began and
+// where it is now without an unbounded list. The active stage's marked unit is always
+// the first label taken when assembling, so it is never the one dropped to make room.
+const stageWindowMax = 4
+
+// stageElision is the marker shown in place of the labels skipped between the first
+// stage and the most-recent window when the trail is too long to render in full.
+const stageElision = "…"
+
 // Units used by formatElapsed to humanize the elapsed counter.
 const (
 	secondsPerMinute = 60
@@ -147,6 +209,15 @@ type Progress struct {
 	// total counts every activity line ever pushed (not no-op/ignored events), so
 	// Frame can show how many lines have scrolled off above the visible window.
 	total int
+	// stages is the deterministic trail of DISTINCT subagent labels seen, in
+	// first-seen order — pure membership taken from the stream, not an inferred
+	// round count. activeStage indexes the currently running subagent within it
+	// (the most recent Task launch). Both stay empty for a plain chat with no Task
+	// events, so the stage line is omitted and the frame is byte-identical to a
+	// non-pipeline run. State changes ONLY on a Tool=="Task" ToolUse (see Observe);
+	// inner subagent tool events never flip the active stage.
+	stages      []string
+	activeStage int
 }
 
 // NewProgress returns a Progress whose header counter reads from elapsed, the
@@ -159,10 +230,11 @@ func NewProgress(elapsed func() time.Duration, ringSize int, baseDir string) *Pr
 		ringSize = defaultRingSize
 	}
 	return &Progress{
-		elapsed:  elapsed,
-		ringSize: ringSize,
-		baseDir:  baseDir,
-		ring:     make([]string, 0, ringSize),
+		elapsed:     elapsed,
+		ringSize:    ringSize,
+		baseDir:     baseDir,
+		ring:        make([]string, 0, ringSize),
+		activeStage: -1,
 	}
 }
 
@@ -171,12 +243,78 @@ func NewProgress(elapsed func() time.Duration, ringSize int, baseDir string) *Pr
 // Final / FinalError to render the terminal message. It reports whether the
 // activity ring changed, so callers can skip a redundant edit.
 func (p *Progress) Observe(e claude.Event) bool {
+	// A Task launch (the Lead spawning a dev-team subagent) advances the stage
+	// header. This is the ONLY event that changes the active stage: inner subagent
+	// tool events arrive flat at the top level (the decoder ignores
+	// parent_tool_use_id), so they are ordinary ToolUse events with a non-Task tool
+	// name and must not flip the active stage.
+	if e.Type == claude.ToolUse && strings.EqualFold(e.Tool, "task") {
+		p.advanceStage(subagentLabel(e.ToolInput))
+	}
 	line, ok := activityLine(e, p.baseDir)
 	if !ok {
 		return false
 	}
 	p.push(line)
 	return true
+}
+
+// advanceStage records label as the currently active subagent, appending it to the
+// distinct-seen trail the first time it appears (preserving first-seen order) and
+// re-selecting it as active when it recurs. Membership only: it never counts rounds.
+func (p *Progress) advanceStage(label string) {
+	for i, s := range p.stages {
+		if s == label {
+			p.activeStage = i
+			return
+		}
+	}
+	p.stages = append(p.stages, label)
+	p.activeStage = len(p.stages) - 1
+}
+
+// subagentLabel extracts the subagent label from a Task tool's JSON input, with the
+// fallback chain subagent_type → description → "subagent". It never returns blank
+// and never panics on malformed input (an unparseable body yields the fallback).
+func subagentLabel(input json.RawMessage) string {
+	var args map[string]any
+	if len(input) > 0 {
+		_ = json.Unmarshal(input, &args)
+	}
+	strField := func(k string) string {
+		if v, ok := args[k].(string); ok {
+			return collapseWhitespace(v)
+		}
+		return ""
+	}
+	if v := strField("subagent_type"); v != "" {
+		return truncateRunes(v, stageLabelMax)
+	}
+	if v := strField("description"); v != "" {
+		return truncateRunes(v, stageLabelMax)
+	}
+	return stageLabelFallbck
+}
+
+// sanitizeStageLabel strips markdown metacharacters (stageLabelMeta) from a stage
+// label's free-text content so the cosmetic label can never inject inline markup
+// into the stage line, which rides in a frame sent on the rich (markdown) path. It
+// is applied at RENDER time (in stageLine), not at capture, so p.stages keeps the
+// raw label for membership/dedup and only the displayed copy is sanitized. A label
+// that becomes empty after stripping (all-metacharacter) falls back to the constant
+// so the active stage is never rendered blank.
+func sanitizeStageLabel(label string) string {
+	cleaned := strings.Map(func(r rune) rune {
+		if strings.ContainsRune(stageLabelMeta, r) {
+			return -1
+		}
+		return r
+	}, label)
+	cleaned = collapseWhitespace(cleaned)
+	if cleaned == "" {
+		return stageLabelFallbck
+	}
+	return cleaned
 }
 
 // activityLine renders the one-line activity summary for an event, or false if
@@ -444,6 +582,104 @@ func formatElapsed(secs int64) string {
 	}
 }
 
+// stageLine renders the compact subagent-trail header shown above the activity
+// ring: the distinct subagents launched so far, in first-seen order, joined by an
+// arrow with the currently active one marked. It returns "" when no Task event has
+// been observed, so a plain chat with zero Task events omits the line entirely (the
+// frame stays byte-identical to a non-pipeline run).
+//
+// Assembly is ATOM-FIRST so the active stage can NEVER be sheared off, no matter how
+// long the labels or how many distinct stages there were:
+//   - When the full first-seen trail fits stageLineMax it is shown whole (the common
+//     short case, byte-identical to listing every marked label joined by an arrow).
+//   - Otherwise the line is elided: the active stage's MARKED UNIT is placed first as
+//     an atomic unit (so it is always present and fully marked), neighbours are added
+//     around it in first-seen order only while the line stays under stageLineMax, and a
+//     leading "first … " / trailing " … " elision marks the gaps to the unshown ends.
+//
+// Because the line is already <= stageLineMax after assembly, the final truncateRunes
+// is a pure no-op safety net that can never cut the active marker. Each label is itself
+// bounded at stageLabelMax (subagentLabel) and stripped of markdown metacharacters
+// (sanitizeStageLabel), and the active markers are plain-text arrows, so the header is
+// markdown-safe and within frameBudgetMax regardless of input.
+func (p *Progress) stageLine() string {
+	if len(p.stages) == 0 {
+		return ""
+	}
+	n := len(p.stages)
+	mark := func(i int) string {
+		label := sanitizeStageLabel(p.stages[i])
+		if i == p.activeStage {
+			return stageActiveLeft + label + stageActiveRight
+		}
+		return label
+	}
+
+	// Fast path: the WHOLE trail (every label, first-seen order) fits — show it in full.
+	// This keeps the common short-trail case identical to a plain marked join.
+	full := make([]string, n)
+	for i := range p.stages {
+		full[i] = mark(i)
+	}
+	whole := stagePrefix + strings.Join(full, stageSeparator)
+	if utf8.RuneCountInString(whole) <= stageLineMax {
+		return whole
+	}
+
+	// Elide. Grow a contiguous window [lo, hi] OUTWARD from the active stage, whose
+	// marked unit is placed first and is therefore the one element never dropped to make
+	// room. Recent context (toward the tail) is preferred, then older context, taking a
+	// neighbour only while the rendered line — including the leading/trailing elision for
+	// any unshown ends — stays within stageLineMax.
+	lo, hi := p.activeStage, p.activeStage
+	render := func(lo, hi int) string {
+		parts := make([]string, 0, n)
+		// Lead with the first stage when it is not already inside the window, plus an
+		// elision only when there is a genuine gap (>1 index) between it and the window.
+		if lo > 0 {
+			parts = append(parts, mark(0))
+			if lo > 1 {
+				parts = append(parts, stageElision)
+			}
+		}
+		for i := lo; i <= hi; i++ {
+			parts = append(parts, mark(i))
+		}
+		if hi < n-1 {
+			parts = append(parts, stageElision)
+		}
+		return stagePrefix + strings.Join(parts, stageSeparator)
+	}
+	fits := func(lo, hi int) bool {
+		return utf8.RuneCountInString(render(lo, hi)) <= stageLineMax
+	}
+	// Defensive: the active marked unit alone (no neighbours, no elision) must fit; if a
+	// pathologically long active label blows the cap even by itself, surface it alone and
+	// let truncateRunes clamp it — the active stage is the single most important element.
+	if !fits(lo, hi) {
+		return truncateRunes(stagePrefix+mark(p.activeStage), stageLineMax)
+	}
+	// Expand the window, alternating tail-side then head-side, while it still fits and
+	// while it has not reached the stageWindowMax span budget on either side.
+	for hi-lo+1 < stageWindowMax {
+		grewTail := hi < n-1 && fits(lo, hi+1)
+		if grewTail {
+			hi++
+			if hi-lo+1 >= stageWindowMax {
+				break
+			}
+		}
+		grewHead := lo > 0 && fits(lo-1, hi)
+		if grewHead {
+			lo--
+		}
+		if !grewTail && !grewHead {
+			break
+		}
+	}
+	return truncateRunes(render(lo, hi), stageLineMax)
+}
+
 // Frame renders the current progress message: a header line driven by the
 // injected clock followed by the recent activity ring.
 func (p *Progress) Frame() string {
@@ -453,6 +689,12 @@ func (p *Progress) Frame() string {
 	}
 	spin := spinnerFrames[secs%int64(len(spinnerFrames))]
 	header := fmt.Sprintf("%s Working… (%s)", spin, formatElapsed(secs))
+	// The optional stage header rides directly under "Working…", separated by a
+	// blank line like every other block. It is empty (and so contributes nothing,
+	// keeping a no-Task chat byte-identical) when no Task event has been observed.
+	if stage := p.stageLine(); stage != "" {
+		header += "\n\n" + stage
+	}
 	if len(p.ring) == 0 {
 		return header
 	}

--- a/core/chat/progress_test.go
+++ b/core/chat/progress_test.go
@@ -793,6 +793,320 @@ func TestElidedIndicatorCountsBudgetDrops(t *testing.T) {
 	}
 }
 
+// taskEvent builds a Task ToolUse event carrying the given subagent_type, the way
+// the Lead's subagent launches surface in the stream (AC1/AC2).
+func taskEvent(subagentType string) claude.Event {
+	return claude.Event{
+		Type:      claude.ToolUse,
+		Tool:      "Task",
+		ToolInput: []byte(`{"subagent_type":"` + subagentType + `"}`),
+	}
+}
+
+// TestStageHeaderActiveSubagent (AC1) asserts a Task event with subagent_type
+// "coder" makes the stage header show the active-stage label "coder".
+func TestStageHeaderActiveSubagent(t *testing.T) {
+	var elapsed time.Duration
+	p := NewProgress(fakeClock(&elapsed), 5, "")
+	p.Observe(taskEvent("coder"))
+	frame := p.Frame()
+	if !strings.Contains(frame, stagePrefix) {
+		t.Fatalf("stage header missing its prefix: %q", frame)
+	}
+	// The active label is the subagent name wrapped in the active markers.
+	if !strings.Contains(frame, stageActiveLeft+"coder"+stageActiveRight) {
+		t.Fatalf("active stage label not marked: %q", frame)
+	}
+}
+
+// TestStageHeaderAbsentWithoutTask (AC1) asserts a chat with ZERO Task events shows
+// NO stage line, and the frame is byte-identical to one rendered before this feature
+// existed (header + ring only, no stage block).
+func TestStageHeaderAbsentWithoutTask(t *testing.T) {
+	var elapsed time.Duration
+	p := NewProgress(fakeClock(&elapsed), 5, "")
+	// A non-Task tool and a thought — ordinary activity, no pipeline.
+	p.Observe(claude.Event{Type: claude.ToolUse, Tool: "Read", ToolInput: []byte(`{"file_path":"a.go"}`)})
+	p.Observe(claude.Event{Type: claude.Text, Text: "thinking"})
+	frame := p.Frame()
+	if strings.Contains(frame, stagePrefix) {
+		t.Fatalf("stage header rendered with no Task events: %q", frame)
+	}
+	// Byte-identical to a frame assembled the old way: header, then each step,
+	// blank-line separated — no stage block between the header and the ring.
+	want := spinnerFrames[0] + " Working… (0s)" + "\n\n" +
+		"📖 Read · a.go" + "\n\n" + "💭 thinking"
+	if frame != want {
+		t.Fatalf("frame not byte-identical to the pre-feature layout:\n got %q\nwant %q", frame, want)
+	}
+}
+
+// TestStageHeaderEmptyRingNoTask guards the empty-ring fast path: with no events at
+// all the frame is exactly the bare "Working…" header (no stage block).
+func TestStageHeaderEmptyRingNoTask(t *testing.T) {
+	var elapsed time.Duration
+	p := NewProgress(fakeClock(&elapsed), 5, "")
+	if got, want := p.Frame(), spinnerFrames[0]+" Working… (0s)"; got != want {
+		t.Fatalf("empty frame not byte-identical: got %q, want %q", got, want)
+	}
+}
+
+// TestStageChangesOnlyOnTask (AC2) asserts the active stage flips ONLY on a
+// Tool=="Task" ToolUse: an inner, non-Task tool event (the kind a running subagent
+// emits, arriving flat at the top level) must NOT change the active stage.
+func TestStageChangesOnlyOnTask(t *testing.T) {
+	var elapsed time.Duration
+	p := NewProgress(fakeClock(&elapsed), 5, "")
+	p.Observe(taskEvent("planner"))
+	// An inner subagent tool call (flat at the top level) — must not flip the stage.
+	p.Observe(claude.Event{Type: claude.ToolUse, Tool: "Bash"})
+	p.Observe(claude.Event{Type: claude.ToolUse, Tool: "Read", ToolInput: []byte(`{"file_path":"x.go"}`)})
+	if p.activeStage != 0 || len(p.stages) != 1 || p.stages[0] != "planner" {
+		t.Fatalf("inner tool events changed the stage: active=%d stages=%v", p.activeStage, p.stages)
+	}
+	if !strings.Contains(p.Frame(), stageActiveLeft+"planner"+stageActiveRight) {
+		t.Fatalf("planner not the active stage after inner tools: %q", p.Frame())
+	}
+}
+
+// TestStageDistinctTrailFirstSeenOrder (AC2) asserts the trail lists each subagent
+// once in first-seen order, with the most recent (active) one marked — and that a
+// recurring subagent re-activates its EXISTING entry rather than appending a dupe.
+func TestStageDistinctTrailFirstSeenOrder(t *testing.T) {
+	var elapsed time.Duration
+	p := NewProgress(fakeClock(&elapsed), 5, "")
+	for _, sub := range []string{"planner", "coder", "tester", "coder"} {
+		p.Observe(taskEvent(sub))
+	}
+	// Distinct + first-seen order: planner, coder, tester (coder not duplicated).
+	if got, want := strings.Join(p.stages, ","), "planner,coder,tester"; got != want {
+		t.Fatalf("distinct-seen trail = %q, want %q", got, want)
+	}
+	// The last Task re-activated coder (index 1), not tester.
+	if p.activeStage != 1 {
+		t.Fatalf("active stage = %d, want coder at index 1", p.activeStage)
+	}
+	frame := p.Frame()
+	wantLine := stagePrefix + "planner" + stageSeparator +
+		stageActiveLeft + "coder" + stageActiveRight + stageSeparator + "tester"
+	if !strings.Contains(frame, wantLine) {
+		t.Fatalf("stage line %q not in frame %q", wantLine, frame)
+	}
+}
+
+// TestStageLabelFallbackChain (AC2) asserts the label fallback chain when
+// subagent_type is empty: subagent_type → description → "subagent". It never blanks
+// and never panics on malformed input.
+func TestStageLabelFallbackChain(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "subagent_type wins", input: `{"subagent_type":"reviewer","description":"d"}`, want: "reviewer"},
+		{name: "falls back to description", input: `{"description":"build the thing"}`, want: "build the thing"},
+		{name: "empty subagent_type falls to description", input: `{"subagent_type":"","description":"do it"}`, want: "do it"},
+		{name: "both empty falls to constant", input: `{"subagent_type":"","description":""}`, want: stageLabelFallbck},
+		{name: "missing fields fall to constant", input: `{"other":"x"}`, want: stageLabelFallbck},
+		{name: "malformed json falls to constant", input: `{not json`, want: stageLabelFallbck},
+		{name: "empty input falls to constant", input: ``, want: stageLabelFallbck},
+		{name: "non-string field falls to constant", input: `{"subagent_type":123}`, want: stageLabelFallbck},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := subagentLabel([]byte(tc.input)); got != tc.want {
+				t.Fatalf("subagentLabel(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestStageLineCountedAgainstBudget asserts the stage header rides within
+// frameBudgetMax even alongside a full ring of maximal lines, so the stage line can
+// never push a frame past the Telegram cap.
+func TestStageLineCountedAgainstBudget(t *testing.T) {
+	var elapsed time.Duration
+	p := NewProgress(fakeClock(&elapsed), 5, "")
+	p.Observe(taskEvent("coder"))
+	for i := 0; i < 5; i++ {
+		p.Observe(claude.Event{Type: claude.Text, Text: strings.Repeat("x", recentSnippetMax+500)})
+	}
+	frame := p.Frame()
+	if n := utf8.RuneCountInString(frame); n > frameBudgetMax {
+		t.Fatalf("frame with stage line exceeded budget: %d runes (max %d)", n, frameBudgetMax)
+	}
+	if !strings.Contains(frame, stagePrefix) {
+		t.Fatalf("stage line dropped under budget pressure: %q", frame)
+	}
+}
+
+// TestStageLineBoundedByManyDistinctStages asserts the stage header is bounded BY
+// CONSTRUCTION: even when the stream produces MANY distinct Task subagent_types with
+// long labels — free, model-controlled text, not the 5 known agents — alongside a
+// full ring of maximal lines and a long elapsed, the assembled stage line stays
+// within stageLineMax and the whole frame within frameBudgetMax. This is the case the
+// single-stage TestStageLineCountedAgainstBudget does not exercise: there the header
+// is tiny and only the ring-drop path is stressed; here the header itself is the risk.
+func TestStageLineBoundedByManyDistinctStages(t *testing.T) {
+	var elapsed time.Duration
+	p := NewProgress(fakeClock(&elapsed), 5, "")
+
+	// A long elapsed (drives the widest "Working… (Nh Nm Ns)" header) plus 200 DISTINCT
+	// long-labelled Task launches — each label is itself near the per-label cap.
+	elapsed = 99*time.Hour + 59*time.Minute + 59*time.Second
+	const distinctStages = 200
+	for i := 0; i < distinctStages; i++ {
+		// The distinguishing index leads so the labels stay DISTINCT after the
+		// per-label stageLabelMax cap (advanceStage dedups by string equality); the
+		// trailing run of 's' makes each one long, near the per-label cap.
+		p.Observe(taskEvent(strconv.Itoa(i) + "-" + strings.Repeat("s", stageLabelMax)))
+	}
+	if len(p.stages) != distinctStages {
+		t.Fatalf("expected %d distinct stages, got %d", distinctStages, len(p.stages))
+	}
+	// A full ring of maximal lines on top, so header + ring are both at their worst.
+	for i := 0; i < 5; i++ {
+		p.Observe(claude.Event{Type: claude.Text, Text: strings.Repeat("x", recentSnippetMax+500)})
+	}
+
+	// The stage line alone must be within its construction cap.
+	stage := p.stageLine()
+	if n := utf8.RuneCountInString(stage); n > stageLineMax {
+		t.Fatalf("stage line exceeded stageLineMax: %d runes (max %d): %q", n, stageLineMax, stage)
+	}
+	// A trail this long must be elided (first … window), not listed in full.
+	if !strings.Contains(stage, stageElision) {
+		t.Fatalf("long stage trail not elided: %q", stage)
+	}
+	// The active (most recent) stage is the last launch and must still be marked.
+	if !strings.Contains(stage, stageActiveLeft) || !strings.Contains(stage, stageActiveRight) {
+		t.Fatalf("active stage not marked in elided trail: %q", stage)
+	}
+
+	// And the whole frame — header (with the bounded stage line) + full ring — stays
+	// within the budget, the spec's hard requirement.
+	frame := p.Frame()
+	if n := utf8.RuneCountInString(frame); n > frameBudgetMax {
+		t.Fatalf("frame with many-stage header exceeded budget: %d runes (max %d)", n, frameBudgetMax)
+	}
+}
+
+// longLabel builds a DISTINCT label of exactly stageLabelMax runes (an index prefix
+// plus an 's' run), mirroring the worst-case free-text labels the stream can produce.
+func longLabel(i int) string {
+	prefix := strconv.Itoa(i) + "-"
+	return prefix + strings.Repeat("s", stageLabelMax-utf8.RuneCountInString(prefix))
+}
+
+// TestStageLineActiveKeptWithLongLabels is the regression for the short-trail shear:
+// with a few stages whose labels sit at the per-label cap (stageLabelMax) the full
+// first-seen join exceeds stageLineMax, so the OLD head-keeping truncate sheared the
+// ACTIVE label (it sits at the tail) clean off. The unified atom-first assembly must
+// instead keep the active stage present AND fully marked at every n in {3,4,5}, while
+// the line stays within stageLineMax and emits no unbalanced markdown.
+func TestStageLineActiveKeptWithLongLabels(t *testing.T) {
+	for _, n := range []int{3, 4, 5} {
+		t.Run(strconv.Itoa(n), func(t *testing.T) {
+			var elapsed time.Duration
+			p := NewProgress(fakeClock(&elapsed), 5, "")
+			for i := 0; i < n; i++ {
+				p.Observe(taskEvent(longLabel(i)))
+			}
+			line := p.stageLine()
+
+			// The line is bounded by construction.
+			if got := utf8.RuneCountInString(line); got > stageLineMax {
+				t.Fatalf("n=%d: stage line %d runes exceeds stageLineMax %d: %q", n, got, stageLineMax, line)
+			}
+			// These labels are long enough that the full join cannot fit — so this case
+			// MUST exercise the elided assembly, not the whole-trail fast path.
+			if !strings.Contains(line, stageElision) {
+				t.Fatalf("n=%d: expected the long-label trail to be elided: %q", n, line)
+			}
+			// The invariant: the active stage is present AND marked as an atomic unit
+			// (the regression was it being sheared off entirely).
+			active := stageActiveLeft + sanitizeStageLabel(p.stages[p.activeStage]) + stageActiveRight
+			if !strings.Contains(line, active) {
+				t.Fatalf("n=%d: active stage not present-and-marked: want %q in %q", n, active, line)
+			}
+			// Markdown safety: the active markers are plain-text arrows and labels are
+			// stripped of metacharacters, so a rich-markdown emphasis run can never be
+			// left unbalanced. Assert no stray emphasis delimiters survive at all.
+			assertMarkdownSafe(t, line)
+		})
+	}
+}
+
+// TestStageLineMarkdownSafeLabelContent asserts a label whose FREE-TEXT content carries
+// markdown metacharacters (subagent_type/description are model-controlled) can never
+// inject inline markup into the stage line: the metacharacters are stripped, the active
+// stage stays marked with the plain-text arrows, and the line is markdown-balanced.
+func TestStageLineMarkdownSafeLabelContent(t *testing.T) {
+	var elapsed time.Duration
+	p := NewProgress(fakeClock(&elapsed), 5, "")
+	// A label peppered with every delimiter the rich path treats specially, around the
+	// readable word so sanitizing strips ONLY the metacharacters, not the content.
+	p.Observe(taskEvent("*_~`|=[]<>reviewer*_~`|=[]<>"))
+	line := p.stageLine()
+
+	assertMarkdownSafe(t, line)
+	// The sanitized label still renders and is marked as the active stage.
+	active := stageActiveLeft + sanitizeStageLabel(p.stages[p.activeStage]) + stageActiveRight
+	if !strings.Contains(line, active) {
+		t.Fatalf("sanitized active label not marked: want %q in %q", active, line)
+	}
+	// Sanitization strips every markdown metacharacter, leaving the readable content.
+	if got := sanitizeStageLabel(p.stages[0]); got != "reviewer" {
+		t.Fatalf("metacharacters not stripped from label: %q", got)
+	}
+	// A label that is ALL metacharacters degrades to the fallback, never an empty marker.
+	if got := sanitizeStageLabel("*_~`|=[]<>"); got != stageLabelFallbck {
+		t.Fatalf("all-metacharacter label should fall back to %q, got %q", stageLabelFallbck, got)
+	}
+}
+
+// TestStageLineActiveMarkedWhenRecurringInLongTrail covers a recurring active stage that
+// is NOT at the tail of a long trail (a subagent relaunched after later ones): the window
+// is anchored on the ACTIVE stage, so its marked unit is always shown even when it sits
+// far from the most-recent end and the trail is elided on both sides.
+func TestStageLineActiveMarkedWhenRecurringInLongTrail(t *testing.T) {
+	var elapsed time.Duration
+	p := NewProgress(fakeClock(&elapsed), 5, "")
+	const distinctStages = 50
+	for i := 0; i < distinctStages; i++ {
+		p.Observe(taskEvent(longLabel(i)))
+	}
+	// Re-launch the FIRST subagent: it becomes active again at index 0, far from the tail.
+	p.Observe(taskEvent(longLabel(0)))
+	if p.activeStage != 0 {
+		t.Fatalf("expected the recurring first stage to be active at index 0, got %d", p.activeStage)
+	}
+
+	line := p.stageLine()
+	if got := utf8.RuneCountInString(line); got > stageLineMax {
+		t.Fatalf("stage line %d runes exceeds stageLineMax %d: %q", got, stageLineMax, line)
+	}
+	active := stageActiveLeft + sanitizeStageLabel(p.stages[0]) + stageActiveRight
+	if !strings.Contains(line, active) {
+		t.Fatalf("recurring active (non-tail) stage not present-and-marked: want %q in %q", active, line)
+	}
+	assertMarkdownSafe(t, line)
+}
+
+// assertMarkdownSafe checks a rendered stage line carries no UNBALANCED inline-markup
+// delimiter. The active markers are plain-text arrows (not "*"-emphasis) and label
+// content is stripped of metacharacters, so every such delimiter count must be even
+// (zero is the expected case here, but an even count is the real invariant the rich
+// markdown parser needs to stay in sync).
+func assertMarkdownSafe(t *testing.T, line string) {
+	t.Helper()
+	for _, meta := range []string{"*", "_", "`", "~", "|"} {
+		if c := strings.Count(line, meta); c%2 != 0 {
+			t.Fatalf("unbalanced %q in stage line (%d occurrences): %q", meta, c, line)
+		}
+	}
+}
+
 func TestFinalSuccess(t *testing.T) {
 	out := Final(&claude.RunResult{Text: "  the answer is 42  ", IsError: false})
 	if out != "the answer is 42" {

--- a/core/chat/service.go
+++ b/core/chat/service.go
@@ -570,7 +570,7 @@ loop:
 	// case their NEXT request is denied (the crossing request still ran).
 	s.recordCost(userID, finalResult)
 
-	s.finish(ctx, chatID, progressMsgID, markerID, finalResult, finalErr, ctx.Err())
+	s.finish(ctx, chatID, progressMsgID, markerID, finalResult, finalErr, ctx.Err(), s.nowFunc().Sub(start))
 
 	// Self-heal a stale/poisoned resume id: when a run that USED a resume session
 	// id terminates with an is_error Result, drop the stored session for this chat
@@ -711,7 +711,7 @@ func (s *Service) clearLanePending(chatID ChatID) {
 // (chunked when the answer exceeds the platform's message size limit).
 func (s *Service) finish(
 	ctx context.Context, chatID ChatID, progressMsgID MessageID, markerID string,
-	res *claude.RunResult, runErr, ctxErr error,
+	res *claude.RunResult, runErr, ctxErr error, total time.Duration,
 ) {
 	// Use a background context for delivery: the run ctx may be cancelled by Stop
 	// or shutdown, but the final message should still reach the user.
@@ -795,6 +795,34 @@ func (s *Service) finish(
 	// reports true, so its behavior is unchanged.
 	if s.outbox != nil && s.caps.CanSendDocument {
 		s.outbox.Sweep(deliverCtx, chatID, s.chat)
+	}
+
+	// Send a SEPARATE completion message carrying the run's total elapsed time. The
+	// in-place edit above never notifies (Telegram is silent on edits), so this is a
+	// real second Send that pings the user the run is done — once per run, distinct
+	// from the answer and never attached to the live "Working…" edit. Its status word
+	// mirrors the same three terminal cases the answer switch covers above (normal
+	// Result, RunError, Stop/timeout).
+	notice := completionNotice(res, runErr, ctxErr, total)
+	if _, sErr := s.chat.Send(deliverCtx, chatID, notice, "", true); sErr != nil {
+		s.log.Error("send completion notice", "error", sErr)
+	}
+}
+
+// completionNotice renders the one-line "done" message sent as a separate bubble
+// after the answer, carrying the run's total elapsed time with a status word that
+// mirrors the three terminal cases finish handles: a user Stop / per-run timeout
+// (ctxErr set, no Result or error) reads "stopped", a RunError or an is_error
+// Result reads "failed", and a clean Result reads "done".
+func completionNotice(res *claude.RunResult, runErr, ctxErr error, total time.Duration) string {
+	elapsed := formatElapsed(int64(total / time.Second))
+	switch {
+	case ctxErr != nil && res == nil && runErr == nil:
+		return "⏹ Stopped after " + elapsed
+	case runErr != nil || (res != nil && res.IsError):
+		return "⚠️ Failed after " + elapsed
+	default:
+		return "✅ Done in " + elapsed
 	}
 }
 

--- a/core/chat/service.go
+++ b/core/chat/service.go
@@ -800,23 +800,32 @@ func (s *Service) finish(
 	// Send a SEPARATE completion message carrying the run's total elapsed time. The
 	// in-place edit above never notifies (Telegram is silent on edits), so this is a
 	// real second Send that pings the user the run is done — once per run, distinct
-	// from the answer and never attached to the live "Working…" edit. Its status word
-	// mirrors the same three terminal cases the answer switch covers above (normal
-	// Result, RunError, Stop/timeout).
-	notice := completionNotice(res, runErr, ctxErr, total)
-	if _, sErr := s.chat.Send(deliverCtx, chatID, notice, "", true); sErr != nil {
+	// from the answer and never attached to the live "Working…" edit. A run cancelled
+	// by a deploy shutdown keeps its marker and auto-resumes on the next startup, so
+	// it is reported as paused (not stopped) to avoid a contradictory signal. The
+	// notice is the deliverable that must reach the user, so it uses the same
+	// rate-limit backoff as the answer rather than a bare Send that a transient 429
+	// would silently drop.
+	notice := completionNotice(res, runErr, ctxErr, total, genuinelyInterrupted)
+	if sErr := s.deliverWithBackoff(deliverCtx, "completion notice", func() error {
+		_, e := s.chat.Send(deliverCtx, chatID, notice, "", true)
+		return e
+	}); sErr != nil {
 		s.log.Error("send completion notice", "error", sErr)
 	}
 }
 
 // completionNotice renders the one-line "done" message sent as a separate bubble
 // after the answer, carrying the run's total elapsed time with a status word that
-// mirrors the three terminal cases finish handles: a user Stop / per-run timeout
-// (ctxErr set, no Result or error) reads "stopped", a RunError or an is_error
-// Result reads "failed", and a clean Result reads "done".
-func completionNotice(res *claude.RunResult, runErr, ctxErr error, total time.Duration) string {
+// mirrors the terminal cases finish handles: a run cancelled by a deploy shutdown
+// (resuming) keeps its marker and auto-resumes, so it reads "paused … will resume";
+// a user Stop / per-run timeout (ctxErr set, no Result or error) reads "stopped"; a
+// RunError or an is_error Result reads "failed"; and a clean Result reads "done".
+func completionNotice(res *claude.RunResult, runErr, ctxErr error, total time.Duration, resuming bool) string {
 	elapsed := formatElapsed(int64(total / time.Second))
 	switch {
+	case resuming:
+		return "⏳ Paused after " + elapsed + " — will resume after restart"
 	case ctxErr != nil && res == nil && runErr == nil:
 		return "⏹ Stopped after " + elapsed
 	case runErr != nil || (res != nil && res.IsError):

--- a/core/chat/service_test.go
+++ b/core/chat/service_test.go
@@ -635,11 +635,12 @@ func TestRunChunksLongFinal(t *testing.T) {
 	defer d.Close()
 	svc.Handle(context.Background(), "100", 100, "1", "go")
 
-	// Wait until the tail chunk has been sent (2 sends: progress + tail).
+	// Wait until the run completed: the anchor send, the tail chunk send, and the
+	// separate completion notice (the final Send) have all landed.
 	waitUntil(t, func() bool {
 		fc.mu.Lock()
 		defer fc.mu.Unlock()
-		return len(fc.sent) == 2
+		return len(fc.sent) == 3
 	})
 
 	// First chunk replaces the progress message; the remainder is a new Send.
@@ -647,6 +648,132 @@ func TestRunChunksLongFinal(t *testing.T) {
 	if utf8.RuneCountInString(first) > TelegramMaxMessage {
 		t.Fatalf("first chunk too big: %d", utf8.RuneCountInString(first))
 	}
+	// The chunk tail is a real Send (not the anchor, not the notice), so a long
+	// answer still spans multiple messages.
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	if fc.sent[0] != anchorText {
+		t.Fatalf("first send was not the anchor: %q", fc.sent[0])
+	}
+}
+
+// noticeCount reports how many of the chat's Send'd texts contain sub (used to
+// assert the completion notice is a real Send that fires exactly once).
+func (f *fakeChat) noticeCount(sub string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	n := 0
+	for _, s := range f.sent {
+		if strings.Contains(s, sub) {
+			n++
+		}
+	}
+	return n
+}
+
+// TestCompletionNoticeOnResult (AC3) asserts a normal Result delivers a SEPARATE
+// completion "Done" notice (a real Send, not only the in-place Edit) and that it
+// fires exactly once, distinct from the edited answer bubble.
+func TestCompletionNoticeOnResult(t *testing.T) {
+	fc := newFakeChat()
+	fr := &fakeRunner{events: []claude.Event{
+		{Type: claude.Result, Result: &claude.RunResult{Text: finalAnswer}},
+	}}
+	svc, d := newTestService(t, fr, fc)
+	defer d.Close()
+
+	svc.Handle(context.Background(), "100", 100, "1", "go")
+
+	// The answer reaches the anchor via Edit.
+	waitUntil(t, func() bool {
+		text, _ := fc.snapshot()
+		return text == finalAnswer
+	})
+	// A separate "Done" notice is Send'd exactly once.
+	waitUntil(t, func() bool { return fc.noticeCount("✅ Done in") == 1 })
+	if n := fc.noticeCount("✅ Done in"); n != 1 {
+		t.Fatalf("completion notice sent %d times, want exactly 1", n)
+	}
+	// It is a genuine Send distinct from the edited answer (the anchor still holds the
+	// answer, not the notice).
+	text, _ := fc.snapshot()
+	if strings.Contains(text, "✅ Done in") {
+		t.Fatalf("notice was attached to the live edit, not a separate Send: %q", text)
+	}
+}
+
+// TestCompletionNoticeFormatsTotal (AC3) drives the run with a manual clock so the
+// total elapsed is deterministic, and asserts the notice carries the humanized
+// duration from formatElapsed.
+func TestCompletionNoticeFormatsTotal(t *testing.T) {
+	fc := newFakeChat()
+	gate := make(chan struct{})
+	fr := &fakeRunner{
+		events: []claude.Event{{Type: claude.ToolUse, Tool: "Bash"}},
+		gate:   gate,
+	}
+	svc, d := newTestService(t, fr, fc)
+	defer d.Close()
+
+	clk := newManualClock()
+	svc.nowFunc = clk.now
+	svc.Handle(context.Background(), "100", 100, "1", "go")
+
+	// Wait until the run is up (anchor with Stop posted), so start has been captured
+	// at clock 0; then advance the clock and release the run. The terminal funnel reads
+	// now - start = the advanced amount.
+	waitUntil(t, func() bool {
+		_, stop := fc.snapshot()
+		return stop
+	})
+	clk.advance(125 * time.Second) // 2m 05s
+	close(gate)
+
+	want := "✅ Done in " + formatElapsed(125)
+	waitUntil(t, func() bool { return fc.noticeCount(want) == 1 })
+	if n := fc.noticeCount(want); n != 1 {
+		t.Fatalf("notice with total %q sent %d times, want exactly 1; sent=%v", want, n, fc.sent)
+	}
+}
+
+// TestCompletionNoticeOnRunError (AC3) asserts a RunError terminal delivers a
+// "Failed" completion notice as a separate Send.
+func TestCompletionNoticeOnRunError(t *testing.T) {
+	fc := newFakeChat()
+	fr := &fakeRunner{events: []claude.Event{
+		{Type: claude.RunError, Err: errors.New("boom")},
+	}}
+	svc, d := newTestService(t, fr, fc)
+	defer d.Close()
+
+	svc.Handle(context.Background(), "100", 100, "1", "go")
+
+	waitUntil(t, func() bool { return fc.noticeCount("⚠️ Failed after") == 1 })
+	if n := fc.noticeCount("⚠️ Failed after"); n != 1 {
+		t.Fatalf("RunError notice sent %d times, want exactly 1", n)
+	}
+}
+
+// TestCompletionNoticeOnStop (AC3) asserts a user Stop (ctx cancelled, no Result)
+// delivers a "Stopped" completion notice as a separate Send, fired once.
+func TestCompletionNoticeOnStop(t *testing.T) {
+	fc := newFakeChat()
+	gate := make(chan struct{})
+	fr := &fakeRunner{
+		events: []claude.Event{{Type: claude.ToolUse, Tool: "Bash"}},
+		gate:   gate,
+	}
+	svc, d := newTestService(t, fr, fc)
+	defer d.Close()
+
+	svc.Handle(context.Background(), "100", 100, "1", "go")
+	waitUntil(t, func() bool { return svc.Stop("1") })
+
+	waitUntil(t, func() bool { return fc.noticeCount("⏹ Stopped after") == 1 })
+	if n := fc.noticeCount("⏹ Stopped after"); n != 1 {
+		t.Fatalf("Stop notice sent %d times, want exactly 1", n)
+	}
+	close(gate)
 }
 
 func TestRunErrorEvent(t *testing.T) {

--- a/core/chat/service_test.go
+++ b/core/chat/service_test.go
@@ -776,6 +776,34 @@ func TestCompletionNoticeOnStop(t *testing.T) {
 	close(gate)
 }
 
+// TestCompletionNoticeStatusWords pins the status word + total for every terminal
+// case, including the deploy-shutdown "resuming" case that must read "paused …
+// will resume" (not "stopped"), since such a run keeps its marker and auto-resumes.
+func TestCompletionNoticeStatusWords(t *testing.T) {
+	const total = 4*time.Minute + 12*time.Second
+	tests := []struct {
+		name     string
+		res      *claude.RunResult
+		runErr   error
+		ctxErr   error
+		resuming bool
+		want     string
+	}{
+		{"clean result", &claude.RunResult{}, nil, nil, false, "✅ Done in 4m 12s"},
+		{"run error", nil, errors.New("boom"), nil, false, "⚠️ Failed after 4m 12s"},
+		{"is_error result", &claude.RunResult{IsError: true}, nil, nil, false, "⚠️ Failed after 4m 12s"},
+		{"user stop", nil, nil, context.Canceled, false, "⏹ Stopped after 4m 12s"},
+		{"deploy shutdown resumes", nil, nil, context.Canceled, true, "⏳ Paused after 4m 12s — will resume after restart"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := completionNotice(tc.res, tc.runErr, tc.ctxErr, total, tc.resuming); got != tc.want {
+				t.Errorf("completionNotice = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestRunErrorEvent(t *testing.T) {
 	fc := newFakeChat()
 	fr := &fakeRunner{events: []claude.Event{


### PR DESCRIPTION
## Summary
Two requested chat-visibility improvements to a run's live progress message.

**1. Stage header.** Above the activity ring, the progress message now shows which pipeline subagent is **active** (planner → coder → tester → reviewer → arbiter) plus a **trail of the distinct subagents that have run so far** — so it's clear who's doing what and which stages have participated. Example:
```
🎏 planner → coder → ▸ tester ◂
⏳ Working… (1m 20s)
…activity…
```
It is derived **purely from the `Task` tool-use events** in the run's event stream — membership + first-seen order, **no inferred round counting** (per the product decision). A plain single-prompt chat with no subagents renders **byte-identical to before** (no stage line).

**2. Completion notice.** Every terminal path now sends a **separate** message reporting the run's **total elapsed time** — which, on Telegram, actually *notifies* (an in-place edit does not, which was the original problem):
- `✅ Done in 4m 12s` · `⏹ Stopped after 1m 03s` · `⚠️ Failed after 12s`

Both adapters reuse the existing neutral `Send`/`Edit` seam — **no adapter code changed**.

## Acceptance
- **AC1** — active subagent shown above the ring from the latest `Task` event's `subagent_type`; zero Task events → no stage line (frame unchanged). ✅
- **AC2** — deterministic distinct-seen trail (first-seen order, active marked); stage changes ONLY on `Task` events; label fallback `subagent_type → description → "subagent"`; no round counting. ✅
- **AC3** — separate completion message with the real total elapsed on Result, RunError, and Stop/timeout; fires once per run. ✅
- **AC4** — no `adapters/` change; both adapters identical; existing invariants hold. ✅

## How it was verified
Repo CI runner (dockerized dev-tools): `task lint` (0 issues), `task build`, `task tests` (`go test -race ./...`) — all green, incl. new stage-header and completion-notice tests.

## Pre-PR review (internal)
coder ⇄ reviewer, **3 rounds to a clean round** (the arbiter APPROVEs only on a clean round):
- **Round 1 — caught & fixed (major):** the stage trail was unbounded and rendered in the always-kept header, so a stream with many distinct `subagent_type`s (model-controlled free text) could push the frame past the Telegram 4096-rune cap. Fixed: the stage line is now bounded by construction.
- **Round 2 — caught & fixed (2 majors):** the round-1 bound used head-keeping truncation, which **sheared the active stage off the tail** (it's the most-recent) and could leave an **unbalanced markdown `*`**. Fixed by a root-cause rewrite: atom-first assembly (the active stage is kept first and never dropped) + plain-text `▸ … ◂` markers + markdown-metachar sanitization of labels.
- **Round 3 — CLEAN:** an independent reviewer fuzzed 50k+ cases and proved every invariant (active always present & marked, balanced markers, ≤ budget, markdown-neutral on both the rich and legacy-HTML paths).

### Residual risks / needs a human eyeball
- **Not exercised in a real client** — tests use fakes; confirm the header and the new completion message *look* right in a real Telegram/VK chat (glyphs `🎏`/`▸`/`◂`, spacing) before relying on it.
- **One extra message per run** — the completion notice adds a second bubble. Notably, a **deploy-time shutdown** now also sends `⏹ Stopped after Ns` per in-flight run (intended per "every terminal path", but new user-visible behavior during deploys).
- **Observational, not authoritative** — the header reflects `Task` launches in the stream; it shows *who is active / has participated*, deliberately **not** an iteration/round number.