### PR TITLE
feat(notice): deliver the completion notice as a native reply to the answer

### DIFF
--- a/adapters/telegram/bot.go
+++ b/adapters/telegram/bot.go
@@ -115,6 +115,37 @@ func (c *botChat) Send(ctx context.Context, chatID chat.ChatID, text, stopRunID 
 		Text:        text,
 		ReplyMarkup: stopMarkup(stopRunID),
 	}
+	return c.sendParams(ctx, params, text, asMarkdown)
+}
+
+// SendReply posts text as a native reply to replyToID, carrying no Stop markup. It
+// reuses the legacy HTML/plain rendering path (the short completion notice does not
+// need the rich path, which has no reply parameter), so it shares the same
+// markdown→HTML render and parse-error plain-text fallback as Send via sendParams.
+// AllowSendingWithoutReply is set so a deleted/missing target still delivers the
+// notice as a plain message instead of erroring.
+func (c *botChat) SendReply(
+	ctx context.Context, chatID chat.ChatID, replyToID chat.MessageID, text string, asMarkdown bool,
+) (chat.MessageID, error) {
+	params := &bot.SendMessageParams{
+		ChatID: parseChatID(chatID),
+		Text:   text,
+		ReplyParameters: &models.ReplyParameters{
+			MessageID:                parseMessageID(replyToID),
+			AllowSendingWithoutReply: true,
+		},
+	}
+	return c.sendParams(ctx, params, text, asMarkdown)
+}
+
+// sendParams renders params.Text as HTML when asMarkdown is set and posts the
+// message, retrying once as plain text if Telegram rejects the HTML markup so a
+// formatting glitch never costs the user the message. text is the ORIGINAL
+// (unrendered) body used for that plain retry. It is the shared body-building tail
+// of Send and SendReply, which differ only in the markup/reply fields on params.
+func (c *botChat) sendParams(
+	ctx context.Context, params *bot.SendMessageParams, text string, asMarkdown bool,
+) (chat.MessageID, error) {
 	if asMarkdown {
 		params.Text = MarkdownToHTML(text)
 		params.ParseMode = models.ParseModeHTML
@@ -122,7 +153,7 @@ func (c *botChat) Send(ctx context.Context, chatID chat.ChatID, text, stopRunID 
 	msg, err := c.b.SendMessage(ctx, params)
 	if err != nil && asMarkdown && isParseError(err) {
 		// Telegram rejected our HTML markup: resend the ORIGINAL text as plain so a
-		// formatting glitch never costs the user the answer.
+		// formatting glitch never costs the user the message.
 		params.Text = text
 		params.ParseMode = ""
 		msg, err = c.b.SendMessage(ctx, params)

--- a/adapters/telegram/bot_reply_test.go
+++ b/adapters/telegram/bot_reply_test.go
@@ -1,0 +1,88 @@
+//nolint:testpackage // whitebox: tests the unexported SendReply rendering/reply-parameter wiring
+package telegram
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/go-telegram/bot"
+)
+
+// captureBotServer builds a *bot.Bot pointed at a fake Bot API that records the
+// last sendMessage request's form fields and always succeeds, so a test can assert
+// the reply parameters and rendered text the adapter sent. The go-telegram lib
+// encodes sendMessage as multipart form-data; reply_parameters rides as a single
+// JSON-encoded form field.
+func captureBotServer(t *testing.T, last *url.Values) *bot.Bot {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/bot123:ABC/sendMessage", func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, testBodyLimit)
+		if err := r.ParseMultipartForm(testBodyLimit); err != nil {
+			t.Errorf("parse multipart form: %v", err)
+		}
+		*last = r.Form
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"ok":     true,
+			"result": map[string]any{"message_id": 7, "chat": map[string]any{"id": 1}, "date": 0},
+		}); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	b, err := bot.New("123:ABC", bot.WithSkipGetMe(), bot.WithServerURL(srv.URL))
+	if err != nil {
+		t.Fatalf("bot.New: %v", err)
+	}
+	return b
+}
+
+// testBodyLimit bounds the parsed multipart form so the fake server stays within
+// gosec's request-size guard.
+const testBodyLimit = 4 << 20 // 4 MiB
+
+// replyParameters is the subset of the Bot API ReplyParameters the test inspects.
+type replyParameters struct {
+	MessageID                int  `json:"message_id"`                  //nolint:tagliatelle // Bot API uses snake_case.
+	AllowSendingWithoutReply bool `json:"allow_sending_without_reply"` //nolint:tagliatelle // Bot API uses snake_case.
+}
+
+// TestSendReplySetsReplyParameters (AC4) asserts SendReply targets the given
+// message id with AllowSendingWithoutReply set, and reuses the markdown→HTML
+// rendering shared with Send.
+func TestSendReplySetsReplyParameters(t *testing.T) {
+	var last url.Values
+	b := captureBotServer(t, &last)
+	c := &botChat{b: b} // rich off → legacy HTML path, which SendReply always uses
+
+	id, err := c.SendReply(context.Background(), "555", "42", "*done*", true)
+	if err != nil {
+		t.Fatalf("SendReply: %v", err)
+	}
+	if id != "7" {
+		t.Errorf("id = %q, want 7", id)
+	}
+	raw := last.Get("reply_parameters")
+	if raw == "" {
+		t.Fatalf("no reply_parameters in request form: %v", last)
+	}
+	var rp replyParameters
+	if err := json.Unmarshal([]byte(raw), &rp); err != nil {
+		t.Fatalf("decode reply_parameters %q: %v", raw, err)
+	}
+	if rp.MessageID != 42 {
+		t.Errorf("reply message_id = %d, want 42", rp.MessageID)
+	}
+	if !rp.AllowSendingWithoutReply {
+		t.Error("allow_sending_without_reply = false, want true (deleted target must still deliver)")
+	}
+	// The markdown was rendered to HTML via the shared Send path (parse_mode HTML).
+	if pm := last.Get("parse_mode"); pm != "HTML" {
+		t.Errorf("parse_mode = %q, want HTML (shared markdown rendering)", pm)
+	}
+}

--- a/adapters/vk/api.go
+++ b/adapters/vk/api.go
@@ -107,6 +107,15 @@ func isBotFeatureDisabled(err error) bool {
 	return errors.As(err, &ae) && ae.Code == errBotFeatureDisabled
 }
 
+// isFloodError reports whether err is a VK flood/rate-limit error (code 6 or 9).
+// Such errors should be retried with back-off (see RetryAfter), so a caller must
+// NOT degrade a request on them (e.g. SendReply does not drop its reply_to on a
+// flood — it lets the Service's back-off retry the reply intact).
+func isFloodError(err error) bool {
+	var ae *apiError
+	return errors.As(err, &ae) && (ae.Code == errCodeTooManyRequests || ae.Code == errCodeFloodControl)
+}
+
 // call invokes a VK API method with the given params, decoding the "response"
 // field of the envelope into out (which may be nil to discard it). The access
 // token and version are added automatically. A VK error envelope is returned as
@@ -172,12 +181,16 @@ func decodeEnvelope(method string, body []byte, out any) error {
 // MessagesSend posts a message to peerID. randomID MUST be unique per logical
 // send within ~1h (VK silently dedupes a repeated random_id); keyboard is the
 // JSON inline keyboard (empty = none) and attachment is the optional attachment
-// spec (e.g. "doc{owner}_{id}"; empty = none). It returns the GLOBAL message id
-// VK assigns, which is what Edit/Delete address (using the global message_id is
-// the least error-prone path — VK's messages.edit accepts message_id directly,
-// avoiding the conversation_message_id round-trip).
+// spec (e.g. "doc{owner}_{id}"; empty = none). replyToID, when non-zero, sets the
+// reply_to parameter to make the message a native reply to that GLOBAL message id
+// (the same id this method returns) — VK's messages.send accepts a global
+// message_id in reply_to directly, so no conversation_message_id round-trip is
+// needed. It returns the GLOBAL message id VK assigns, which is what Edit/Delete
+// address (using the global message_id is the least error-prone path — VK's
+// messages.edit accepts message_id directly, avoiding the
+// conversation_message_id round-trip).
 func (c *Client) MessagesSend(
-	ctx context.Context, peerID int64, message string, randomID int64, keyboard, attachment string,
+	ctx context.Context, peerID int64, message string, randomID int64, keyboard, attachment string, replyToID int64,
 ) (int64, error) {
 	params := url.Values{}
 	params.Set("peer_id", strconv.FormatInt(peerID, 10))
@@ -188,6 +201,9 @@ func (c *Client) MessagesSend(
 	}
 	if attachment != "" {
 		params.Set("attachment", attachment)
+	}
+	if replyToID != 0 {
+		params.Set("reply_to", strconv.FormatInt(replyToID, 10))
 	}
 	// messages.send returns the bare message id as the "response" value.
 	var msgID int64

--- a/adapters/vk/api_test.go
+++ b/adapters/vk/api_test.go
@@ -81,7 +81,7 @@ func TestMessagesSendParams(t *testing.T) {
 	})
 	c := rs.client("secret-token")
 
-	msgID, err := c.MessagesSend(context.Background(), 100, "hello", 777, `{"inline":true}`, "")
+	msgID, err := c.MessagesSend(context.Background(), 100, "hello", 777, `{"inline":true}`, "", 0)
 	if err != nil {
 		t.Fatalf("MessagesSend: %v", err)
 	}
@@ -91,6 +91,10 @@ func TestMessagesSendParams(t *testing.T) {
 	got := rs.last("messages.send")
 	if got.Get("peer_id") != "100" {
 		t.Errorf("peer_id = %q, want 100", got.Get("peer_id"))
+	}
+	// A zero replyToID must omit reply_to entirely (not send reply_to=0).
+	if got.Has("reply_to") {
+		t.Errorf("reply_to = %q, want unset for a non-reply send", got.Get("reply_to"))
 	}
 	if got.Get("message") != "hello" {
 		t.Errorf("message = %q, want hello", got.Get("message"))
@@ -142,7 +146,7 @@ func TestAPIErrorEnvelope(t *testing.T) {
 		"messages.send": `{"error": {"error_code": 9, "error_msg": "Flood control"}}`,
 	})
 	c := rs.client("tok")
-	_, err := c.MessagesSend(context.Background(), 1, "x", 1, "", "")
+	_, err := c.MessagesSend(context.Background(), 1, "x", 1, "", "", 0)
 	if err == nil {
 		t.Fatal("MessagesSend on error envelope = nil, want *apiError")
 	}

--- a/adapters/vk/bot.go
+++ b/adapters/vk/bot.go
@@ -3,7 +3,6 @@ package vk
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"io"
 	"log/slog"
 	"strconv"
@@ -93,14 +92,45 @@ func (c *botChat) Send(
 ) (chat.MessageID, error) {
 	peerID := parsePeerID(chatID)
 	keyboard := stopKeyboard(stopRunID)
-	msgID, err := c.api.MessagesSend(ctx, peerID, text, c.nextRandomID(), keyboard, "")
+	msgID, err := c.api.MessagesSend(ctx, peerID, text, c.nextRandomID(), keyboard, "", 0)
 	// VK error 912: the community has "Bot abilities" OFF, so a keyboard'd send is
 	// rejected while the same send WITHOUT a keyboard succeeds. Retry once without
 	// the keyboard (Stop then falls back to the /stop text command); the message
 	// must still be delivered. Only retry when a keyboard was actually attached.
 	if err != nil && keyboard != "" && isBotFeatureDisabled(err) {
 		c.warnKeyboardsDisabled()
-		msgID, err = c.api.MessagesSend(ctx, peerID, text, c.nextRandomID(), "", "")
+		msgID, err = c.api.MessagesSend(ctx, peerID, text, c.nextRandomID(), "", "", 0)
+	}
+	if err != nil {
+		return "", err
+	}
+	return strconv.FormatInt(msgID, 10), nil
+}
+
+// SendReply posts text as a native reply to replyToID. VK's messages.send accepts
+// the GLOBAL message id (what Send/Edit already use as the neutral MessageID) in
+// its reply_to parameter, so the reply is reliable and needs no
+// conversation_message_id round-trip. The notice carries no keyboard, so error 912
+// (bot keyboards disabled) cannot occur here. asMarkdown is IGNORED — VK has no
+// parse mode, matching Send. If the reply target was deleted VK rejects the send;
+// rather than drop the notice we fall back once to a plain send (no reply), so the
+// user still gets the completion ping. It returns the new GLOBAL message id.
+func (c *botChat) SendReply(
+	ctx context.Context, chatID chat.ChatID, replyToID chat.MessageID, text string, _ bool,
+) (chat.MessageID, error) {
+	peerID := parsePeerID(chatID)
+	replyTo := parseMessageID(replyToID)
+	// One random_id for BOTH attempts: if the reply send actually landed but its
+	// response was lost, VK dedups the plain resend against the same id rather than
+	// posting the notice twice.
+	randomID := c.nextRandomID()
+	msgID, err := c.api.MessagesSend(ctx, peerID, text, randomID, "", "", replyTo)
+	if err != nil && replyTo != 0 && !isFloodError(err) {
+		// The reply target is likely gone (deleted answer); resend without reply_to so
+		// the completion notice still reaches the user rather than being lost. A flood
+		// error is NOT degraded here — it is returned so the Service's RetryAfter
+		// back-off retries the reply intact instead of hammering a throttled endpoint.
+		msgID, err = c.api.MessagesSend(ctx, peerID, text, randomID, "", "", 0)
 	}
 	if err != nil {
 		return "", err
@@ -153,7 +183,7 @@ func (c *botChat) SendDocument(ctx context.Context, chatID chat.ChatID, name str
 	if err != nil {
 		return err
 	}
-	_, err = c.api.MessagesSend(ctx, peerID, "", c.nextRandomID(), "", attachment)
+	_, err = c.api.MessagesSend(ctx, peerID, "", c.nextRandomID(), "", attachment, 0)
 	return err
 }
 
@@ -161,7 +191,7 @@ func (c *botChat) SendDocument(ctx context.Context, chatID chat.ChatID, name str
 // button (a callback keyboard whose payload triggers the star action), mirroring
 // the Telegram nudge's separate-seam shape. It returns the new global message id.
 func (c *botChat) SendStarNudge(ctx context.Context, chatID chat.ChatID, text string) (chat.MessageID, error) {
-	msgID, err := c.api.MessagesSend(ctx, parsePeerID(chatID), text, c.nextRandomID(), starKeyboard(), "")
+	msgID, err := c.api.MessagesSend(ctx, parsePeerID(chatID), text, c.nextRandomID(), starKeyboard(), "", 0)
 	if err != nil {
 		return "", err
 	}
@@ -174,8 +204,7 @@ func (c *botChat) SendStarNudge(ctx context.Context, chatID chat.ChatID, text st
 // the neutral run loop throttles its edit fallback and backs off terminal
 // delivery without importing VK's error types.
 func RetryAfter(err error) (time.Duration, bool) {
-	var ae *apiError
-	if errors.As(err, &ae) && (ae.Code == errCodeTooManyRequests || ae.Code == errCodeFloodControl) {
+	if isFloodError(err) {
 		return floodBackoff, true
 	}
 	return 0, false

--- a/adapters/vk/bot_test.go
+++ b/adapters/vk/bot_test.go
@@ -206,6 +206,116 @@ func TestEditRetriesWithoutKeyboardOn912(t *testing.T) {
 	}
 }
 
+func TestSendReplyRepliesToGlobalMessageID(t *testing.T) {
+	// SendReply must set reply_to to the target GLOBAL message id (the same neutral
+	// MessageID Send/Edit use), carry no keyboard, and return the new message id.
+	rs := newRecordingServer(t, map[string]string{"messages.send": `{"response": 88}`})
+	c := NewBotChat(rs.client("tok"), 100, 1)
+
+	id, err := c.SendReply(context.Background(), "200", "55", "✅ Done in 4m 12s", true)
+	if err != nil {
+		t.Fatalf("SendReply: %v", err)
+	}
+	if id != "88" {
+		t.Errorf("returned id = %q, want 88", id)
+	}
+	got := rs.last("messages.send")
+	if got.Get("reply_to") != "55" {
+		t.Errorf("reply_to = %q, want the target global message id 55", got.Get("reply_to"))
+	}
+	if got.Get("keyboard") != "" {
+		t.Errorf("keyboard = %q, want none (the notice carries no Stop button)", got.Get("keyboard"))
+	}
+	if got.Get("message") != "✅ Done in 4m 12s" {
+		t.Errorf("message = %q, want the notice text", got.Get("message"))
+	}
+	if rs.count("messages.send") != 1 {
+		t.Errorf("messages.send call count = %d, want 1 (no fallback needed)", rs.count("messages.send"))
+	}
+}
+
+func TestSendReplyFallsBackToPlainWhenReplyTargetGone(t *testing.T) {
+	// When the reply target was deleted VK rejects the reply_to send; SendReply must
+	// resend once WITHOUT reply_to so the notice still reaches the user.
+	var attempts int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, testBodyLimit)
+		_ = r.ParseForm()
+		attempts++
+		if r.Form.Get("reply_to") != "" {
+			// First attempt (with reply_to) fails as if the target is gone.
+			_, _ = io.WriteString(w, `{"error": {"error_code": 100, "error_msg": "message to reply not found"}}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"response": 91}`)
+	}))
+	t.Cleanup(srv.Close)
+	c := NewBotChat(&Client{Token: "tok", BaseURL: srv.URL + "/", HTTPClient: srv.Client()}, 100, 1)
+
+	id, err := c.SendReply(context.Background(), "200", "55", "✅ Done in 1s", true)
+	if err != nil {
+		t.Fatalf("SendReply fallback = %v, want nil (plain resend should succeed)", err)
+	}
+	if id != "91" {
+		t.Errorf("returned id = %q, want 91 (the plain resend)", id)
+	}
+	if attempts != 2 {
+		t.Errorf("messages.send attempts = %d, want 2 (reply attempt + plain fallback)", attempts)
+	}
+}
+
+// TestSendReplyDoesNotFallBackOnFlood asserts a flood/rate-limit error (code 6) on
+// the reply attempt is RETURNED rather than degraded to a plain resend, so the
+// Service's RetryAfter back-off retries the reply intact instead of double-hitting
+// an already-throttled endpoint.
+func TestSendReplyDoesNotFallBackOnFlood(t *testing.T) {
+	var attempts int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, testBodyLimit)
+		_ = r.ParseForm()
+		attempts++
+		_, _ = io.WriteString(w, `{"error": {"error_code": 6, "error_msg": "too many requests per second"}}`)
+	}))
+	t.Cleanup(srv.Close)
+	c := NewBotChat(&Client{Token: "tok", BaseURL: srv.URL + "/", HTTPClient: srv.Client()}, 100, 1)
+
+	if _, err := c.SendReply(context.Background(), "200", "55", "✅ Done in 1s", true); err == nil {
+		t.Fatal("SendReply on a flood error = nil, want the error returned so RetryAfter backs off")
+	}
+	if attempts != 1 {
+		t.Errorf("messages.send attempts = %d, want 1 (a flood must NOT trigger the plain fallback)", attempts)
+	}
+}
+
+// TestSendReplyFallbackReusesRandomID asserts the plain resend reuses the SAME
+// random_id as the failed reply attempt, so VK dedups a notice that actually landed
+// before its response was lost rather than posting the completion ping twice.
+func TestSendReplyFallbackReusesRandomID(t *testing.T) {
+	var randoms []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, testBodyLimit)
+		_ = r.ParseForm()
+		randoms = append(randoms, r.Form.Get("random_id"))
+		if r.Form.Get("reply_to") != "" {
+			_, _ = io.WriteString(w, `{"error": {"error_code": 100, "error_msg": "message to reply not found"}}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"response": 91}`)
+	}))
+	t.Cleanup(srv.Close)
+	c := NewBotChat(&Client{Token: "tok", BaseURL: srv.URL + "/", HTTPClient: srv.Client()}, 100, 1)
+
+	if _, err := c.SendReply(context.Background(), "200", "55", "✅ Done in 1s", true); err != nil {
+		t.Fatalf("SendReply fallback = %v, want nil", err)
+	}
+	if len(randoms) != 2 {
+		t.Fatalf("messages.send attempts = %d, want 2 (reply + plain fallback)", len(randoms))
+	}
+	if randoms[0] != randoms[1] {
+		t.Errorf("random_id differs (reply=%q fallback=%q); want the SAME id so VK dedups a true double", randoms[0], randoms[1])
+	}
+}
+
 func TestSendDoesNotRetryNon912(t *testing.T) {
 	// A non-912 error from a keyboard'd send must propagate unchanged, with no
 	// second attempt.

--- a/adapters/vk/receiver.go
+++ b/adapters/vk/receiver.go
@@ -91,7 +91,7 @@ func NewNoticeSender(api *Client, seed int64, logger *slog.Logger) NoticeSender 
 func (n *clientNotice) Notify(ctx context.Context, peerID int64, text string) {
 	//nolint:gosec // G115: deliberate wrap into the signed random_id space; uniqueness, not range, matters.
 	randomID := n.seed + int64(n.seq.Add(1))
-	if _, err := n.api.MessagesSend(ctx, peerID, text, randomID, "", ""); err != nil {
+	if _, err := n.api.MessagesSend(ctx, peerID, text, randomID, "", "", 0); err != nil {
 		n.logger.Debug("vk: send notice", "peer_id", peerID, "error", err)
 	}
 }

--- a/core/chat/service.go
+++ b/core/chat/service.go
@@ -746,6 +746,13 @@ func (s *Service) finish(
 	// renderable (balanced ``` per chunk) on both the rich and legacy paths.
 	chunks := ChunkFencedSize(text, s.maxRunes)
 
+	// Track the id of the message that ends up holding the first answer chunk, so the
+	// completion notice can be sent as a native reply to it (tapping the "done" ping
+	// jumps to the answer). It starts as the run's own anchor; the delete+resend
+	// fallback and the no-anchor path below update it to the actual answer message id,
+	// and it stays "" if every send failed (then the notice is sent plain).
+	answerMsgID := progressMsgID
+
 	// Replace the progress message with the first chunk (clearing Stop markup);
 	// send any further chunks as new messages.
 	//nolint:nestif // the edit-then-resend fallback is a single cohesive delivery path.
@@ -760,16 +767,27 @@ func (s *Service) finish(
 			if dErr := s.chat.Delete(deliverCtx, chatID, progressMsgID); dErr != nil {
 				s.log.Debug("delete progress", "error", dErr)
 			}
+			// The anchor is gone; the answer now lives in the resent message, so the
+			// notice must reply to THAT id (or none, if the resend also failed).
+			answerMsgID = ""
 			if sErr := s.deliverWithBackoff(deliverCtx, "send final", func() error {
-				_, e := s.chat.Send(deliverCtx, chatID, chunks[0], "", true)
+				id, e := s.chat.Send(deliverCtx, chatID, chunks[0], "", true)
+				if e == nil {
+					answerMsgID = id
+				}
 				return e
 			}); sErr != nil {
 				s.log.Error("send final chunk", "error", sErr)
 			}
 		}
 	} else {
+		// No anchor existed (the initial progress Send failed): the first chunk is a
+		// fresh Send, so the notice replies to its returned id.
 		if sErr := s.deliverWithBackoff(deliverCtx, "send final", func() error {
-			_, e := s.chat.Send(deliverCtx, chatID, chunks[0], "", true)
+			id, e := s.chat.Send(deliverCtx, chatID, chunks[0], "", true)
+			if e == nil {
+				answerMsgID = id
+			}
 			return e
 		}); sErr != nil {
 			s.log.Error("send final chunk", "error", sErr)
@@ -806,8 +824,16 @@ func (s *Service) finish(
 	// notice is the deliverable that must reach the user, so it uses the same
 	// rate-limit backoff as the answer rather than a bare Send that a transient 429
 	// would silently drop.
+	// Reply the notice to this run's own answer/anchor message so tapping the "done"
+	// ping jumps to the answer bubble. When no usable answer id exists (every send
+	// failed) fall back to a plain Send so the notice still reaches the user. Either
+	// way it fires once, through the same 429-aware backoff as the answer.
 	notice := completionNotice(res, runErr, ctxErr, total, genuinelyInterrupted)
 	if sErr := s.deliverWithBackoff(deliverCtx, "completion notice", func() error {
+		if answerMsgID != "" {
+			_, e := s.chat.SendReply(deliverCtx, chatID, answerMsgID, notice, true)
+			return e
+		}
 		_, e := s.chat.Send(deliverCtx, chatID, notice, "", true)
 		return e
 	}); sErr != nil {

--- a/core/chat/service_test.go
+++ b/core/chat/service_test.go
@@ -42,16 +42,27 @@ func openRealStore(path string) (*session.FileStore, error) {
 // the final state. It is safe for concurrent use because edits arrive from the
 // ticker goroutine and the run goroutine.
 type fakeChat struct {
-	mu      sync.Mutex
-	nextID  int
-	texts   map[MessageID]string // current text per message id
-	hasStop map[MessageID]bool   // whether the message currently shows a Stop button
-	deleted map[MessageID]bool
-	sent    []string // every Send'd text, in order
-	docs    []string // every SendDocument'd filename, in order
-	nudges  []string // every SendStarNudge'd text, in order
-	editErr error    // when set, Edit returns it (e.g. a 429 to exercise throttling)
-	edits   int      // count of Edit calls (progress + final), for the throttle test
+	mu        sync.Mutex
+	nextID    int
+	texts     map[MessageID]string // current text per message id
+	hasStop   map[MessageID]bool   // whether the message currently shows a Stop button
+	deleted   map[MessageID]bool
+	sent      []string    // every Send'd AND SendReply'd text, in order
+	replies   []sentReply // every SendReply call (target id + text), in order
+	docs      []string    // every SendDocument'd filename, in order
+	nudges    []string    // every SendStarNudge'd text, in order
+	editErr   error       // when set, Edit returns it (e.g. a 429 to exercise throttling)
+	sendErr   error       // returned by the first sendFailN Send calls (no-answer-id path)
+	sendFailN int         // how many leading Send calls fail with sendErr (then Send succeeds)
+	sendCalls int         // total Send calls (failed or not), to drive sendFailN
+	edits     int         // count of Edit calls (progress + final), for the throttle test
+}
+
+// sentReply records one SendReply call so a test can assert the completion notice
+// was delivered as a reply to the expected answer/anchor message id.
+type sentReply struct {
+	replyToID MessageID
+	text      string
 }
 
 func newFakeChat() *fakeChat {
@@ -71,12 +82,47 @@ func (f *fakeChat) Capabilities() Capabilities {
 func (f *fakeChat) Send(_ context.Context, _ ChatID, text, stopRunID string, _ bool) (MessageID, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.sendCalls++
+	if f.sendErr != nil && f.sendCalls <= f.sendFailN {
+		return "", f.sendErr
+	}
 	f.nextID++
 	id := strconv.Itoa(f.nextID)
 	f.texts[id] = text
 	f.hasStop[id] = stopRunID != ""
 	f.sent = append(f.sent, text)
 	return id, nil
+}
+
+// SendReply records the reply target and text, and (like Send) appends the text to
+// f.sent so the existing notice-text assertions keep working while new tests can
+// additionally inspect the reply target via f.replies.
+func (f *fakeChat) SendReply(_ context.Context, _ ChatID, replyToID MessageID, text string, _ bool) (MessageID, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.nextID++
+	id := strconv.Itoa(f.nextID)
+	f.texts[id] = text
+	f.sent = append(f.sent, text)
+	f.replies = append(f.replies, sentReply{replyToID: replyToID, text: text})
+	return id, nil
+}
+
+// lastReply returns the most recent SendReply call and whether any was recorded.
+func (f *fakeChat) lastReply() (sentReply, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.replies) == 0 {
+		return sentReply{}, false
+	}
+	return f.replies[len(f.replies)-1], true
+}
+
+// replyCount reports how many SendReply calls the chat has received.
+func (f *fakeChat) replyCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.replies)
 }
 
 func (f *fakeChat) Edit(_ context.Context, _ ChatID, messageID MessageID, text, stopRunID string, _ bool) error {
@@ -801,6 +847,102 @@ func TestCompletionNoticeStatusWords(t *testing.T) {
 				t.Errorf("completionNotice = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+// TestCompletionNoticeRepliesToAnswer (AC1) asserts that on a normal run the
+// completion notice is delivered as a native reply whose target is the
+// answer/anchor message id (the progress bubble the bot edited into the answer).
+func TestCompletionNoticeRepliesToAnswer(t *testing.T) {
+	fc := newFakeChat()
+	fr := &fakeRunner{events: []claude.Event{
+		{Type: claude.Result, Result: &claude.RunResult{Text: finalAnswer}},
+	}}
+	svc, d := newTestService(t, fr, fc)
+	defer d.Close()
+
+	svc.Handle(context.Background(), "100", 100, "1", "go")
+
+	// The notice is sent once as a reply.
+	waitUntil(t, func() bool { return fc.replyCount() == 1 })
+	r, ok := fc.lastReply()
+	if !ok {
+		t.Fatal("completion notice was not sent as a reply")
+	}
+	// It replies to the anchor (the message the answer was edited into), and carries
+	// the same Done notice text — only the delivery changed to a reply.
+	if r.replyToID != anchorMsgID {
+		t.Errorf("notice reply target = %q, want the answer/anchor id %q", r.replyToID, anchorMsgID)
+	}
+	if !strings.Contains(r.text, "✅ Done in") {
+		t.Errorf("notice text = %q, want the Done notice", r.text)
+	}
+}
+
+// TestCompletionNoticeRepliesToResentAnswer (AC2) drives the delete+resend
+// fallback (the final edit fails) and asserts the notice replies to the RESENT
+// answer message id, not the deleted anchor id.
+func TestCompletionNoticeRepliesToResentAnswer(t *testing.T) {
+	fc := newFakeChat()
+	fc.editErr = errors.New("edit boom") // every Edit fails → final edit triggers delete+resend
+	fr := &fakeRunner{events: []claude.Event{
+		{Type: claude.Result, Result: &claude.RunResult{Text: finalAnswer}},
+	}}
+	svc, d := newTestService(t, fr, fc)
+	defer d.Close()
+
+	svc.Handle(context.Background(), "100", 100, "1", "go")
+
+	waitUntil(t, func() bool { return fc.replyCount() == 1 })
+	r, ok := fc.lastReply()
+	if !ok {
+		t.Fatal("completion notice was not sent as a reply")
+	}
+	// The anchor (id 1) was deleted and the answer resent as a new message (id 2);
+	// the notice must reply to the RESENT id, never the deleted anchor.
+	if r.replyToID == anchorMsgID {
+		t.Fatalf("notice replied to the DELETED anchor id %q; want the resent answer id", anchorMsgID)
+	}
+	fc.mu.Lock()
+	deleted := fc.deleted[anchorMsgID]
+	fc.mu.Unlock()
+	if !deleted {
+		t.Fatal("expected the anchor to be deleted on the resend fallback")
+	}
+	// The resent answer is the message after the deleted anchor (id 2).
+	if r.replyToID != "2" {
+		t.Errorf("notice reply target = %q, want the resent answer id %q", r.replyToID, "2")
+	}
+	if !strings.Contains(r.text, "✅ Done in") {
+		t.Errorf("notice text = %q, want the Done notice", r.text)
+	}
+}
+
+// TestCompletionNoticeSentPlainWhenNoAnswerID (AC3) drives the path where no usable
+// answer id exists (the anchor send and the final-chunk send both fail): the notice
+// must be sent as a PLAIN message (no reply), still exactly once, via backoff, and
+// the run must not panic.
+func TestCompletionNoticeSentPlainWhenNoAnswerID(t *testing.T) {
+	fc := newFakeChat()
+	// Fail the first two Send calls (the anchor and the resent/first answer chunk) so
+	// answerMsgID is never established; the third Send (the notice) succeeds.
+	fc.sendErr = errors.New("send boom")
+	fc.sendFailN = 2
+	fr := &fakeRunner{events: []claude.Event{
+		{Type: claude.Result, Result: &claude.RunResult{Text: finalAnswer}},
+	}}
+	svc, d := newTestService(t, fr, fc)
+	defer d.Close()
+
+	svc.Handle(context.Background(), "100", 100, "1", "go")
+
+	// The notice lands as a plain Send (recorded in f.sent), and NO reply is ever made.
+	waitUntil(t, func() bool { return fc.noticeCount("✅ Done in") == 1 })
+	if n := fc.noticeCount("✅ Done in"); n != 1 {
+		t.Fatalf("plain notice sent %d times, want exactly 1", n)
+	}
+	if rc := fc.replyCount(); rc != 0 {
+		t.Fatalf("notice was sent as a reply %d times; want a PLAIN send when no answer id exists", rc)
 	}
 }
 

--- a/core/chat/transport.go
+++ b/core/chat/transport.go
@@ -31,6 +31,17 @@ type Transport interface {
 	// asMarkdown is true the text is rendered as the platform's rich format (with a
 	// plain-text fallback on a parse error); false sends it verbatim as plain text.
 	Send(ctx context.Context, chatID ChatID, text, stopRunID string, asMarkdown bool) (messageID MessageID, err error)
+	// SendReply posts a new message as a native reply to replyToID (so tapping it
+	// jumps to that message), carrying no Stop markup, and returns its id. It is a
+	// sibling of Send rather than an extra Send parameter so existing Send call
+	// sites and fakes stay untouched. asMarkdown behaves as for Send. If replyToID
+	// no longer exists the platform must still deliver the message without the reply
+	// (Telegram: allow_sending_without_reply); a platform that cannot reply to the
+	// id at all falls back to a plain send. Used for the completion notice, which
+	// replies to the run's own answer/anchor message.
+	SendReply(
+		ctx context.Context, chatID ChatID, replyToID MessageID, text string, asMarkdown bool,
+	) (messageID MessageID, err error)
 	// Edit updates an existing message's text (and Stop markup, when stopRunID is
 	// non-empty; empty clears the markup). asMarkdown behaves as for Send.
 	Edit(ctx context.Context, chatID ChatID, messageID MessageID, text, stopRunID string, asMarkdown bool) error


### PR DESCRIPTION
## Summary
The run-completion notice (`✅ Done in Ns` / `⏹ Stopped after Ns` / `⏳ Paused after Ns — will resume after restart` / `⚠️ Failed after Ns`) is now a **native reply to the bot's own progress/answer message** — the live "Working…" bubble that gets edited into the final answer. So when the "done" ping arrives, tapping it jumps straight to the answer it refers to. This is the reliable target (the run's own anchor), not the racy `lastMsg`.

## What changed
- **`Transport.SendReply(ctx, chatID, replyToID, text, asMarkdown)`** — a sibling to `Send`, so existing `Send` call sites and fakes are untouched (minimal interface widening).
- **Telegram**: `ReplyParameters{MessageID, AllowSendingWithoutReply: true}` — a deleted/missing target still delivers the notice (server-side, single call) instead of erroring. `Send`/`SendReply` share an extracted `sendParams` tail (no duplication).
- **VK**: replies via `messages.send` `reply_to` using the same global message id `Send`/`Edit` already address. If the target is gone it resends once without `reply_to`; the reply attempt and that resend **share one `random_id`** so VK dedups a notice that landed but lost its response; a **flood error (6/9) is returned, not degraded**, so the Service's `RetryAfter` retries the reply intact rather than double-hitting a throttled endpoint.
- **`finish()`** tracks the real answer message id across all paths (normal edit → anchor; edit-fail → delete+resend → resent id; no-anchor → fresh-send id; all-failed → `""` → plain notice) and replies to it, still wrapped in `deliverWithBackoff` (fires once, 429-aware).

## Acceptance
- **AC1** — notice replies to the answer/anchor message id. ✅
- **AC2** — on the delete+resend fallback, it replies to the RESENT id, never the deleted anchor. ✅
- **AC3** — no usable id ⇒ plain notice, still once, no panic. ✅
- **AC4** — both adapters implement `SendReply`; Telegram uses `AllowSendingWithoutReply`; VK reply + plain fallback; no `Send` call site/behaviour changed. ✅

## How it was verified
Repo CI runner (dockerized dev-tools): `task lint` (0 issues), `task vet`, `task build`, `task tests` (`go test -race ./...`) — all green, incl. new Telegram reply-param and VK reply/fallback/flood/random-id tests.

## Pre-PR review (internal)
coder → reviewer (APPROVE, clean — surfaced two VK-fallback minors) → coder fixed both → focused re-review (CLEAN). The two fixes: reuse one `random_id` across the reply+plain pair (dedup a true double) and don't degrade on a flood (let `RetryAfter` retry the reply). Also caught: `task build` only builds the Telegram binary, so the VK package's unused-import error surfaced only under `task vet`/`tests` — fixed.

### Residual risks / needs a human eyeball
- **VK `reply_to` is live-unverified.** The claim that VK `messages.send reply_to` accepts the bot's own **global** message id (not a `conversation_message_id`) is exercised only against a fake server; it is internally consistent (the same global id already round-trips through `messages.edit`/`messages.delete`). Confirm on a real VK community; the plain-resend fallback guarantees the notice still delivers regardless, so the reply itself is best-effort on VK.
- **Telegram** path is clean and standard (`reply_to_message_id` with `allow_sending_without_reply`).
- Cosmetic: the notice is now a second bubble that *replies* — on a very long answer that overflowed into multiple chunks, the reply points at the FIRST (anchor) chunk, which holds the start of the answer.