### PR TITLE
feat(schedule): scheduler on by default + Lead hands users a ready /schedule command

### DIFF
--- a/adapters/telegram/.env.example
+++ b/adapters/telegram/.env.example
@@ -73,15 +73,16 @@ VOICE_PROVIDER=mistral         # mistral | openai | local
 MISTRAL_API_KEY=               # for VOICE_PROVIDER=mistral (console.mistral.ai)
 # OPENAI_API_KEY=              # for VOICE_PROVIDER=openai
 
-# ===== SCHEDULER (optional) — durable per-chat cron jobs =====
-# false (default) = off: no background scheduler (no store, no goroutine). /schedule
-# stays in the command menu but only replies that it is disabled.
-# true = enable /schedule (list/show/add/remove/pause/resume/tz) and a background loop
-# that fires each due job's prompt into its chat, just like a user message. Cron is a
-# 5-field spec (min hour day-of-month month day-of-week) evaluated in the chat's
-# timezone (/schedule tz <IANA>), else the server's LOCAL zone (UTC in the default
-# container).
-ENABLE_SCHEDULER=false
+# ===== SCHEDULER — durable per-chat cron jobs (ON by default) =====
+# /schedule (list/show/add/remove/pause/resume/tz) lets a user register a recurring
+# prompt the bot fires into the chat on a cron schedule — a 5-field spec
+# (min hour day-of-month month day-of-week) evaluated in the chat's timezone
+# (/schedule tz <IANA>), else the server's LOCAL zone (UTC in the default container).
+# Jobs run UNATTENDED and incur model cost, but nothing fires until a user deliberately
+# does /schedule add (allow-list gated, capped, cost-metered). Set ENABLE_SCHEDULER=false
+# to disable the scheduler entirely (no store, no background loop; /schedule then just
+# replies that it is disabled).
+# ENABLE_SCHEDULER=false
 # SCHEDULE_STORE_PATH=          # JSON job store; default <APPROVED_DIRECTORY>/schedules.json
 
 # ===== DOCKER-IN-DOCKER (optional, with `--profile dind`) — dockerized linters/tests for the team =====

--- a/adapters/vk/.env.example
+++ b/adapters/vk/.env.example
@@ -60,15 +60,16 @@ VOICE_PROVIDER=mistral         # mistral | openai | local
 MISTRAL_API_KEY=               # for VOICE_PROVIDER=mistral (console.mistral.ai)
 # OPENAI_API_KEY=              # for VOICE_PROVIDER=openai
 
-# ===== SCHEDULER (optional) — durable per-chat cron jobs =====
-# false (default) = off: no background scheduler (no store, no goroutine). /schedule
-# stays a bot command but only replies that it is disabled.
-# true = enable /schedule (list/show/add/remove/pause/resume/tz) and a background loop
-# that fires each due job's prompt into its chat, just like a user message. Cron is a
-# 5-field spec (min hour day-of-month month day-of-week) evaluated in the chat's
-# timezone (/schedule tz <IANA>), else the server's LOCAL zone (UTC in the default
-# container).
-ENABLE_SCHEDULER=false
+# ===== SCHEDULER — durable per-chat cron jobs (ON by default) =====
+# /schedule (list/show/add/remove/pause/resume/tz) lets a user register a recurring
+# prompt the bot fires into the chat on a cron schedule — a 5-field spec
+# (min hour day-of-month month day-of-week) evaluated in the chat's timezone
+# (/schedule tz <IANA>), else the server's LOCAL zone (UTC in the default container).
+# Jobs run UNATTENDED and incur model cost, but nothing fires until a user deliberately
+# does /schedule add (allow-list gated, capped, cost-metered). Set ENABLE_SCHEDULER=false
+# to disable the scheduler entirely (no store, no background loop; /schedule then just
+# replies that it is disabled).
+# ENABLE_SCHEDULER=false
 # SCHEDULE_STORE_PATH=          # JSON job store; default <APPROVED_DIRECTORY>/schedules.json
 
 # ===== DOCKER-IN-DOCKER (optional, with `--profile dind`) — dockerized linters/tests for the team =====

--- a/core/CLAUDE.workspace.md.tmpl
+++ b/core/CLAUDE.workspace.md.tmpl
@@ -52,6 +52,32 @@ work, including quick direct tasks that skip the full pipeline — use them.
   actually depends on. A stale-API guess is a top source of subtly-wrong code; a quick docs
   lookup beats a wrong guess you then have to debug.
 
+## Scheduling recurring tasks — hand the user a ready `/schedule` command
+
+The bot has a built-in scheduler: a user can register a recurring prompt that fires into THIS
+chat on a cron schedule (it runs unattended and posts the result here). It is driven by the
+reserved **`/schedule`** command, which the bot handles itself — it is NOT a tool you can call,
+and you cannot create a job. So when a user asks for anything recurring/scheduled ("каждый
+понедельник делай отчёт", "remind me every morning", "run X hourly"), DON'T claim you'll do it
+on a timer and DON'T try — instead **translate their request into the exact command and give it
+to them to send**, then they paste it. Produce a ready-to-send line of this shape:
+
+    /schedule add "<short name>" <min> <hour> <day-of-month> <month> <day-of-week> <the prompt…>
+
+Cron is 5 fields — minute(0-59) hour(0-23) day-of-month(1-31) month(1-12) day-of-week(0-6, **0=Sun**);
+each takes `*`, `n`, `a-b`, an `a,b` list, or a `*/n` step. Sunday is `0`, never `7`. When BOTH
+day-of-month and day-of-week are restricted a job fires only when they BOTH match — restrict at
+most one. Quote a multi-word name. Times use the chat's timezone — tell the user to set it once
+with `/schedule tz <IANA>` (e.g. `Europe/Moscow`); otherwise it's the server zone (UTC).
+Examples: weekdays 09:00 → `0 9 * * 1-5`; Monday 10:00 → `0 10 * * 1`; hourly → `0 * * * *`;
+every 15 min → `*/15 * * * *`.
+
+Give the full command with their real time translated to cron and a concrete prompt, plus one
+short line on what it does and how to manage it (`/schedule list`, `show <id>`, `pause <id>`,
+`remove <id>`). If the time or day is ambiguous, ask ONE clarifying question rather than guess.
+(If `/schedule` ever replies that the scheduler is disabled, tell the user to set
+`ENABLE_SCHEDULER=true` — but it is on by default.)
+
 ## Building a feature (the dev team) — TWO PHASES
 
 When the user asks you to implement / add / build / fix something, act as the **Lead** and run

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -99,13 +99,16 @@ type Config struct {
 	SessionStorePath string `env:"SESSION_STORE_PATH"`
 
 	// EnableScheduler gates the /schedule command and its background cron
-	// scheduler. OFF by default: with the flag off no schedule store is opened and
-	// no scheduler goroutine runs (the background side is a true no-op). /schedule
-	// itself stays a reserved, bot-owned command — it remains in the command menu
-	// and replies with a "disabled" notice rather than being forwarded to the model.
-	// Set ENABLE_SCHEDULER=true to enable durable per-chat cron jobs (see
-	// SchedulerEnabled).
-	EnableScheduler bool `env:"ENABLE_SCHEDULER" envDefault:"false"`
+	// scheduler. ON by default — durable per-chat cron jobs work out of the box.
+	// Set ENABLE_SCHEDULER=false to disable: no schedule store is opened and no
+	// scheduler goroutine runs (a true no-op), and /schedule (still a reserved,
+	// bot-owned command) replies with a "disabled" notice rather than reaching the
+	// model. The off switch is kept on purpose: scheduled jobs run UNATTENDED and
+	// incur model cost, so an operator can kill the whole scheduler with one env
+	// change. Job creation is still always a deliberate /schedule add (allow-list
+	// gated, capped, cost-metered), so default-on never schedules anything by
+	// itself.
+	EnableScheduler bool `env:"ENABLE_SCHEDULER" envDefault:"true"`
 
 	// ScheduleStorePath is the JSON file persisting chatID -> the chat's cron jobs,
 	// reloaded on startup so scheduled jobs survive a restart. When empty it

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -99,6 +99,11 @@ func TestTeamConfigDefaults(t *testing.T) {
 	if cfg.TeamTemplatePath != "/opt/duck/CLAUDE.workspace.md.tmpl" || cfg.TeamAgentsDir != "/opt/duck/agents" {
 		t.Fatalf("team source defaults = %q/%q", cfg.TeamTemplatePath, cfg.TeamAgentsDir)
 	}
+	// The scheduler is ON by default (durable per-chat cron jobs work out of the
+	// box); ENABLE_SCHEDULER=false is the explicit off switch.
+	if !cfg.SchedulerEnabled() {
+		t.Fatal("SchedulerEnabled default = false, want true (scheduler on by default)")
+	}
 	// REQUIRE_GROUP_MENTION defaults to false to match the Python adapter's
 	// .env.example / mention_gate.py (answer every group message by default).
 	if cfg.RequireGroupMention {


### PR DESCRIPTION
## Summary
Two small changes so users get the scheduler with minimal friction (no buttons — that's a separate, bigger effort).

1. **Scheduler ON by default.** `ENABLE_SCHEDULER` default flips `false → true`, so `/schedule` works out of the box. `ENABLE_SCHEDULER=false` is kept as an explicit **off switch** (no store, no goroutine, `/schedule` replies "disabled") because scheduled jobs run **unattended and cost money** — an operator can kill the whole scheduler with one env change. Default-on **schedules nothing by itself**: job creation is always a deliberate `/schedule add` (allow-list gated, capped at 25/chat, cost-metered to the creator — from #51). Both `.env.example` files now **comment out** the `ENABLE_SCHEDULER` line so copying `.env` no longer forces it back off.

2. **The Lead now guides users to the command.** A new section in `core/CLAUDE.workspace.md.tmpl` tells the bot's Lead that `/schedule` exists and — since it's a reserved command the Lead can't call — to **translate a user's natural-language recurring request into cron and hand them the exact `/schedule add …` line** to send. It includes the correct cron facts (5 fields, dow 0-6/0=Sun, dom+dow AND-semantics, timezone, quoted names) so generated commands are valid. (So "сделай отчёт каждый понедельник в 10" → the bot replies with `/schedule add "отчёт" 0 10 * * 1 …` ready to paste.)

## Acceptance
- **AC1** — with `ENABLE_SCHEDULER` unset the scheduler is on (`SchedulerEnabled()==true`); `=false` still fully disables it. Pinned by a config default test that fails if reverted. ✅
- **AC2** — `.env.example` (both adapters) no longer forces off on copy (line commented). ✅
- **AC3** — the Lead is instructed to produce a correct, ready-to-send `/schedule add` command from natural language and NOT to claim it scheduled anything itself. ✅

## How it was verified
`task lint` (0), `task vet`, `task tests` (`go test -race ./...`) — all green, incl. the new default-on assertion. The template renderer is `strings.NewReplacer` (not `text/template`), so the new prose's backticks / `*/n` cron syntax are inert — confirmed.

## Pre-PR review
Reviewer (fresh context) — **CLEAN, zero findings**: both `.env` lines commented (no default contradiction), config doc/test/gating consistent, every cron fact and example verified against the real `core/schedule` parser, no stale "off by default" reference anywhere in the repo (compose/Ansible/README/docs all clear).

### Residual risks / needs a human eyeball
- **Operator-facing default change.** Every deployment that pulls `:latest` and doesn't set `ENABLE_SCHEDULER=false` now runs the background scheduler loop and exposes `/schedule`. Nothing fires without a deliberate `/schedule add`, but the capability is live by default — confirm that's the intended posture for the public image (the alternative is keeping it default-off and just enabling it in your own deployment).
- The Lead's NL→cron translation is model judgment; the template gives it the correct rules, but a user should sanity-check the cron in the command before sending.