### PR TITLE
feat(progress): attribute live progress to dev-team subagents

### DIFF
--- a/core/chat/progress.go
+++ b/core/chat/progress.go
@@ -213,12 +213,19 @@ type Progress struct {
 	// stages is the deterministic trail of DISTINCT subagent labels seen, in
 	// first-seen order — pure membership taken from the stream, not an inferred
 	// round count. activeStage indexes the currently running subagent within it
-	// (the most recent Task launch). Both stay empty for a plain chat with no Task
-	// events, so the stage line is omitted and the frame is byte-identical to a
-	// non-pipeline run. State changes ONLY on a Tool=="Task" ToolUse (see Observe);
-	// inner subagent tool events never flip the active stage.
+	// (the most recent Task/Agent launch). Both stay empty for a plain chat with no
+	// subagent launches, so the stage line is omitted and the frame is byte-identical
+	// to a non-pipeline run. State changes ONLY on a Tool=="Task"/"Agent" ToolUse (see
+	// Observe); inner subagent tool events never flip the active stage.
 	stages      []string
 	activeStage int
+	// subagentByToolID maps a launching Agent/Task tool_use id (Event.ToolID) to the
+	// subagent label it spawned, so an inner event whose Event.ParentID matches can be
+	// tagged with that label (see activityLine). It is populated only when a launch
+	// carries a non-empty ToolID; it stays nil/empty when the live stream omits
+	// tool_use ids or parent_tool_use_id, in which case per-line attribution is a
+	// no-op with zero regression.
+	subagentByToolID map[string]string
 }
 
 // NewProgress returns a Progress whose header counter reads from elapsed, the
@@ -244,20 +251,46 @@ func NewProgress(elapsed func() time.Duration, ringSize int, baseDir string) *Pr
 // Final / FinalError to render the terminal message. It reports whether the
 // activity ring changed, so callers can skip a redundant edit.
 func (p *Progress) Observe(e claude.Event) bool {
-	// A Task launch (the Lead spawning a dev-team subagent) advances the stage
-	// header. This is the ONLY event that changes the active stage: inner subagent
-	// tool events arrive flat at the top level (the decoder ignores
-	// parent_tool_use_id), so they are ordinary ToolUse events with a non-Task tool
-	// name and must not flip the active stage.
-	if e.Type == claude.ToolUse && strings.EqualFold(e.Tool, "task") {
-		p.advanceStage(subagentLabel(e.ToolInput))
+	// A subagent launch (the Lead spawning a dev-team subagent — via the Task OR the
+	// Agent tool, depending on the harness) advances the stage header. This is the
+	// ONLY event that changes the active stage: an inner subagent's own tool events
+	// arrive flat at the top level (linked back only by ParentID), so they are
+	// ordinary ToolUse events with a non-task/agent tool name and must not flip the
+	// active stage. When the launch carries a tool_use id, remember it so the
+	// subagent's inner activity lines can be attributed to it (see activityLine).
+	if e.Type == claude.ToolUse && isSubagentLaunch(e.Tool) {
+		label := subagentLabel(e.ToolInput)
+		p.advanceStage(label)
+		if e.ToolID != "" {
+			if p.subagentByToolID == nil {
+				p.subagentByToolID = make(map[string]string)
+			}
+			p.subagentByToolID[e.ToolID] = label
+		}
 	}
-	line, ok := activityLine(e, p.baseDir)
+	line, ok := activityLine(e, p.baseDir, p.subagentLabelFor(e.ParentID))
 	if !ok {
 		return false
 	}
 	p.push(line)
 	return true
+}
+
+// isSubagentLaunch reports whether a tool name is a dev-team subagent launch. Both
+// the Task tool and the Agent tool spawn a subagent (the harness picks one), so
+// either advances the stage trail; every other tool is ordinary inner activity.
+func isSubagentLaunch(tool string) bool {
+	return strings.EqualFold(tool, "task") || strings.EqualFold(tool, "agent")
+}
+
+// subagentLabelFor returns the subagent label remembered for parentID (a launching
+// Agent/Task tool_use id), or "" when parentID is empty or not a known launch. A
+// returned label tags the event's activity line with the subagent that produced it.
+func (p *Progress) subagentLabelFor(parentID string) string {
+	if parentID == "" {
+		return ""
+	}
+	return p.subagentByToolID[parentID]
 }
 
 // advanceStage records label as the currently active subagent, appending it to the
@@ -323,7 +356,13 @@ func sanitizeStageLabel(label string) string {
 // upper bound (recentSnippetMax) when stored — enough for any ring position — and
 // Frame() re-caps it tighter per recency. The emoji prefix is added on top of the
 // text budget, so it is never split or counted against the cap.
-func activityLine(e claude.Event, baseDir string) (string, bool) {
+//
+// subagentTag, when non-empty, is the dev-team subagent the event was produced
+// inside (resolved from the event's ParentID); it is prepended to the line BODY,
+// right after the emoji prefix ("⌨️ coder ▸ Bash"), so the tag survives the recency
+// re-cap and the prefix-peeling in capLine. An empty tag (a top-level event, or
+// a stream that omits parent linkage) renders EXACTLY as before — byte-identical.
+func activityLine(e claude.Event, baseDir, subagentTag string) (string, bool) {
 	switch e.Type {
 	case claude.ToolUse:
 		tool := e.Tool
@@ -339,7 +378,7 @@ func activityLine(e claude.Event, baseDir string) (string, bool) {
 				line += toolDetailSeparator + detail
 			}
 		}
-		return toolLinePrefix(tool) + truncateRunes(line, recentSnippetMax), true
+		return toolLinePrefix(tool) + withSubagentTag(subagentTag, truncateRunes(line, recentSnippetMax)), true
 	case claude.Text:
 		// Model "thought" text is free-form prose, not a CLI-shaped command, so it is
 		// shown verbatim and deliberately NOT run through redactSecrets: the keyword
@@ -351,11 +390,30 @@ func activityLine(e claude.Event, baseDir string) (string, bool) {
 		if snippet == "" {
 			return "", false
 		}
-		return thoughtPrefix + truncateRunes(snippet, recentSnippetMax), true
+		return thoughtPrefix + withSubagentTag(subagentTag, truncateRunes(snippet, recentSnippetMax)), true
 	default:
 		// SystemInit, ToolResult, Result, RunError: no activity line.
 		return "", false
 	}
+}
+
+// subagentTagSeparator joins a subagent label to the activity it produced:
+// "coder ▸ Bash · …". It is a plain-text marker (no markdown metacharacters) so it
+// can never desync the rich-markdown parser the live frame is sent on.
+const subagentTagSeparator = " ▸ "
+
+// withSubagentTag prepends the subagent label (sanitized markdown-safe) to a line
+// body so an inner subagent's activity reads "coder ▸ Bash · …". The tag goes at the
+// HEAD of the body — after the caller's emoji prefix, before the tool/thought text —
+// so it survives the tail-truncation in capLine/Frame and capLine's emoji-prefix
+// peeling still works unchanged. An empty label is a no-op: the body is returned
+// untouched, so a top-level event renders byte-identical to before this feature.
+func withSubagentTag(label, body string) string {
+	if label == "" {
+		return body
+	}
+	clean := sanitizeStageLabel(label)
+	return clean + subagentTagSeparator + body
 }
 
 // toolDetail extracts a short, human-readable detail from a tool's JSON input so a

--- a/core/chat/progress.go
+++ b/core/chat/progress.go
@@ -224,7 +224,10 @@ type Progress struct {
 	// tagged with that label (see activityLine). It is populated only when a launch
 	// carries a non-empty ToolID; it stays nil/empty when the live stream omits
 	// tool_use ids or parent_tool_use_id, in which case per-line attribution is a
-	// no-op with zero regression.
+	// no-op with zero regression. Attribution assumes the launching tool_use envelope
+	// is decoded BEFORE any inner envelope carrying its id as parent_tool_use_id (the
+	// CLI guarantees this ordering); out-of-order arrival degrades to an untagged line
+	// (a benign no-op).
 	subagentByToolID map[string]string
 }
 
@@ -408,6 +411,10 @@ const subagentTagSeparator = " ▸ "
 // so it survives the tail-truncation in capLine/Frame and capLine's emoji-prefix
 // peeling still works unchanged. An empty label is a no-op: the body is returned
 // untouched, so a top-level event renders byte-identical to before this feature.
+//
+// The tag consumes line budget, so an attributed line's content is truncated
+// ~tag-length earlier than the byte-identical untagged line — intentional, since the
+// attribution is higher-signal than the trailing chars of a long command.
 func withSubagentTag(label, body string) string {
 	if label == "" {
 		return body

--- a/core/chat/progress_test.go
+++ b/core/chat/progress_test.go
@@ -794,13 +794,20 @@ func TestElidedIndicatorCountsBudgetDrops(t *testing.T) {
 }
 
 // taskEvent builds a Task ToolUse event carrying the given subagent_type, the way
-// the Lead's subagent launches surface in the stream (AC1/AC2).
-func taskEvent(subagentType string) claude.Event {
-	return claude.Event{
+// the Lead's subagent launches surface in the stream (AC1/AC2). An optional toolID
+// (the first variadic arg) sets the launch's tool_use id — what an inner event later
+// echoes as its ParentID, so the inner activity can be attributed back to this
+// subagent (AC3). Omitting it keeps the existing no-id call sites unchanged.
+func taskEvent(subagentType string, toolID ...string) claude.Event {
+	e := claude.Event{
 		Type:      claude.ToolUse,
 		Tool:      "Task",
 		ToolInput: []byte(`{"subagent_type":"` + subagentType + `"}`),
 	}
+	if len(toolID) > 0 {
+		e.ToolID = toolID[0]
+	}
+	return e
 }
 
 // agentEvent builds an Agent ToolUse launch carrying the given subagent_type and
@@ -997,6 +1004,124 @@ func TestActivityLineUnknownParentNoTag(t *testing.T) {
 	}
 	if !strings.Contains(frame, "⌨️ Bash") {
 		t.Fatalf("expected a plain Bash line for an unknown parent: %q", frame)
+	}
+}
+
+// TestActivityLineTagSurvivesTruncation (AC3) is the load-bearing property test for
+// the HEAD-anchored subagent tag: because the tag is prepended to the body (right
+// after the emoji prefix), it survives both capLine's tail-truncation and the older-
+// line recency re-cap to olderSnippetMax. We attribute a thought event whose body far
+// exceeds olderSnippetMax (400) — a tool-detail line cannot, since toolDetail self-caps
+// at toolDetailMax (160), so a thought is the only body long enough to force the 400-cap
+// truncation — then push enough later lines to shove the tagged line into an OLDER
+// (non-most-recent) ring slot. The rendered older line must STILL begin with the emoji
+// prefix + "coder" + the tag separator (the tag survived) AND end with the ellipsis
+// (the body tail was cut), proving tag-survival, not just that a short tagged line renders.
+func TestActivityLineTagSurvivesTruncation(t *testing.T) {
+	var elapsed time.Duration
+	p := NewProgress(fakeClock(&elapsed), 5, "")
+	p.Observe(agentEvent("coder", "toolu_1"))
+
+	// A long inner thought attributed to the coder subagent. Its body (after the head
+	// tag) must comfortably exceed olderSnippetMax so the 400-cap actually truncates it.
+	longBody := strings.Repeat("z", olderSnippetMax+300)
+	if !p.Observe(claude.Event{Type: claude.Text, Text: longBody, ParentID: "toolu_1"}) {
+		t.Fatal("expected the inner thought event to push an activity line")
+	}
+	// Sanity: the STORED body (emoji prefix peeled) really exceeds olderSnippetMax before
+	// any re-cap, so the older-line truncation below is genuinely exercised.
+	stored := p.ring[len(p.ring)-1]
+	storedBody := strings.TrimPrefix(stored, thoughtPrefix)
+	if n := utf8.RuneCountInString(storedBody); n <= olderSnippetMax {
+		t.Fatalf("stored tagged body = %d runes, must exceed olderSnippetMax %d to test truncation", n, olderSnippetMax)
+	}
+
+	// Push additional lines so the tagged line leaves the most-recent slot for an OLDER
+	// ring position (where it is re-capped to olderSnippetMax), while staying inside the
+	// 5-slot ring — the launch line + the tagged thought + these three fill it exactly.
+	for i := 0; i < 3; i++ {
+		p.Observe(claude.Event{Type: claude.ToolUse, Tool: "Bash"})
+	}
+
+	var taggedOlder string
+	for _, line := range strings.Split(p.Frame(), "\n") {
+		if strings.HasPrefix(line, thoughtPrefix+"coder"+subagentTagSeparator) {
+			taggedOlder = line
+		}
+	}
+	if taggedOlder == "" {
+		t.Fatalf("tagged older line not found in frame: %q", p.Frame())
+	}
+	// The tag survived to the HEAD of the older, truncated line.
+	if !strings.HasPrefix(taggedOlder, thoughtPrefix+"coder"+subagentTagSeparator) {
+		t.Fatalf("tag did not survive at the head of the older line: %q", taggedOlder)
+	}
+	// And the body tail was cut: the line ends with the truncation ellipsis.
+	if !strings.HasSuffix(taggedOlder, "…") {
+		t.Fatalf("older tagged line should be tail-truncated with an ellipsis: %q", taggedOlder)
+	}
+	// The older line is capped to olderSnippetMax text runes (prefix rides on top), so the
+	// tag genuinely traded line budget against the body tail rather than expanding the cap.
+	prefixRunes := utf8.RuneCountInString(thoughtPrefix)
+	if n := utf8.RuneCountInString(taggedOlder) - prefixRunes; n != olderSnippetMax {
+		t.Fatalf("older tagged line text = %d runes, want olderSnippetMax %d", n, olderSnippetMax)
+	}
+}
+
+// TestActivityLineTagMarkdownSanitized (AC3) pins the markdown-sanitization of the tag
+// directly on the PER-LINE attribution path (not just transitively via the stage line):
+// a subagent label full of markdown metacharacters from stageLabelMeta must be stripped
+// before it is prepended to the body, so the tag can never inject inline markup into the
+// rich-markdown frame. This is the one NEW injection surface the per-line tag adds.
+func TestActivityLineTagMarkdownSanitized(t *testing.T) {
+	var elapsed time.Duration
+	p := NewProgress(fakeClock(&elapsed), 5, "")
+	// A label peppered with markdown metacharacters around readable content. Stripping
+	// stageLabelMeta ("*_~`|=[]<>") from "a*b_c~d`|" leaves "abcd".
+	rawLabel := "a*b_c~d`|"
+	p.Observe(agentEvent(rawLabel, "toolu_2"))
+	p.Observe(claude.Event{Type: claude.ToolUse, Tool: "Bash", ParentID: "toolu_2"})
+
+	var tagged string
+	for _, line := range strings.Split(p.Frame(), "\n") {
+		if strings.Contains(line, subagentTagSeparator) {
+			tagged = line
+		}
+	}
+	if tagged == "" {
+		t.Fatalf("no tagged activity line found: %q", p.Frame())
+	}
+	// The tag carries the SANITIZED label (what sanitizeStageLabel actually produces for
+	// this input) ahead of the separator.
+	wantClean := sanitizeStageLabel(rawLabel)
+	if wantClean != "abcd" {
+		t.Fatalf("precondition: sanitizeStageLabel(%q) = %q, want %q", rawLabel, wantClean, "abcd")
+	}
+	if !strings.Contains(tagged, wantClean+subagentTagSeparator) {
+		t.Fatalf("sanitized label %q not at the head of the tag: %q", wantClean, tagged)
+	}
+	// None of the stripped metacharacters survive into the rendered line.
+	for _, meta := range strings.Split(stageLabelMeta, "") {
+		if strings.Contains(tagged, meta) {
+			t.Fatalf("stripped metacharacter %q leaked into the tagged line: %q", meta, tagged)
+		}
+	}
+}
+
+// TestActivityLineTaskLaunchAttribution (AC3) locks the Task launch path to the same
+// per-line attribution contract as the Agent path: production decode stamps a ToolID on
+// both. A Task launch carrying a ToolID, followed by an inner Bash whose ParentID matches,
+// must tag that inner line with the subagent label.
+func TestActivityLineTaskLaunchAttribution(t *testing.T) {
+	var elapsed time.Duration
+	p := NewProgress(fakeClock(&elapsed), 5, "")
+	p.Observe(taskEvent("coder", "toolu_t"))
+	p.Observe(claude.Event{Type: claude.ToolUse, Tool: "Bash", ParentID: "toolu_t"})
+
+	frame := p.Frame()
+	wantLine := "⌨️ coder" + subagentTagSeparator + "Bash"
+	if !strings.Contains(frame, wantLine) {
+		t.Fatalf("Task-launch attributed line %q not in frame %q", wantLine, frame)
 	}
 }
 

--- a/core/chat/progress_test.go
+++ b/core/chat/progress_test.go
@@ -803,6 +803,19 @@ func taskEvent(subagentType string) claude.Event {
 	}
 }
 
+// agentEvent builds an Agent ToolUse launch carrying the given subagent_type and
+// (optionally) a tool_use id, mirroring how THIS harness spawns subagents — via the
+// Agent tool, not Task (AC1/AC3). A non-empty toolID is what an inner event later
+// echoes as its ParentID, so it can be attributed back to this subagent.
+func agentEvent(subagentType, toolID string) claude.Event {
+	return claude.Event{
+		Type:      claude.ToolUse,
+		Tool:      "Agent",
+		ToolInput: []byte(`{"subagent_type":"` + subagentType + `"}`),
+		ToolID:    toolID,
+	}
+}
+
 // TestStageHeaderActiveSubagent (AC1) asserts a Task event with subagent_type
 // "coder" makes the stage header show the active-stage label "coder".
 func TestStageHeaderActiveSubagent(t *testing.T) {
@@ -866,6 +879,124 @@ func TestStageChangesOnlyOnTask(t *testing.T) {
 	}
 	if !strings.Contains(p.Frame(), stageActiveLeft+"planner"+stageActiveRight) {
 		t.Fatalf("planner not the active stage after inner tools: %q", p.Frame())
+	}
+}
+
+// TestStageTrailFromAgentLaunches (AC1) asserts the stage trail builds when
+// subagents are launched via the Agent tool (this harness's mechanism), with inner
+// non-task/agent ToolUse events NOT flipping the active stage. The sequence
+// Agent{coder} → (inner Bash) → Agent{reviewer} → Agent{arbiter} renders the trail
+// "coder → reviewer → ▸ arbiter ◂" with the most recent one active.
+func TestStageTrailFromAgentLaunches(t *testing.T) {
+	var elapsed time.Duration
+	p := NewProgress(fakeClock(&elapsed), 5, "")
+	p.Observe(agentEvent("coder", "toolu_1"))
+	// An inner subagent tool call (flat at the top level) — must not advance the stage.
+	p.Observe(claude.Event{Type: claude.ToolUse, Tool: "Bash", ParentID: "toolu_1"})
+	p.Observe(agentEvent("reviewer", "toolu_2"))
+	p.Observe(agentEvent("arbiter", "toolu_3"))
+
+	if got, want := strings.Join(p.stages, ","), "coder,reviewer,arbiter"; got != want {
+		t.Fatalf("Agent-launch trail = %q, want %q", got, want)
+	}
+	if p.activeStage != 2 {
+		t.Fatalf("active stage = %d, want arbiter at index 2", p.activeStage)
+	}
+	wantLine := stagePrefix + "coder" + stageSeparator + "reviewer" + stageSeparator +
+		stageActiveLeft + "arbiter" + stageActiveRight
+	if frame := p.Frame(); !strings.Contains(frame, wantLine) {
+		t.Fatalf("stage line %q not in frame %q", wantLine, frame)
+	}
+}
+
+// TestStageTaskAndAgentInterop (AC1) asserts the Task tool still advances the stage
+// alongside Agent launches, so a mixed stream keeps working.
+func TestStageTaskAndAgentInterop(t *testing.T) {
+	var elapsed time.Duration
+	p := NewProgress(fakeClock(&elapsed), 5, "")
+	p.Observe(taskEvent("planner"))
+	p.Observe(agentEvent("coder", "toolu_1"))
+	if got, want := strings.Join(p.stages, ","), "planner,coder"; got != want {
+		t.Fatalf("mixed Task/Agent trail = %q, want %q", got, want)
+	}
+	if p.activeStage != 1 {
+		t.Fatalf("active stage = %d, want coder at index 1", p.activeStage)
+	}
+}
+
+// TestActivityLineSubagentAttribution (AC3) asserts an inner event whose ParentID
+// matches a prior Agent launch's ToolID is tagged with that subagent's label at the
+// HEAD of the line body — right after the emoji prefix, before the tool text — so the
+// tag survives capLine's prefix-peeling and tail truncation.
+func TestActivityLineSubagentAttribution(t *testing.T) {
+	var elapsed time.Duration
+	p := NewProgress(fakeClock(&elapsed), 5, "")
+	p.Observe(agentEvent("coder", "toolu_1"))
+	// The coder subagent runs a Bash command; it arrives flat with ParentID == the
+	// launch's ToolID, so the line is attributed to "coder".
+	p.Observe(claude.Event{Type: claude.ToolUse, Tool: "Bash", ParentID: "toolu_1"})
+
+	frame := p.Frame()
+	wantLine := "⌨️ coder" + subagentTagSeparator + "Bash"
+	if !strings.Contains(frame, wantLine) {
+		t.Fatalf("attributed activity line %q not in frame %q", wantLine, frame)
+	}
+	// The label sits AFTER the emoji prefix, not before it (so capLine's prefix-peel
+	// and the activity-line emoji convention are preserved).
+	if strings.Contains(frame, "coder ⌨️") {
+		t.Fatalf("label leaked BEFORE the emoji prefix: %q", frame)
+	}
+}
+
+// TestActivityLineNoAttributionByteIdentical (AC3/AC4) asserts an event with an
+// empty ParentID (a top-level event, or a stream with no parent linkage) renders
+// with NO tag — byte-identical to the same event observed with attribution machinery
+// absent. The two frames must match exactly.
+func TestActivityLineNoAttributionByteIdentical(t *testing.T) {
+	var e1, e2 time.Duration
+
+	// (a) A progress that never saw a subagent launch — pure top-level activity.
+	bare := NewProgress(fakeClock(&e1), 5, "")
+	bare.Observe(claude.Event{Type: claude.ToolUse, Tool: "Bash"})
+
+	// (b) A progress that DID launch a subagent, then sees an unrelated top-level
+	// event (empty ParentID): it must render identically to (a), with no tag.
+	withMap := NewProgress(fakeClock(&e2), 5, "")
+	withMap.Observe(agentEvent("coder", "toolu_1"))
+	bareTopLevel := withMap.Observe(claude.Event{Type: claude.ToolUse, Tool: "Bash"})
+	if !bareTopLevel {
+		t.Fatal("expected the top-level Bash event to push an activity line")
+	}
+
+	// The Bash line in (b) must carry no subagent tag.
+	wantBash := "⌨️ Bash"
+	if frame := withMap.Frame(); !strings.Contains(frame, wantBash) {
+		t.Fatalf("untagged Bash line %q not in frame %q", wantBash, frame)
+	}
+	if frame := withMap.Frame(); strings.Contains(frame, "⌨️ coder"+subagentTagSeparator) {
+		t.Fatalf("top-level event wrongly tagged with a subagent: %q", frame)
+	}
+	// And the bare-progress Bash line is byte-identical to the pre-feature rendering.
+	if got, want := bare.Frame(), spinnerFrames[0]+" Working… (0s)"+"\n\n"+"⌨️ Bash"; got != want {
+		t.Fatalf("untagged frame not byte-identical:\n got %q\nwant %q", got, want)
+	}
+}
+
+// TestActivityLineUnknownParentNoTag (AC3) asserts an event whose ParentID does NOT
+// map to a known subagent launch renders untagged (graceful no-op), so a stream that
+// carries parent ids we never saw a launch for never produces a bogus label.
+func TestActivityLineUnknownParentNoTag(t *testing.T) {
+	var elapsed time.Duration
+	p := NewProgress(fakeClock(&elapsed), 5, "")
+	p.Observe(agentEvent("coder", "toolu_1"))
+	// ParentID points at a tool_use id we never recorded — degrade to no tag.
+	p.Observe(claude.Event{Type: claude.ToolUse, Tool: "Bash", ParentID: "toolu_unknown"})
+	frame := p.Frame()
+	if strings.Contains(frame, subagentTagSeparator+"Bash") {
+		t.Fatalf("unknown-parent event wrongly tagged: %q", frame)
+	}
+	if !strings.Contains(frame, "⌨️ Bash") {
+		t.Fatalf("expected a plain Bash line for an unknown parent: %q", frame)
 	}
 }
 

--- a/core/claude/decode.go
+++ b/core/claude/decode.go
@@ -17,6 +17,11 @@ type envelope struct {
 	NumTurns  int          `json:"num_turns"`      //nolint:tagliatelle // Claude CLI emits snake_case.
 	CostUSD   float64      `json:"total_cost_usd"` //nolint:tagliatelle // Claude CLI emits snake_case.
 	Duration  int64        `json:"duration_ms"`    //nolint:tagliatelle // Claude CLI emits snake_case.
+	// ParentToolUseID links an event to the subagent that produced it: when the
+	// CLI runs a subagent (an Agent/Task tool_use), the subagent's own assistant/
+	// user envelopes carry the launching tool_use's id here. It is empty for
+	// top-level events. Surfaced on every derived Event as Event.ParentID.
+	ParentToolUseID string `json:"parent_tool_use_id"` //nolint:tagliatelle // Claude CLI emits snake_case.
 }
 
 // messageBody is the assistant/user message wrapper holding content blocks.
@@ -30,6 +35,7 @@ type contentBlock struct {
 	Text  string          `json:"text"`  // text block
 	Name  string          `json:"name"`  // tool_use block
 	Input json.RawMessage `json:"input"` // tool_use block
+	ID    string          `json:"id"`    // tool_use block: the tool_use id
 }
 
 // decode parses one stream-json line into zero or more Events. The bool is
@@ -50,10 +56,10 @@ func decode(line []byte) ([]Event, bool) {
 		return nil, false
 
 	case "assistant":
-		return assistantEvents(env.Message), true
+		return assistantEvents(env.Message, env.ParentToolUseID), true
 
 	case roleUser:
-		return userEvents(env.Message), true
+		return userEvents(env.Message, env.ParentToolUseID), true
 
 	case "result":
 		res := &RunResult{
@@ -73,7 +79,9 @@ func decode(line []byte) ([]Event, bool) {
 }
 
 // assistantEvents converts an assistant message's content blocks into events.
-func assistantEvents(msg *messageBody) []Event {
+// parentID is the envelope's parent_tool_use_id, stamped on every derived event
+// so an inner subagent's activity can be attributed to its launching tool_use.
+func assistantEvents(msg *messageBody, parentID string) []Event {
 	if msg == nil {
 		return nil
 	}
@@ -82,24 +90,26 @@ func assistantEvents(msg *messageBody) []Event {
 		switch b.Type {
 		case "text":
 			if b.Text != "" {
-				evs = append(evs, Event{Type: Text, Text: b.Text})
+				evs = append(evs, Event{Type: Text, Text: b.Text, ParentID: parentID})
 			}
 		case "tool_use":
-			evs = append(evs, Event{Type: ToolUse, Tool: b.Name, ToolInput: b.Input})
+			evs = append(evs, Event{Type: ToolUse, Tool: b.Name, ToolInput: b.Input, ToolID: b.ID, ParentID: parentID})
 		}
 	}
 	return evs
 }
 
 // userEvents emits a ToolResult for each tool_result block in a user message.
-func userEvents(msg *messageBody) []Event {
+// parentID is the envelope's parent_tool_use_id, carried through for consistency
+// with assistantEvents (inner tool results are linked to their subagent too).
+func userEvents(msg *messageBody, parentID string) []Event {
 	if msg == nil {
 		return nil
 	}
 	var evs []Event
 	for _, b := range msg.Content {
 		if b.Type == "tool_result" {
-			evs = append(evs, Event{Type: ToolResult})
+			evs = append(evs, Event{Type: ToolResult, ParentID: parentID})
 		}
 	}
 	return evs

--- a/core/claude/decode_test.go
+++ b/core/claude/decode_test.go
@@ -1,0 +1,94 @@
+//nolint:testpackage // intentionally whitebox to test the unexported decode path.
+package claude
+
+import "testing"
+
+// TestDecodeAssistantParentAndToolID (AC2) feeds a raw `assistant` stream-json
+// line that carries a top-level "parent_tool_use_id" and a tool_use content block
+// with an "id", and asserts the derived events surface both: every event carries
+// ParentID from the envelope, and the ToolUse event carries ToolID from the block.
+func TestDecodeAssistantParentAndToolID(t *testing.T) {
+	line := []byte(`{"type":"assistant","parent_tool_use_id":"toolu_X",` +
+		`"message":{"role":"assistant","content":[` +
+		`{"type":"text","text":"thinking"},` +
+		`{"type":"tool_use","name":"Bash","id":"toolu_Y","input":{"command":"go test ./..."}}` +
+		`]}}`)
+
+	evs, ok := decode(line)
+	if !ok {
+		t.Fatal("decode returned ok=false for a valid assistant line")
+	}
+	if len(evs) != 2 {
+		t.Fatalf("expected 2 events (text + tool_use), got %d: %+v", len(evs), evs)
+	}
+
+	// Every derived event carries the envelope's parent_tool_use_id.
+	for i, e := range evs {
+		if e.ParentID != "toolu_X" {
+			t.Errorf("event %d ParentID = %q, want %q", i, e.ParentID, "toolu_X")
+		}
+	}
+
+	// The text event has no ToolID; the tool_use event carries the block id.
+	text, tool := evs[0], evs[1]
+	if text.Type != Text {
+		t.Fatalf("event 0 type = %v, want Text", text.Type)
+	}
+	if text.ToolID != "" {
+		t.Errorf("text event ToolID = %q, want empty", text.ToolID)
+	}
+	if tool.Type != ToolUse {
+		t.Fatalf("event 1 type = %v, want ToolUse", tool.Type)
+	}
+	if tool.ToolID != "toolu_Y" {
+		t.Errorf("tool_use ToolID = %q, want %q", tool.ToolID, "toolu_Y")
+	}
+}
+
+// TestDecodeUserToolResultCarriesParentID (AC2) asserts the user/tool_result path
+// also threads parent_tool_use_id onto its derived ToolResult event, so an inner
+// subagent's tool results are linked back to the subagent too.
+func TestDecodeUserToolResultCarriesParentID(t *testing.T) {
+	line := []byte(`{"type":"user","parent_tool_use_id":"toolu_Z",` +
+		`"message":{"role":"user","content":[` +
+		`{"type":"tool_result","tool_use_id":"toolu_Y","content":"ok"}` +
+		`]}}`)
+
+	evs, ok := decode(line)
+	if !ok {
+		t.Fatal("decode returned ok=false for a valid user line")
+	}
+	if len(evs) != 1 {
+		t.Fatalf("expected 1 ToolResult event, got %d: %+v", len(evs), evs)
+	}
+	if evs[0].Type != ToolResult {
+		t.Fatalf("event type = %v, want ToolResult", evs[0].Type)
+	}
+	if evs[0].ParentID != "toolu_Z" {
+		t.Errorf("tool_result ParentID = %q, want %q", evs[0].ParentID, "toolu_Z")
+	}
+}
+
+// TestDecodeTopLevelEventsHaveNoParent guards the no-subagent case: a top-level
+// assistant line with no parent_tool_use_id yields events whose ParentID is empty,
+// so per-line attribution stays a no-op (the frame is byte-identical to before).
+func TestDecodeTopLevelEventsHaveNoParent(t *testing.T) {
+	line := []byte(`{"type":"assistant",` +
+		`"message":{"role":"assistant","content":[` +
+		`{"type":"tool_use","name":"Agent","id":"toolu_A","input":{"subagent_type":"coder"}}` +
+		`]}}`)
+
+	evs, ok := decode(line)
+	if !ok {
+		t.Fatal("decode returned ok=false for a valid assistant line")
+	}
+	if len(evs) != 1 {
+		t.Fatalf("expected 1 event, got %d: %+v", len(evs), evs)
+	}
+	if evs[0].ParentID != "" {
+		t.Errorf("top-level event ParentID = %q, want empty", evs[0].ParentID)
+	}
+	if evs[0].ToolID != "toolu_A" {
+		t.Errorf("ToolUse ToolID = %q, want %q", evs[0].ToolID, "toolu_A")
+	}
+}

--- a/core/claude/runner.go
+++ b/core/claude/runner.go
@@ -50,6 +50,16 @@ type Event struct {
 	SessionID string          // set on SystemInit
 	Result    *RunResult      // set on Result
 	Err       error           // set on RunError
+	// ParentID is the stream-json envelope's parent_tool_use_id, set on every
+	// event derived from an assistant/user envelope. It is non-empty when the
+	// event was produced INSIDE a subagent the Lead launched (the launching
+	// tool_use's id), so a flat top-level activity line can be attributed to that
+	// subagent. It is empty for top-level (non-subagent) events.
+	ParentID string
+	// ToolID is the tool_use content block's id, set on ToolUse events. For an
+	// Agent/Task launch it is the id later carried as ParentID by the subagent's
+	// own events, letting the renderer map an inner event back to its subagent.
+	ToolID string
 }
 
 // RunResult is the parsed terminal result envelope of a run.


### PR DESCRIPTION
## Summary

The live "Working…" progress frame is meant to show **which dev-team subagent is running** — a `🧭` stage trail (`planner → coder → ▸ reviewer ◂ → arbiter`) and per-line attribution of each activity line to the subagent that produced it. In the current harness both were dead:

1. **Stage trail never built.** `Progress.Observe` advanced the trail only on a tool_use named `task`, but this harness launches subagents via the **`Agent`** tool (`subagent_type: coder/reviewer/...`), not `Task`. So `p.stages` stayed empty and `stageLine()` returned `""` — no trail ever rendered.
2. **No parent linkage.** `core/claude/decode.go` never decoded the stream-json `parent_tool_use_id` (nor the tool_use block `id`), so an inner subagent's flat top-level Bash/Text events could not be tied back to the launching subagent.

This PR fixes both: the trail advances on `Task` **or** `Agent` launches, the decoder surfaces `parent_tool_use_id`/`id`, and inner activity lines whose parent resolves to a known launch are tagged with the subagent label (`⌨️ coder ▸ Bash · …`).

## Changes

- **`core/claude/runner.go`** — `Event` gains `ParentID` (the envelope `parent_tool_use_id`, on every derived event) and `ToolID` (the tool_use block `id`, on `ToolUse` events).
- **`core/claude/decode.go`** — `envelope` decodes `parent_tool_use_id`; `contentBlock` decodes the tool_use `id`; `assistantEvents`/`userEvents` stamp `ParentID` on each derived event and `ToolID` on tool_use events.
- **`core/chat/progress.go`** — `isSubagentLaunch` (task **or** agent, case-insensitive) drives `advanceStage`; each launch's `ToolID → subagentLabel` is remembered in `subagentByToolID`; `activityLine` tags a line via `withSubagentTag` at the **head of the body, after the emoji prefix**, markdown-sanitized (reusing `sanitizeStageLabel`), so it survives `capLine`/`Frame` tail-truncation. An empty/unknown parent renders **byte-identical** to before.

## Acceptance criteria

- [x] **AC1** — `🧭` stage trail builds for `Agent` launches (Task still works); inner tool events don't flip the active stage. *(`TestStageTrailFromAgentLaunches`, `TestStageTaskAndAgentInterop`, `TestStageDistinctTrailFirstSeenOrder`)*
- [x] **AC2** — decoder surfaces `parent_tool_use_id`→`Event.ParentID` and tool_use `id`→`Event.ToolID`; `system`/`result` envelopes never receive a parent. *(`TestDecodeAssistantParentAndToolID`, `TestDecodeUserToolResultCarriesParentID`, `TestDecodeTopLevelEventsHaveNoParent`)*
- [x] **AC3** — inner event whose `ParentID` maps to a launch is tagged at the body head; empty/unknown parent is byte-identical; the tag is markdown-sanitized and survives truncation; Task and Agent launches attribute identically. *(`TestActivityLineSubagentAttribution`, `TestActivityLineNoAttributionByteIdentical`, `TestActivityLineUnknownParentNoTag`, `TestActivityLineTagSurvivesTruncation`, `TestActivityLineTagMarkdownSanitized`, `TestActivityLineTaskLaunchAttribution`)*
- [x] **AC4** — no regression. `task lint` → 0 issues, `task tests` → all packages ok (race on), `task build` → exit 0.

## How it was verified

- Root cause confirmed against a real run transcript: subagent launches are `Agent{subagent_type:"coder"/"reviewer"}`, not `Task`.
- Full gate run in the foreground: **`task lint` 0 issues**, **`task tests` green with the race detector** (incl. `core/chat`, `core/claude`), **`task build` exit 0**.
- 11 unit tests cover each AC's success path and the degradation/byte-identical paths, including the load-bearing tag-survival-under-truncation, per-line markdown-sanitization, and Task-path parity.

## Review

Two internal critic passes were run: a pre-PR review, then a separate **independent multi-lens review** (4 reviewers — correctness / rendering-truncation / security-markdown / design-spec-tests — plus an empirical stream probe, adversarial verification of each finding, and a completeness critic). **Verdict: APPROVE, risk low, zero blocker/major.**

- **Caught & fixed pre-PR:** the `activityLine` parameter shadowed the package-level `subagentLabel` function — renamed to `subagentTag`.
- **Independent review added** three regression tests that pin the most load-bearing / highest-risk properties (tag survives `olderSnippetMax`/`recentSnippetMax` tail-truncation; the per-line tag — the one **new** injection surface — is markdown-sanitized; Task-launch attribution matches Agent), plus two clarifying doc comments (the launch-before-inner stream-ordering assumption; the tag consuming line budget).

### Empirical finding on the live stream (resolves the prior open risk)

Against the **version-current Claude Agent SDK docs**, `parent_tool_use_id` **is** emitted on a subagent's `tool_use`/`tool_result` events in `--output-format stream-json` stdout by default (the official detection pattern is exactly `block.name === "Task"||"Agent"` **and** `parent_tool_use_id`, matching this PR's logic). So **AC3 tool-line attribution will fire in production** — it is **not** a no-op.

**One residual caveat (needs a human eyeball):** subagent **text/thinking** blocks are **not** forwarded to stdout unless the run passes `forwardSubagentText` / `--forward-subagent-text`, which flock's invocation (`claude --print --output-format stream-json --verbose`) does not set. So the live frame will show attributed **tool** lines (`⌨️ coder ▸ Bash …`) but **not** attributed **thought** lines — the `claude.Text` branch of the tag is currently inert and exercised only by unit tests. This is a harmless degradation (it renders the byte-identical untagged line, covered by AC4), not a regression. If attributed thoughts are wanted later, wire the forwarding flag. Worth one live multi-subagent run to confirm the `coder ▸ Bash` tag renders on this CLI build (2.1.187); attribution degrades to a byte-identical untagged line if the field is ever absent, so there is no merge risk.
