### PR TITLE
feat(chat): explain a turn-limit stop instead of reporting it as a failure

### DIFF
--- a/cmd/duck-vk/main.go
+++ b/cmd/duck-vk/main.go
@@ -236,9 +236,12 @@ func run() int {
 		StarNudge:  starNudge,
 		PostRun:    postRun,
 		Opts:       opts,
-		Timeout:    cfg.ClaudeTimeout(),
-		RetryAfter: vk.RetryAfter,
-		Logger:     logger,
+		// Let a turn-limit stop name the knob that raises the cap. Empty for a
+		// provider that applies no turn cap, which keeps the knob out of the message.
+		MaxTurnsEnv: airunner.TurnLimitEnv(provider.Name),
+		Timeout:     cfg.ClaudeTimeout(),
+		RetryAfter:  vk.RetryAfter,
+		Logger:      logger,
 	})
 
 	// One-shot follow-ups (the workspace followup/<delay>.md convention).

--- a/cmd/flock-telegram/main.go
+++ b/cmd/flock-telegram/main.go
@@ -308,9 +308,12 @@ func run() int {
 		StarNudge:  starNudge,
 		PostRun:    postRun,
 		Opts:       opts,
-		Timeout:    cfg.ClaudeTimeout(),
-		RetryAfter: telegram.RetryAfter,
-		Logger:     logger,
+		// Let a turn-limit stop name the knob that raises the cap. Empty for a
+		// provider that applies no turn cap, which keeps the knob out of the message.
+		MaxTurnsEnv: airunner.TurnLimitEnv(provider.Name),
+		Timeout:     cfg.ClaudeTimeout(),
+		RetryAfter:  telegram.RetryAfter,
+		Logger:      logger,
 	})
 
 	// Background cron scheduler (OFF by default). When enabled, open the durable

--- a/core/chat/progress.go
+++ b/core/chat/progress.go
@@ -975,7 +975,10 @@ func turnLimitExplanation(res *agent.RunResult, limits RunLimits) string {
 				" whatever default the provider applies. Set `" + env + "` and restart the bot to control it.")
 		}
 	}
-	// Keep the raw token: it is what an operator greps for in the logs.
+	// Keep the raw token: it is the provider's stable, unlocalized name for this
+	// stop, so it is what an operator matches against provider docs and issue
+	// reports — and nothing on this path logs it, so the delivered message is the
+	// only place it ever surfaces.
 	_, _ = b.WriteString(" (" + turnLimitSubtype + ")")
 	return b.String()
 }

--- a/core/chat/progress.go
+++ b/core/chat/progress.go
@@ -831,10 +831,26 @@ func (p *Progress) Frame() string {
 	return assemble([]string{capLine(lines[0], budget)})
 }
 
+// RunLimits carries the run-level caps the terminal renderer needs to explain a
+// stop that was caused by a configured limit rather than by a failure. The zero
+// value means "unknown": the renderer then omits every clause it cannot state
+// truthfully, so callers that have no limits to report lose nothing.
+type RunLimits struct {
+	// MaxTurns is the agent turn cap actually in force for the run. Non-positive
+	// means no cap was passed to the provider, so its built-in limit applied.
+	MaxTurns int
+	// MaxTurnsEnv names the environment variable that configures MaxTurns, so a
+	// message can point at the knob without core/chat knowing any env name.
+	// Empty means the active provider has no such knob and none is mentioned.
+	MaxTurnsEnv string
+}
+
 // Final renders the terminal message text for a successful run result. A
 // result that carries no text (e.g. an error subtype with an empty body) yields
-// a short placeholder so the user is never left with an empty message.
-func Final(res *agent.RunResult) string {
+// a short placeholder so the user is never left with an empty message. limits
+// describes the caps the run ran under; the zero value renders the generic
+// wording.
+func Final(res *agent.RunResult, _ RunLimits) string {
 	if res == nil {
 		return "(no result)"
 	}

--- a/core/chat/progress.go
+++ b/core/chat/progress.go
@@ -342,17 +342,24 @@ func subagentLabel(input json.RawMessage) string {
 // that becomes empty after stripping (all-metacharacter) falls back to the constant
 // so the active stage is never rendered blank.
 func sanitizeStageLabel(label string) string {
-	cleaned := strings.Map(func(r rune) rune {
-		if strings.ContainsRune(stageLabelMeta, r) {
-			return -1
-		}
-		return r
-	}, label)
-	cleaned = collapseWhitespace(cleaned)
+	cleaned := collapseWhitespace(stripRunes(label, stageLabelMeta))
 	if cleaned == "" {
 		return stageLabelFallbck
 	}
 	return cleaned
+}
+
+// stripRunes removes every rune of meta from s. It backs both markdown-safety
+// sanitizers in this file, which strip DIFFERENT sets because they render into
+// different contexts (sanitizeStageLabel into bare inline text, sanitizeEnvName
+// into an inline-code span).
+func stripRunes(s, meta string) string {
+	return strings.Map(func(r rune) rune {
+		if strings.ContainsRune(meta, r) {
+			return -1
+		}
+		return r
+	}, s)
 }
 
 // activityLine renders the one-line activity summary for an event, or false if
@@ -843,7 +850,8 @@ const turnLimitSubtype = "error_max_turns"
 // truthfully, so callers that have no limits to report lose nothing.
 type RunLimits struct {
 	// MaxTurns is the agent turn cap actually in force for the run. Non-positive
-	// means no cap was passed to the provider, so its built-in limit applied.
+	// means no cap was passed to the provider; what the provider then does on its
+	// own is unverified, so no message states it.
 	MaxTurns int
 	// MaxTurnsEnv names the environment variable that configures MaxTurns, so a
 	// message can point at the knob without core/chat knowing any env name.
@@ -895,6 +903,29 @@ func errorBody(res *agent.RunResult, limits RunLimits, text string) string {
 	}
 }
 
+// envNameMeta is the set of characters stripped from an operator-supplied env-var
+// name before it is rendered inside an inline-code span (see sanitizeEnvName).
+// Only the backtick can escape such a span: every other markdown metacharacter is
+// inert between backticks, both on the rich-markdown path and on the legacy
+// MarkdownToHTML one (which stashes and HTML-escapes code spans before any
+// formatting pass runs). The set is deliberately NARROWER than stageLabelMeta,
+// which strips "_" — legal and common in an env var name, so reusing it here would
+// print a knob that does not exist.
+const envNameMeta = "`"
+
+// sanitizeEnvName makes an operator-supplied environment-variable name safe to
+// interpolate into an inline-code span: it drops the characters that could close
+// the span (envNameMeta) and collapses whitespace, since a newline also ends a code
+// span and would leave the backticks visible. An odd backtick count desyncs the
+// rich-markdown parser and takes the WHOLE message off the rich path, so this is a
+// by-construction guarantee rather than a validation. The name is NOT truncated: a
+// shortened knob name would be a wrong one. An empty result means there is nothing
+// safe to name, and callers drop the whole clause rather than render empty
+// backticks.
+func sanitizeEnvName(name string) string {
+	return collapseWhitespace(stripRunes(name, envNameMeta))
+}
+
 // turnLimitExplanation spells out a stop caused by the agent turn cap: that it is
 // a configured cutoff rather than a failure, what survived it, and which knob
 // raises it — reporting the value actually in force rather than any default, since
@@ -904,21 +935,38 @@ func turnLimitExplanation(res *agent.RunResult, limits RunLimits) string {
 	// strings.Builder writes never return an error, so the results are discarded.
 	var b strings.Builder
 	_, _ = b.WriteString("The run stopped because it reached its turn limit")
-	// The provider's own turn counter has unverified semantics and can exceed the
-	// cap; "501 of 250 turns" would read as a bug, so only a consistent pair shows.
-	if res.NumTurns > 0 && res.NumTurns <= limits.MaxTurns {
+	// num_turns is the provider's own counter and its semantics are unverified: it
+	// can both undershoot and exceed the cap. The sentence already states that the
+	// cap was reached, so a count that disagrees with it reads as a bug ("3 of 40
+	// turns" as much as "501 of 250 turns"). The count is therefore rendered ONLY
+	// when it corroborates the cap exactly and is silently omitted otherwise — the
+	// sentence stands on its own without it. A positive cap is still required so an
+	// unknown cap (0) can never be corroborated by a zero count.
+	if limits.MaxTurns > 0 && res.NumTurns == limits.MaxTurns {
 		_, _ = b.WriteString(" (" + strconv.Itoa(res.NumTurns) + " of " + strconv.Itoa(limits.MaxTurns) + " turns)")
 	}
 	_, _ = b.WriteString(" — not a crash, timeout or API error.")
+	// Workspace state survives, but the run's conversation context may not: a
+	// terminal is_error Result while resuming clears this chat's stored session (the
+	// self-heal in Service.run), so the next message then starts a FRESH session
+	// with no memory of what was in flight. A run that was itself a fresh session
+	// keeps its id and does resume — hence "may not", which is exact for both paths.
 	_, _ = b.WriteString(" Everything already written, committed or pushed is kept in the workspace,")
-	_, _ = b.WriteString(" and the next message starts a new run.")
-	if env := strings.TrimSpace(limits.MaxTurnsEnv); env != "" {
+	_, _ = b.WriteString(" but the stopped run's chat context may not carry over —")
+	_, _ = b.WriteString(" restate anything you want continued in your next message.")
+	// The knob name is operator-supplied (chat.Config.MaxTurnsEnv is exported), so
+	// it is sanitized before it lands inside the inline-code span; a name left empty
+	// by sanitizing names nothing and drops the clause with it.
+	if env := sanitizeEnvName(limits.MaxTurnsEnv); env != "" {
 		if limits.MaxTurns > 0 {
 			_, _ = b.WriteString(" To allow longer runs, raise `" + env + "` (current: " +
 				strconv.Itoa(limits.MaxTurns) + ") and restart the bot.")
 		} else {
-			_, _ = b.WriteString(" No turn cap is configured, so the provider's built-in limit applied —" +
-				" set `" + env + "` and restart the bot to raise it.")
+			// Nothing is claimed about WHY a run without a configured cap still stopped:
+			// the provider's own fallback behaviour is unverified. "Raise it" would be
+			// wrong too — the only way to reach this branch is an explicitly zeroed cap.
+			_, _ = b.WriteString(" No turn cap is configured for this bot — set `" + env +
+				"` and restart the bot to add one.")
 		}
 	}
 	// Keep the raw token: it is what an operator greps for in the logs.

--- a/core/chat/progress.go
+++ b/core/chat/progress.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -831,6 +832,11 @@ func (p *Progress) Frame() string {
 	return assemble([]string{capLine(lines[0], budget)})
 }
 
+// turnLimitSubtype is the provider result subtype for a run the agent turn cap
+// cut short. It is the only error subtype whose cause we can state truthfully,
+// so it is the only one with dedicated wording.
+const turnLimitSubtype = "error_max_turns"
+
 // RunLimits carries the run-level caps the terminal renderer needs to explain a
 // stop that was caused by a configured limit rather than by a failure. The zero
 // value means "unknown": the renderer then omits every clause it cannot state
@@ -850,27 +856,74 @@ type RunLimits struct {
 // a short placeholder so the user is never left with an empty message. limits
 // describes the caps the run ran under; the zero value renders the generic
 // wording.
-func Final(res *agent.RunResult, _ RunLimits) string {
+func Final(res *agent.RunResult, limits RunLimits) string {
 	if res == nil {
 		return "(no result)"
 	}
 	text := strings.TrimSpace(res.Text)
 	if res.IsError {
-		if text == "" {
-			// Surface the result subtype (e.g. "error_max_turns") when present so the
-			// cause isn't fully opaque; fall back to the plain message otherwise.
-			if res.Subtype != "" {
-				text = "the run ended with an error (" + res.Subtype + ")"
-			} else {
-				text = "the run ended with an error"
-			}
-		}
-		return "⚠️ " + text
+		return "⚠️ " + errorBody(res, limits, text)
 	}
 	if text == "" {
 		return "(empty response)"
 	}
 	return text
+}
+
+// errorBody renders the terminal message body (everything after the warning sign)
+// for an error result, where text is the result's already-trimmed text. Only a
+// subtype whose cause we can state truthfully gets dedicated wording; every other
+// one keeps the generic message with the raw subtype appended, so the cause is at
+// least not fully opaque.
+func errorBody(res *agent.RunResult, limits RunLimits, text string) string {
+	switch res.Subtype {
+	case turnLimitSubtype:
+		// Keep whatever the run did produce and append the explanation after it: the
+		// generic wording used to replace that text outright.
+		if text != "" {
+			return text + "\n\n" + turnLimitExplanation(res, limits)
+		}
+		return turnLimitExplanation(res, limits)
+	default:
+		if text != "" {
+			return text
+		}
+		if res.Subtype != "" {
+			return "the run ended with an error (" + res.Subtype + ")"
+		}
+		return "the run ended with an error"
+	}
+}
+
+// turnLimitExplanation spells out a stop caused by the agent turn cap: that it is
+// a configured cutoff rather than a failure, what survived it, and which knob
+// raises it — reporting the value actually in force rather than any default, since
+// deployments override it. Every clause whose limit is unknown is dropped, so a
+// zero RunLimits still yields a truthful (if shorter) message.
+func turnLimitExplanation(res *agent.RunResult, limits RunLimits) string {
+	// strings.Builder writes never return an error, so the results are discarded.
+	var b strings.Builder
+	_, _ = b.WriteString("The run stopped because it reached its turn limit")
+	// The provider's own turn counter has unverified semantics and can exceed the
+	// cap; "501 of 250 turns" would read as a bug, so only a consistent pair shows.
+	if res.NumTurns > 0 && res.NumTurns <= limits.MaxTurns {
+		_, _ = b.WriteString(" (" + strconv.Itoa(res.NumTurns) + " of " + strconv.Itoa(limits.MaxTurns) + " turns)")
+	}
+	_, _ = b.WriteString(" — not a crash, timeout or API error.")
+	_, _ = b.WriteString(" Everything already written, committed or pushed is kept in the workspace,")
+	_, _ = b.WriteString(" and the next message starts a new run.")
+	if env := strings.TrimSpace(limits.MaxTurnsEnv); env != "" {
+		if limits.MaxTurns > 0 {
+			_, _ = b.WriteString(" To allow longer runs, raise `" + env + "` (current: " +
+				strconv.Itoa(limits.MaxTurns) + ") and restart the bot.")
+		} else {
+			_, _ = b.WriteString(" No turn cap is configured, so the provider's built-in limit applied —" +
+				" set `" + env + "` and restart the bot to raise it.")
+		}
+	}
+	// Keep the raw token: it is what an operator greps for in the logs.
+	_, _ = b.WriteString(" (" + turnLimitSubtype + ")")
+	return b.String()
 }
 
 // FinalError renders the terminal message text when a run fails without a

--- a/core/chat/progress.go
+++ b/core/chat/progress.go
@@ -886,11 +886,14 @@ func Final(res *agent.RunResult, limits RunLimits) string {
 func errorBody(res *agent.RunResult, limits RunLimits, text string) string {
 	switch res.Subtype {
 	case turnLimitSubtype:
-		// Keep whatever the run did produce and append the explanation after it: the
-		// generic wording used to replace that text outright.
-		if text != "" {
-			return text + "\n\n" + turnLimitExplanation(res, limits)
-		}
+		// The result text this subtype carries is a fixed boilerplate sentence from the
+		// provider ("Reached the maximum number of turns." — see
+		// core/claude/testdata/error.jsonl) that states exactly what the explanation's
+		// own first sentence states, minus the actionable knob and the raw subtype
+		// token. Echoing it would open the message with a duplicate of its own next
+		// line, so it is dropped. The rule is gated on the SUBTYPE, never on matching
+		// the sentence: a reworded boilerplate must not start leaking back in, and
+		// every OTHER subtype still keeps whatever text came with the result.
 		return turnLimitExplanation(res, limits)
 	default:
 		if text != "" {

--- a/core/chat/progress.go
+++ b/core/chat/progress.go
@@ -962,11 +962,14 @@ func turnLimitExplanation(res *agent.RunResult, limits RunLimits) string {
 			_, _ = b.WriteString(" To allow longer runs, raise `" + env + "` (current: " +
 				strconv.Itoa(limits.MaxTurns) + ") and restart the bot.")
 		} else {
-			// Nothing is claimed about WHY a run without a configured cap still stopped:
-			// the provider's own fallback behaviour is unverified. "Raise it" would be
-			// wrong too — the only way to reach this branch is an explicitly zeroed cap.
-			_, _ = b.WriteString(" No turn cap is configured for this bot — set `" + env +
-				"` and restart the bot to add one.")
+			// Still nothing is claimed about WHAT the provider's fallback cap is — that
+			// behaviour is unverified — only that the limit which bound this run was not
+			// one this bot set. Without that connective the sentence reads as a
+			// contradiction of the opening one ("reached its turn limit" / "no turn cap
+			// is configured"). "Raise it" would be wrong too: the only way to reach this
+			// branch is an explicitly zeroed cap.
+			_, _ = b.WriteString(" No turn cap is configured for this bot, so the run was bound by" +
+				" whatever default the provider applies. Set `" + env + "` and restart the bot to control it.")
 		}
 	}
 	// Keep the raw token: it is what an operator greps for in the logs.

--- a/core/chat/progress_test.go
+++ b/core/chat/progress_test.go
@@ -1363,6 +1363,32 @@ func assertMarkdownSafe(t *testing.T, line string) {
 	}
 }
 
+// assertCodeSpanSafe checks a message that legitimately carries an inline-code
+// span: every span opens and closes (an even backtick count) and none is broken
+// by a newline, which also ends a code span and would leave the backticks
+// visible. It deliberately asserts LESS than assertMarkdownSafe: a stage line
+// strips every markdown metacharacter from its labels, whereas the turn-limit
+// message interpolates an operator-supplied env-var name that KEEPS "_"
+// (sanitizeEnvName strips only the backtick, because a knob name with its
+// underscores removed names no variable). Inside a code span "_" and "*" are
+// inert, so a realistic name like MAX_TURNS leaves an odd "_" count on a message
+// that is perfectly safe — demanding balance here would fail a correct message
+// and pressure the next reader into stripping "_".
+func assertCodeSpanSafe(t *testing.T, msg string) {
+	t.Helper()
+	parts := strings.Split(msg, "`")
+	if len(parts)%2 == 0 {
+		t.Fatalf("unbalanced backticks in message (%d occurrences): %q", len(parts)-1, msg)
+	}
+	// Odd indices are the contents of a code span: parts[1] sits between the
+	// first and second backtick, parts[3] between the third and fourth, and so on.
+	for i := 1; i < len(parts); i += 2 {
+		if strings.ContainsAny(parts[i], "\n\r") {
+			t.Fatalf("newline inside a code span (%q) breaks it: %q", parts[i], msg)
+		}
+	}
+}
+
 func TestFinalSuccess(t *testing.T) {
 	out := Final(&agent.RunResult{Text: "  the answer is 42  ", IsError: false}, RunLimits{})
 	if out != "the answer is 42" {
@@ -1432,6 +1458,11 @@ func TestFinalTurnLimitStop(t *testing.T) {
 		limits  RunLimits
 		want    []string
 		notWant []string
+		// oddUnderscores marks the case that exists to prove this message is checked
+		// as a code span rather than for emphasis balance: its rendered text must
+		// carry an ODD number of "_", which assertMarkdownSafe (right for a stage
+		// line) would reject even though every "_" here is inert.
+		oddUnderscores bool
 	}{
 		{
 			// The count corroborates the cap exactly, so it is safe to show.
@@ -1511,6 +1542,18 @@ func TestFinalTurnLimitStop(t *testing.T) {
 			notWant: []string{"X`", "\n"},
 		},
 		{
+			// The everyday case the code span exists for: "_" is legal in an env var
+			// name and sanitizeEnvName keeps it (a name with its underscores removed
+			// names no variable), so a realistic knob leaves an odd "_" count in the
+			// message. That is safe — the underscores sit inside a code span, where
+			// they are inert — and the assertion below must not demand otherwise.
+			name:           "knob name with an odd underscore count stays safe",
+			res:            &agent.RunResult{IsError: true, Subtype: turnLimitSubtype, NumTurns: 40},
+			limits:         RunLimits{MaxTurns: 40, MaxTurnsEnv: "MAX_TURNS"},
+			want:           []string{"raise `MAX_TURNS` (current: 40)", turnLimitSubtype},
+			oddUnderscores: true,
+		},
+		{
 			// A knob name that is nothing BUT metacharacters names no variable, so the
 			// clause is dropped rather than rendered as empty backticks.
 			name:    "knob name left empty by sanitizing drops the clause",
@@ -1562,7 +1605,13 @@ func TestFinalTurnLimitStop(t *testing.T) {
 					t.Fatalf("Final() = %q, want it NOT to contain %q", got, notWant)
 				}
 			}
-			assertMarkdownSafe(t, got)
+			// This message is NOT a stage line: it carries an inline-code span whose
+			// content keeps its underscores on purpose, so only the code-span
+			// invariant applies here (see assertCodeSpanSafe).
+			assertCodeSpanSafe(t, got)
+			if tt.oddUnderscores && strings.Count(got, "_")%2 == 0 {
+				t.Fatalf("Final() = %q, want an ODD underscore count so this case covers what assertMarkdownSafe rejects", got)
+			}
 		})
 	}
 }

--- a/core/chat/progress_test.go
+++ b/core/chat/progress_test.go
@@ -1467,11 +1467,16 @@ func TestFinalTurnLimitStop(t *testing.T) {
 		},
 		{
 			// No cap is configured, so never print a cap of 0 and never corroborate it
-			// with a count: only the knob to set is actionable here.
-			name:    "knob known but no cap configured",
-			res:     &agent.RunResult{IsError: true, Subtype: turnLimitSubtype, NumTurns: 7},
-			limits:  RunLimits{MaxTurnsEnv: testMaxTurnsEnv},
-			want:    []string{"turn limit", "No turn cap is configured", "`" + testMaxTurnsEnv + "`", turnLimitSubtype},
+			// with a count: only the knob to set is actionable here. The clause also has
+			// to say WHOSE limit then bound the run, or it contradicts the opening
+			// sentence — without claiming to know what that limit is.
+			name:   "knob known but no cap configured",
+			res:    &agent.RunResult{IsError: true, Subtype: turnLimitSubtype, NumTurns: 7},
+			limits: RunLimits{MaxTurnsEnv: testMaxTurnsEnv},
+			want: []string{
+				"turn limit", "No turn cap is configured for this bot, so the run was bound by" +
+					" whatever default the provider applies", "`" + testMaxTurnsEnv + "`", turnLimitSubtype,
+			},
 			notWant: []string{"0", "7", "current:", " of ", "raise"},
 		},
 		{

--- a/core/chat/progress_test.go
+++ b/core/chat/progress_test.go
@@ -1408,7 +1408,10 @@ const testMaxTurnsEnv = "X_MAX_TURNS"
 // TestFinalTurnLimitStop covers the terminal message for a run that exhausted the
 // agent turn cap. It must state the cause, rule out a crash/timeout/API error,
 // keep the raw subtype token, and name the knob plus the value actually in force —
-// each clause appearing exactly when the limit behind it is known.
+// each clause appearing exactly when the limit behind it is known. The reported
+// turn count rides along ONLY when it equals the cap (num_turns semantics are
+// unverified, so a count that contradicts the sentence is dropped, not shown), and
+// the knob name — operator-supplied — can never break out of its code span.
 func TestFinalTurnLimitStop(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -1418,40 +1421,30 @@ func TestFinalTurnLimitStop(t *testing.T) {
 		notWant []string
 	}{
 		{
-			name:   "cap and knob known",
-			res:    &agent.RunResult{IsError: true, Subtype: turnLimitSubtype, NumTurns: 7},
+			// The count corroborates the cap exactly, so it is safe to show.
+			name:   "reported turns match the cap",
+			res:    &agent.RunResult{IsError: true, Subtype: turnLimitSubtype, NumTurns: 40},
 			limits: RunLimits{MaxTurns: 40, MaxTurnsEnv: testMaxTurnsEnv},
 			want: []string{
-				"turn limit", "not a crash, timeout or API error",
-				"(7 of 40 turns)", "`" + testMaxTurnsEnv + "`", "current: 40", turnLimitSubtype,
+				"turn limit", "not a crash, timeout or API error", "restate anything you want continued",
+				"(40 of 40 turns)", "`" + testMaxTurnsEnv + "`", "current: 40", turnLimitSubtype,
 			},
+			// A stopped run's session is cleared when it was resuming, so the message
+			// must not promise the next one picks up where this one left off.
+			notWant: []string{"starts a new run"},
 		},
 		{
-			name:    "cap known but provider has no knob",
-			res:     &agent.RunResult{IsError: true, Subtype: turnLimitSubtype, NumTurns: 7},
-			limits:  RunLimits{MaxTurns: 40},
-			want:    []string{"turn limit", "not a crash, timeout or API error", "(7 of 40 turns)", turnLimitSubtype},
-			notWant: []string{testMaxTurnsEnv, "current:"},
+			// num_turns semantics are unverified and the counter can undershoot the
+			// cap; "3 of 40 turns" under a sentence that says the cap was reached reads
+			// as a bug, so the count is dropped while the cap itself still shows.
+			name:    "reported turns fall short of the cap",
+			res:     &agent.RunResult{IsError: true, Subtype: turnLimitSubtype, NumTurns: 3},
+			limits:  RunLimits{MaxTurns: 40, MaxTurnsEnv: testMaxTurnsEnv},
+			want:    []string{"turn limit", "`" + testMaxTurnsEnv + "`", "current: 40", turnLimitSubtype},
+			notWant: []string{" of ", "3"},
 		},
 		{
-			// No cap was passed to the provider, so its built-in limit applied: never
-			// print a cap of 0, and say the variable is unset instead.
-			name:    "knob known but no cap configured",
-			res:     &agent.RunResult{IsError: true, Subtype: turnLimitSubtype, NumTurns: 7},
-			limits:  RunLimits{MaxTurnsEnv: testMaxTurnsEnv},
-			want:    []string{"turn limit", "built-in", "`" + testMaxTurnsEnv + "`", turnLimitSubtype},
-			notWant: []string{"0", "current:", " of "},
-		},
-		{
-			name:    "neither cap nor knob known",
-			res:     &agent.RunResult{IsError: true, Subtype: turnLimitSubtype, NumTurns: 7},
-			limits:  RunLimits{},
-			want:    []string{"turn limit", "not a crash, timeout or API error", turnLimitSubtype},
-			notWant: []string{testMaxTurnsEnv, "current:", " of ", "0"},
-		},
-		{
-			// num_turns is the provider's own counter and may exceed the cap; a
-			// "501 of 250" clause would read as a bug, so it is dropped entirely.
+			// The same counter can also exceed the cap: "501 of 250" reads as a bug too.
 			name:    "reported turns exceed the cap",
 			res:     &agent.RunResult{IsError: true, Subtype: turnLimitSubtype, NumTurns: 501},
 			limits:  RunLimits{MaxTurns: 250, MaxTurnsEnv: testMaxTurnsEnv},
@@ -1466,10 +1459,53 @@ func TestFinalTurnLimitStop(t *testing.T) {
 			notWant: []string{" of "},
 		},
 		{
+			name:    "cap known but provider has no knob",
+			res:     &agent.RunResult{IsError: true, Subtype: turnLimitSubtype, NumTurns: 40},
+			limits:  RunLimits{MaxTurns: 40},
+			want:    []string{"turn limit", "not a crash, timeout or API error", "(40 of 40 turns)", turnLimitSubtype},
+			notWant: []string{testMaxTurnsEnv, "current:", "`"},
+		},
+		{
+			// No cap is configured, so never print a cap of 0 and never corroborate it
+			// with a count: only the knob to set is actionable here.
+			name:    "knob known but no cap configured",
+			res:     &agent.RunResult{IsError: true, Subtype: turnLimitSubtype, NumTurns: 7},
+			limits:  RunLimits{MaxTurnsEnv: testMaxTurnsEnv},
+			want:    []string{"turn limit", "No turn cap is configured", "`" + testMaxTurnsEnv + "`", turnLimitSubtype},
+			notWant: []string{"0", "7", "current:", " of ", "raise"},
+		},
+		{
+			name:    "neither cap nor knob known",
+			res:     &agent.RunResult{IsError: true, Subtype: turnLimitSubtype, NumTurns: 7},
+			limits:  RunLimits{},
+			want:    []string{"turn limit", "not a crash, timeout or API error", turnLimitSubtype},
+			notWant: []string{testMaxTurnsEnv, "current:", " of ", "0", "7", "`"},
+		},
+		{
+			// chat.Config.MaxTurnsEnv is exported, so the knob name is whatever an
+			// embedder set: a backtick in it would leave an odd count and take the
+			// WHOLE message off the rich-markdown path. Backticks are stripped and
+			// surrounding whitespace/newlines collapsed, so the code span always closes.
+			name:    "hostile knob name cannot break the code span",
+			res:     &agent.RunResult{IsError: true, Subtype: turnLimitSubtype, NumTurns: 40},
+			limits:  RunLimits{MaxTurns: 40, MaxTurnsEnv: "  X`_MAX`_TURNS\n"},
+			want:    []string{"raise `" + testMaxTurnsEnv + "` (current: 40)", turnLimitSubtype},
+			notWant: []string{"X`", "\n"},
+		},
+		{
+			// A knob name that is nothing BUT metacharacters names no variable, so the
+			// clause is dropped rather than rendered as empty backticks.
+			name:    "knob name left empty by sanitizing drops the clause",
+			res:     &agent.RunResult{IsError: true, Subtype: turnLimitSubtype, NumTurns: 40},
+			limits:  RunLimits{MaxTurns: 40, MaxTurnsEnv: " `` "},
+			want:    []string{"turn limit", "(40 of 40 turns)", turnLimitSubtype},
+			notWant: []string{"`", "current:", "raise"},
+		},
+		{
 			// Text that came with the result used to be swallowed by the generic
 			// wording; it is now kept and the explanation follows it.
 			name:   "result text is kept and explained",
-			res:    &agent.RunResult{Text: "partial answer", IsError: true, Subtype: turnLimitSubtype, NumTurns: 7},
+			res:    &agent.RunResult{Text: "partial answer", IsError: true, Subtype: turnLimitSubtype, NumTurns: 40},
 			limits: RunLimits{MaxTurns: 40, MaxTurnsEnv: testMaxTurnsEnv},
 			want:   []string{"⚠️ partial answer\n\nThe run stopped", "current: 40", turnLimitSubtype},
 		},

--- a/core/chat/progress_test.go
+++ b/core/chat/progress_test.go
@@ -1381,10 +1381,11 @@ func TestFinalErrorResult(t *testing.T) {
 		t.Fatalf("empty error result not flagged: %q", empty)
 	}
 
-	// Diagnostic: an empty-bodied error Result surfaces the subtype so the cause
-	// isn't fully opaque.
-	withSub := Final(&agent.RunResult{Text: "", IsError: true, Subtype: "error_max_turns"}, RunLimits{})
-	if !strings.Contains(withSub, "error_max_turns") {
+	// Diagnostic: the raw subtype survives into the message so the cause isn't
+	// fully opaque, including for the subtype that has dedicated wording
+	// (TestFinalTurnLimitStop covers what that wording says).
+	withSub := Final(&agent.RunResult{Text: "", IsError: true, Subtype: turnLimitSubtype}, RunLimits{})
+	if !strings.Contains(withSub, turnLimitSubtype) {
 		t.Fatalf("empty error result should include the subtype: %q", withSub)
 	}
 	// With no subtype the plain fallback is kept (no empty parentheses).
@@ -1397,6 +1398,138 @@ func TestFinalErrorResult(t *testing.T) {
 	}
 	if got := Final(nil, RunLimits{}); got != "(no result)" {
 		t.Fatalf("nil result: %q", got)
+	}
+}
+
+// testMaxTurnsEnv stands in for the deployment's real turn-cap variable. core/chat
+// must never hardcode a provider env name, so the tests do not name one either.
+const testMaxTurnsEnv = "X_MAX_TURNS"
+
+// TestFinalTurnLimitStop covers the terminal message for a run that exhausted the
+// agent turn cap. It must state the cause, rule out a crash/timeout/API error,
+// keep the raw subtype token, and name the knob plus the value actually in force —
+// each clause appearing exactly when the limit behind it is known.
+func TestFinalTurnLimitStop(t *testing.T) {
+	tests := []struct {
+		name    string
+		res     *agent.RunResult
+		limits  RunLimits
+		want    []string
+		notWant []string
+	}{
+		{
+			name:   "cap and knob known",
+			res:    &agent.RunResult{IsError: true, Subtype: turnLimitSubtype, NumTurns: 7},
+			limits: RunLimits{MaxTurns: 40, MaxTurnsEnv: testMaxTurnsEnv},
+			want: []string{
+				"turn limit", "not a crash, timeout or API error",
+				"(7 of 40 turns)", "`" + testMaxTurnsEnv + "`", "current: 40", turnLimitSubtype,
+			},
+		},
+		{
+			name:    "cap known but provider has no knob",
+			res:     &agent.RunResult{IsError: true, Subtype: turnLimitSubtype, NumTurns: 7},
+			limits:  RunLimits{MaxTurns: 40},
+			want:    []string{"turn limit", "not a crash, timeout or API error", "(7 of 40 turns)", turnLimitSubtype},
+			notWant: []string{testMaxTurnsEnv, "current:"},
+		},
+		{
+			// No cap was passed to the provider, so its built-in limit applied: never
+			// print a cap of 0, and say the variable is unset instead.
+			name:    "knob known but no cap configured",
+			res:     &agent.RunResult{IsError: true, Subtype: turnLimitSubtype, NumTurns: 7},
+			limits:  RunLimits{MaxTurnsEnv: testMaxTurnsEnv},
+			want:    []string{"turn limit", "built-in", "`" + testMaxTurnsEnv + "`", turnLimitSubtype},
+			notWant: []string{"0", "current:", " of "},
+		},
+		{
+			name:    "neither cap nor knob known",
+			res:     &agent.RunResult{IsError: true, Subtype: turnLimitSubtype, NumTurns: 7},
+			limits:  RunLimits{},
+			want:    []string{"turn limit", "not a crash, timeout or API error", turnLimitSubtype},
+			notWant: []string{testMaxTurnsEnv, "current:", " of ", "0"},
+		},
+		{
+			// num_turns is the provider's own counter and may exceed the cap; a
+			// "501 of 250" clause would read as a bug, so it is dropped entirely.
+			name:    "reported turns exceed the cap",
+			res:     &agent.RunResult{IsError: true, Subtype: turnLimitSubtype, NumTurns: 501},
+			limits:  RunLimits{MaxTurns: 250, MaxTurnsEnv: testMaxTurnsEnv},
+			want:    []string{"turn limit", "current: 250", turnLimitSubtype},
+			notWant: []string{"501", " of "},
+		},
+		{
+			name:    "no turn count reported",
+			res:     &agent.RunResult{IsError: true, Subtype: turnLimitSubtype},
+			limits:  RunLimits{MaxTurns: 40, MaxTurnsEnv: testMaxTurnsEnv},
+			want:    []string{"turn limit", "current: 40", turnLimitSubtype},
+			notWant: []string{" of "},
+		},
+		{
+			// Text that came with the result used to be swallowed by the generic
+			// wording; it is now kept and the explanation follows it.
+			name:   "result text is kept and explained",
+			res:    &agent.RunResult{Text: "partial answer", IsError: true, Subtype: turnLimitSubtype, NumTurns: 7},
+			limits: RunLimits{MaxTurns: 40, MaxTurnsEnv: testMaxTurnsEnv},
+			want:   []string{"⚠️ partial answer\n\nThe run stopped", "current: 40", turnLimitSubtype},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Final(tt.res, tt.limits)
+			if !strings.HasPrefix(got, "⚠️") {
+				t.Fatalf("turn-limit stop not flagged: %q", got)
+			}
+			for _, want := range tt.want {
+				if !strings.Contains(got, want) {
+					t.Fatalf("Final() = %q, want it to contain %q", got, want)
+				}
+			}
+			for _, notWant := range tt.notWant {
+				if strings.Contains(got, notWant) {
+					t.Fatalf("Final() = %q, want it NOT to contain %q", got, notWant)
+				}
+			}
+			assertMarkdownSafe(t, got)
+		})
+	}
+}
+
+// TestFinalKeepsWordingOutsideTurnLimit pins the exact terminal text for every
+// result the turn-limit wording does not own, so threading RunLimits through
+// Final cannot silently reword an unrelated message. The limits must make no
+// difference to any of them.
+func TestFinalKeepsWordingOutsideTurnLimit(t *testing.T) {
+	tests := []struct {
+		name string
+		res  *agent.RunResult
+		want string
+	}{
+		{"success text is trimmed", &agent.RunResult{Text: "  the answer is 42  "}, "the answer is 42"},
+		{"empty success", &agent.RunResult{}, "(empty response)"},
+		{"nil result", nil, "(no result)"},
+		{"error with text", &agent.RunResult{Text: "boom", IsError: true}, "⚠️ boom"},
+		{"error without subtype", &agent.RunResult{IsError: true}, "⚠️ the run ended with an error"},
+		{
+			// Another subtype's cause cannot be stated truthfully, so it keeps the
+			// generic message with the raw token appended.
+			"other error subtype",
+			&agent.RunResult{IsError: true, Subtype: "error_during_execution"},
+			"⚠️ the run ended with an error (error_during_execution)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Final(tt.res, RunLimits{}); got != tt.want {
+				t.Fatalf("Final() with zero limits = %q, want %q", got, tt.want)
+			}
+			limits := RunLimits{MaxTurns: 40, MaxTurnsEnv: testMaxTurnsEnv}
+			if got := Final(tt.res, limits); got != tt.want {
+				t.Fatalf("Final() with limits = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/core/chat/progress_test.go
+++ b/core/chat/progress_test.go
@@ -1405,13 +1405,26 @@ func TestFinalErrorResult(t *testing.T) {
 // must never hardcode a provider env name, so the tests do not name one either.
 const testMaxTurnsEnv = "X_MAX_TURNS"
 
+// turnLimitProviderText is the result text a real provider ships with an
+// error_max_turns envelope, copied verbatim from core/claude/testdata/error.jsonl
+// (which also reports num_turns 5). It is fixed boilerplate that says what the
+// explanation says, which is why the message does not echo it back.
+const turnLimitProviderText = "Reached the maximum number of turns."
+
+// turnLimitOpener is the explanation's first clause. It must appear exactly once in
+// every turn-limit message: twice would mean a provider result was echoed alongside
+// it, stating the same fact in two consecutive lines.
+const turnLimitOpener = "The run stopped because it reached its turn limit"
+
 // TestFinalTurnLimitStop covers the terminal message for a run that exhausted the
 // agent turn cap. It must state the cause, rule out a crash/timeout/API error,
 // keep the raw subtype token, and name the knob plus the value actually in force —
 // each clause appearing exactly when the limit behind it is known. The reported
 // turn count rides along ONLY when it equals the cap (num_turns semantics are
-// unverified, so a count that contradicts the sentence is dropped, not shown), and
-// the knob name — operator-supplied — can never break out of its code span.
+// unverified, so a count that contradicts the sentence is dropped, not shown), the
+// provider's own result text is never echoed alongside it (it only restates the
+// cause), and the knob name — operator-supplied — can never break out of its code
+// span.
 func TestFinalTurnLimitStop(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -1507,12 +1520,25 @@ func TestFinalTurnLimitStop(t *testing.T) {
 			notWant: []string{"`", "current:", "raise"},
 		},
 		{
-			// Text that came with the result used to be swallowed by the generic
-			// wording; it is now kept and the explanation follows it.
-			name:   "result text is kept and explained",
-			res:    &agent.RunResult{Text: "partial answer", IsError: true, Subtype: turnLimitSubtype, NumTurns: 40},
-			limits: RunLimits{MaxTurns: 40, MaxTurnsEnv: testMaxTurnsEnv},
-			want:   []string{"⚠️ partial answer\n\nThe run stopped", "current: 40", turnLimitSubtype},
+			// The realistic payload: the provider fills the result with fixed boilerplate
+			// for this subtype. It states exactly what the explanation's first sentence
+			// states, so echoing it would open the message with a duplicate of its own
+			// next line — the explanation stands alone instead.
+			name:    "provider boilerplate is not echoed back",
+			res:     &agent.RunResult{Text: turnLimitProviderText, IsError: true, Subtype: turnLimitSubtype, NumTurns: 5},
+			limits:  RunLimits{MaxTurns: 5, MaxTurnsEnv: testMaxTurnsEnv},
+			want:    []string{"⚠️ " + turnLimitOpener, "(5 of 5 turns)", "current: 5", turnLimitSubtype},
+			notWant: []string{turnLimitProviderText},
+		},
+		{
+			// The rule is gated on the subtype, not on matching the boilerplate sentence,
+			// so ANY text arriving with this subtype is dropped and a reworded provider
+			// message cannot start leaking back in.
+			name:    "result text is dropped whatever it says",
+			res:     &agent.RunResult{Text: "partial answer", IsError: true, Subtype: turnLimitSubtype, NumTurns: 40},
+			limits:  RunLimits{MaxTurns: 40, MaxTurnsEnv: testMaxTurnsEnv},
+			want:    []string{"⚠️ " + turnLimitOpener, "current: 40", turnLimitSubtype},
+			notWant: []string{"partial answer"},
 		},
 	}
 
@@ -1521,6 +1547,10 @@ func TestFinalTurnLimitStop(t *testing.T) {
 			got := Final(tt.res, tt.limits)
 			if !strings.HasPrefix(got, "⚠️") {
 				t.Fatalf("turn-limit stop not flagged: %q", got)
+			}
+			// The cause is stated once and only once, whatever the result carried.
+			if n := strings.Count(got, turnLimitOpener); n != 1 {
+				t.Fatalf("Final() = %q, want the explanation exactly once, got %d", got, n)
 			}
 			for _, want := range tt.want {
 				if !strings.Contains(got, want) {

--- a/core/chat/progress_test.go
+++ b/core/chat/progress_test.go
@@ -1387,6 +1387,17 @@ func assertCodeSpanSafe(t *testing.T, msg string) {
 			t.Fatalf("newline inside a code span (%q) breaks it: %q", parts[i], msg)
 		}
 	}
+	// Even indices are OUTSIDE every span, where the metacharacters are NOT inert and
+	// the stage line's balance rule still applies. Only the span interior earned the
+	// exemption above, so anything a future clause interpolates outside one stays held
+	// to it.
+	for i := 0; i < len(parts); i += 2 {
+		for _, meta := range []string{"*", "_", "~", "|"} {
+			if c := strings.Count(parts[i], meta); c%2 != 0 {
+				t.Fatalf("unbalanced %q outside a code span (%d occurrences): %q", meta, c, msg)
+			}
+		}
+	}
 }
 
 func TestFinalSuccess(t *testing.T) {

--- a/core/chat/progress_test.go
+++ b/core/chat/progress_test.go
@@ -1364,26 +1364,26 @@ func assertMarkdownSafe(t *testing.T, line string) {
 }
 
 func TestFinalSuccess(t *testing.T) {
-	out := Final(&agent.RunResult{Text: "  the answer is 42  ", IsError: false})
+	out := Final(&agent.RunResult{Text: "  the answer is 42  ", IsError: false}, RunLimits{})
 	if out != "the answer is 42" {
 		t.Fatalf("got %q", out)
 	}
 }
 
 func TestFinalErrorResult(t *testing.T) {
-	out := Final(&agent.RunResult{Text: "max turns exceeded", IsError: true})
+	out := Final(&agent.RunResult{Text: "max turns exceeded", IsError: true}, RunLimits{})
 	if !strings.HasPrefix(out, "⚠️") || !strings.Contains(out, "max turns exceeded") {
 		t.Fatalf("error result not flagged: %q", out)
 	}
 
-	empty := Final(&agent.RunResult{Text: "", IsError: true})
+	empty := Final(&agent.RunResult{Text: "", IsError: true}, RunLimits{})
 	if !strings.HasPrefix(empty, "⚠️") {
 		t.Fatalf("empty error result not flagged: %q", empty)
 	}
 
 	// Diagnostic: an empty-bodied error Result surfaces the subtype so the cause
 	// isn't fully opaque.
-	withSub := Final(&agent.RunResult{Text: "", IsError: true, Subtype: "error_max_turns"})
+	withSub := Final(&agent.RunResult{Text: "", IsError: true, Subtype: "error_max_turns"}, RunLimits{})
 	if !strings.Contains(withSub, "error_max_turns") {
 		t.Fatalf("empty error result should include the subtype: %q", withSub)
 	}
@@ -1392,10 +1392,10 @@ func TestFinalErrorResult(t *testing.T) {
 		t.Fatalf("empty error result without subtype should use the plain fallback: %q", empty)
 	}
 
-	if got := Final(&agent.RunResult{Text: "", IsError: false}); got != "(empty response)" {
+	if got := Final(&agent.RunResult{Text: "", IsError: false}, RunLimits{}); got != "(empty response)" {
 		t.Fatalf("empty success placeholder: %q", got)
 	}
-	if got := Final(nil); got != "(no result)" {
+	if got := Final(nil, RunLimits{}); got != "(no result)" {
 		t.Fatalf("nil result: %q", got)
 	}
 }

--- a/core/chat/service.go
+++ b/core/chat/service.go
@@ -943,7 +943,10 @@ func (s *Service) finish(
 // mirrors the terminal cases finish handles: a run cancelled by a deploy shutdown
 // (resuming) keeps its marker and auto-resumes, so it reads "paused … will resume";
 // a user Stop / per-run timeout (ctxErr set, no Result or error) reads "stopped"; a
-// RunError or an is_error Result reads "failed"; and a clean Result reads "done".
+// run the agent turn cap cut short reads "turn limit reached", because it is a
+// configured cutoff rather than a failure and the answer bubble right above says
+// so — "failed" here would contradict it; any OTHER RunError or is_error Result
+// reads "failed"; and a clean Result reads "done".
 func completionNotice(res *agent.RunResult, runErr, ctxErr error, total time.Duration, resuming bool) string {
 	elapsed := formatElapsed(int64(total / time.Second))
 	switch {
@@ -951,6 +954,11 @@ func completionNotice(res *agent.RunResult, runErr, ctxErr error, total time.Dur
 		return "⏳ Paused after " + elapsed + " — will resume after restart"
 	case ctxErr != nil && res == nil && runErr == nil:
 		return "⏹ Stopped after " + elapsed
+	// runErr must be nil to claim a clean turn-limit stop: with one set, finish
+	// renders FinalError instead of the turn-limit explanation, so the notice keeps
+	// the failure wording that matches the delivered answer.
+	case runErr == nil && res != nil && res.IsError && res.Subtype == turnLimitSubtype:
+		return "⏹ Turn limit reached after " + elapsed
 	case runErr != nil || (res != nil && res.IsError):
 		return "⚠️ Failed after " + elapsed
 	default:

--- a/core/chat/service.go
+++ b/core/chat/service.go
@@ -124,10 +124,13 @@ type Service struct {
 	nudge      *starNudge
 	postrun    PostRunConfig
 	opts       agent.Options
-	timeout    time.Duration
-	log        *slog.Logger
-	tick       time.Duration
-	nowFunc    func() time.Time
+	// maxTurnsEnv names the environment variable that configures opts.MaxTurns,
+	// supplied by the adapter so core/chat never hardcodes a provider env name.
+	maxTurnsEnv string
+	timeout     time.Duration
+	log         *slog.Logger
+	tick        time.Duration
+	nowFunc     func() time.Time
 
 	mu             sync.Mutex                 // guards runChat, lastMsg, verifyRetry, budgetNotified and snapCache
 	runChat        map[string]ChatID          // active runID -> chatID, for mapping Stop back to a chat
@@ -172,6 +175,12 @@ type Config struct {
 	// zero value disables all of it (see PostRunConfig).
 	PostRun PostRunConfig
 	Opts    agent.Options // Model/MaxTurns/Env for every run; Workdir is set per chat
+	// MaxTurnsEnv names the environment variable that configures Opts.MaxTurns for
+	// the active provider, so a terminal message can point the operator at the knob
+	// that raises the cap. Empty (the default) means the provider has no such knob
+	// and no variable is ever named. It exists so core/chat stays free of provider
+	// env names; the adapter derives it from the provider it built.
+	MaxTurnsEnv string
 	// Timeout bounds a single run's delivery; 0 means no deadline. On timeout the
 	// run is cancelled but the captured session_id is still stored (plan §7.3).
 	Timeout time.Duration
@@ -202,27 +211,28 @@ func New(cfg Config) *Service {
 		maxRunes = defaultMaxMessageRunes
 	}
 	return &Service{
-		runner:     cfg.Runner,
-		chat:       cfg.Transport,
-		caps:       caps,
-		retryAfter: cfg.RetryAfter,
-		maxRunes:   maxRunes,
-		dispatch:   cfg.Dispatcher,
-		workspace:  cfg.Workspace,
-		sessions:   cfg.Sessions,
-		pending:    cfg.Pending,
-		costs:      cfg.Costs,
-		costCapUSD: cfg.CostCapUSD,
-		outbox:     cfg.Outbox,
-		nudge:      newStarNudge(cfg.StarNudge, cfg.Transport, log),
-		postrun:    cfg.PostRun,
-		opts:       cfg.Opts,
-		timeout:    cfg.Timeout,
-		log:        log,
-		tick:       tickInterval,
-		nowFunc:    time.Now,
-		runChat:    map[string]ChatID{},
-		lastMsg:    map[ChatID]MessageID{},
+		runner:      cfg.Runner,
+		chat:        cfg.Transport,
+		caps:        caps,
+		retryAfter:  cfg.RetryAfter,
+		maxRunes:    maxRunes,
+		dispatch:    cfg.Dispatcher,
+		workspace:   cfg.Workspace,
+		sessions:    cfg.Sessions,
+		pending:     cfg.Pending,
+		costs:       cfg.Costs,
+		costCapUSD:  cfg.CostCapUSD,
+		outbox:      cfg.Outbox,
+		nudge:       newStarNudge(cfg.StarNudge, cfg.Transport, log),
+		postrun:     cfg.PostRun,
+		opts:        cfg.Opts,
+		maxTurnsEnv: cfg.MaxTurnsEnv,
+		timeout:     cfg.Timeout,
+		log:         log,
+		tick:        tickInterval,
+		nowFunc:     time.Now,
+		runChat:     map[string]ChatID{},
+		lastMsg:     map[ChatID]MessageID{},
 
 		verifyRetry:    map[ChatID][]string{},
 		budgetNotified: map[ChatID]string{},
@@ -821,7 +831,12 @@ func (s *Service) finish(
 	case runErr != nil:
 		text = FinalError(runErr)
 	default:
-		text = Final(res)
+		// s.opts is the single source of truth for the cap behind any result that
+		// reaches here: run() copies s.opts and overwrites only Images/Workdir/
+		// SessionID, so the main run never overrides MaxTurns; the evaluator's
+		// EvalMaxTurns override applies to runEvaluator, whose result is consumed
+		// inside the post-run loop and never passes through finish.
+		text = Final(res, RunLimits{MaxTurns: s.opts.MaxTurns, MaxTurnsEnv: s.maxTurnsEnv})
 	}
 
 	// Fence-aware chunking so a code block that crosses a chunk boundary stays

--- a/core/chat/service_test.go
+++ b/core/chat/service_test.go
@@ -671,6 +671,57 @@ func TestProgressEditsRespectMinInterval(t *testing.T) {
 	close(gate)
 }
 
+// TestRunExplainsTurnLimitWithRuntimeCap asserts the turn-limit message a user
+// actually receives carries the cap and knob THIS deployment runs with, end to
+// end from chat.Config through the run loop. Printing a compiled-in default
+// instead would be actively misleading: deployments override the cap.
+func TestRunExplainsTurnLimitWithRuntimeCap(t *testing.T) {
+	const (
+		maxTurns = 7
+		envName  = "X_MAX_TURNS"
+	)
+	fc := newFakeChat()
+	fr := &fakeRunner{events: []agent.Event{
+		{Type: agent.SystemInit, SessionID: "s1"},
+		{Type: agent.Result, Result: &agent.RunResult{
+			IsError: true, Subtype: "error_max_turns", NumTurns: maxTurns, SessionID: "s1",
+		}},
+	}}
+	d := dispatch.New(4)
+	defer d.Close()
+	svc := New(Config{
+		Runner:      fr,
+		Transport:   fc,
+		Dispatcher:  d,
+		Workspace:   &fakeWorkspace{},
+		Opts:        agent.Options{MaxTurns: maxTurns},
+		MaxTurnsEnv: envName,
+		Logger:      slog.New(slog.DiscardHandler),
+	})
+	svc.tick = 5 * time.Millisecond
+
+	svc.Handle(context.Background(), "100", 100, "1", "go")
+
+	waitUntil(t, func() bool {
+		text, stop := fc.snapshot()
+		return strings.Contains(text, "error_max_turns") && !stop
+	})
+
+	text, _ := fc.snapshot()
+	for _, want := range []string{"turn limit", strconv.Itoa(maxTurns), envName} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("delivered turn-limit message = %q, want it to contain %q", text, want)
+		}
+	}
+	// Neither the compiled-in default nor the deploy role's value may leak in: the
+	// message must report the cap this Service was actually built with.
+	for _, notWant := range []string{"40", "250"} {
+		if strings.Contains(text, notWant) {
+			t.Fatalf("delivered turn-limit message = %q, want it NOT to contain %q", text, notWant)
+		}
+	}
+}
+
 func TestRunChunksLongFinal(t *testing.T) {
 	long := strings.Repeat("x", TelegramMaxMessage+500)
 	fc := newFakeChat()

--- a/core/chat/service_test.go
+++ b/core/chat/service_test.go
@@ -678,13 +678,18 @@ func TestProgressEditsRespectMinInterval(t *testing.T) {
 func TestRunExplainsTurnLimitWithRuntimeCap(t *testing.T) {
 	const (
 		maxTurns = 7
+		// Deliberately different from maxTurns, so the assertion on "7" below can
+		// only be satisfied by the CAP the Service was built with and never by the
+		// result's own counter. A count that does not corroborate the cap is omitted
+		// from the message entirely, which is exactly what makes "7" unambiguous.
+		numTurns = 3
 		envName  = "X_MAX_TURNS"
 	)
 	fc := newFakeChat()
 	fr := &fakeRunner{events: []agent.Event{
 		{Type: agent.SystemInit, SessionID: "s1"},
 		{Type: agent.Result, Result: &agent.RunResult{
-			IsError: true, Subtype: "error_max_turns", NumTurns: maxTurns, SessionID: "s1",
+			IsError: true, Subtype: "error_max_turns", NumTurns: numTurns, SessionID: "s1",
 		}},
 	}}
 	d := dispatch.New(4)
@@ -714,11 +719,20 @@ func TestRunExplainsTurnLimitWithRuntimeCap(t *testing.T) {
 		}
 	}
 	// Neither the compiled-in default nor the deploy role's value may leak in: the
-	// message must report the cap this Service was actually built with.
-	for _, notWant := range []string{"40", "250"} {
+	// message must report the cap this Service was actually built with. The result's
+	// own turn count must not appear either — it does not corroborate the cap.
+	for _, notWant := range []string{"40", "250", strconv.Itoa(numTurns)} {
 		if strings.Contains(text, notWant) {
 			t.Fatalf("delivered turn-limit message = %q, want it NOT to contain %q", text, notWant)
 		}
+	}
+
+	// The separate completion notice must not contradict the answer it follows: the
+	// answer says "not a crash, timeout or API error", so the notice cannot read
+	// "Failed".
+	waitUntil(t, func() bool { return fc.noticeCount("⏹ Turn limit reached after") == 1 })
+	if n := fc.noticeCount("⚠️ Failed after"); n != 0 {
+		t.Fatalf("turn-limit run sent %d failure notices, want 0", n)
 	}
 }
 
@@ -876,6 +890,9 @@ func TestCompletionNoticeOnStop(t *testing.T) {
 // TestCompletionNoticeStatusWords pins the status word + total for every terminal
 // case, including the deploy-shutdown "resuming" case that must read "paused …
 // will resume" (not "stopped"), since such a run keeps its marker and auto-resumes.
+// A turn-limit stop is a configured cutoff, not a failure — the answer bubble above
+// the notice says so, so the notice must not contradict it — while EVERY other
+// error subtype keeps the "failed" wording byte-identically.
 func TestCompletionNoticeStatusWords(t *testing.T) {
 	const total = 4*time.Minute + 12*time.Second
 	tests := []struct {
@@ -889,6 +906,28 @@ func TestCompletionNoticeStatusWords(t *testing.T) {
 		{"clean result", &agent.RunResult{}, nil, nil, false, "✅ Done in 4m 12s"},
 		{"run error", nil, errors.New("boom"), nil, false, "⚠️ Failed after 4m 12s"},
 		{"is_error result", &agent.RunResult{IsError: true}, nil, nil, false, "⚠️ Failed after 4m 12s"},
+		{
+			"is_error result with another subtype",
+			&agent.RunResult{IsError: true, Subtype: "error_during_execution"},
+			nil, nil, false, "⚠️ Failed after 4m 12s",
+		},
+		{
+			"turn limit result",
+			&agent.RunResult{IsError: true, Subtype: turnLimitSubtype},
+			nil, nil, false, "⏹ Turn limit reached after 4m 12s",
+		},
+		{
+			// The subtype alone never softens the notice: without is_error the run
+			// completed, and a RunError means finish rendered the failure text instead.
+			"turn limit subtype on a clean result",
+			&agent.RunResult{Subtype: turnLimitSubtype},
+			nil, nil, false, "✅ Done in 4m 12s",
+		},
+		{
+			"turn limit result alongside a run error",
+			&agent.RunResult{IsError: true, Subtype: turnLimitSubtype},
+			errors.New("boom"), nil, false, "⚠️ Failed after 4m 12s",
+		},
 		{"user stop", nil, nil, context.Canceled, false, "⏹ Stopped after 4m 12s"},
 		{"deploy shutdown resumes", nil, nil, context.Canceled, true, "⏳ Paused after 4m 12s — will resume after restart"},
 	}

--- a/core/chat/service_test.go
+++ b/core/chat/service_test.go
@@ -928,6 +928,19 @@ func TestCompletionNoticeStatusWords(t *testing.T) {
 			&agent.RunResult{IsError: true, Subtype: turnLimitSubtype},
 			errors.New("boom"), nil, false, "⚠️ Failed after 4m 12s",
 		},
+		{
+			// A ctxErr must NOT soften the turn-limit wording, which is why that case
+			// deliberately does not guard on ctxErr == nil. run reads ctx.Err() only
+			// after the event loop drained, so a Stop press or the per-run timeout
+			// landing once the Result was already captured reaches finish with BOTH a
+			// turn-limit result and a ctxErr — and finish then falls through to its
+			// default branch and renders the turn-limit explanation. The notice sits
+			// directly under that bubble, so it has to read "Turn limit reached" too;
+			// "Stopped" here would contradict the answer.
+			"turn limit result with a stop that landed after it",
+			&agent.RunResult{IsError: true, Subtype: turnLimitSubtype},
+			nil, context.Canceled, false, "⏹ Turn limit reached after 4m 12s",
+		},
 		{"user stop", nil, nil, context.Canceled, false, "⏹ Stopped after 4m 12s"},
 		{"deploy shutdown resumes", nil, nil, context.Canceled, true, "⏳ Paused after 4m 12s — will resume after restart"},
 	}

--- a/internal/airunner/backend.go
+++ b/internal/airunner/backend.go
@@ -133,6 +133,24 @@ func (claudeProvider) Build(cfg config.Config) (agent.Runner, agent.Options, err
 	}, nil
 }
 
+// TurnLimitEnv names the environment variable that configures the agent turn cap
+// for the given AI_BACKEND name or alias, or "" when that provider has no such
+// knob. An empty name resolves to the default provider, exactly as an unset
+// AI_BACKEND does; an unrecognized one yields "" rather than a guess.
+//
+// Only the Claude backend passes a turn cap down to its CLI — codexProvider and
+// openAICompatProvider leave agent.Options.MaxTurns zero — so it is the only
+// provider whose knob can be named truthfully. This is a plain function rather
+// than a Provider method because two of the three implementations would do
+// nothing but return "".
+func TurnLimitEnv(provider string) string {
+	p, err := DefaultRegistry().Provider(provider)
+	if err != nil || p.Name() != config.AIBackendClaude {
+		return ""
+	}
+	return config.ClaudeMaxTurnsEnv
+}
+
 type codexProvider struct{}
 
 func (codexProvider) Name() string        { return config.AIBackendCodex }

--- a/internal/airunner/backend_test.go
+++ b/internal/airunner/backend_test.go
@@ -97,6 +97,33 @@ func TestBuildProviderAliases(t *testing.T) {
 	}
 }
 
+// TestTurnLimitEnv checks the turn-cap knob is named only for the provider that
+// actually applies one, so a message can never point at a variable that does
+// nothing for the configured backend.
+func TestTurnLimitEnv(t *testing.T) {
+	tests := []struct {
+		provider string
+		want     string
+	}{
+		{config.AIBackendClaude, config.ClaudeMaxTurnsEnv},
+		{"claude-cli", config.ClaudeMaxTurnsEnv},
+		{"  CLAUDE  ", config.ClaudeMaxTurnsEnv},
+		{"", config.ClaudeMaxTurnsEnv}, // unset AI_BACKEND defaults to claude
+		{config.AIBackendCodex, ""},
+		{"codex-cli", ""},
+		{config.AIBackendOpenAICompat, ""},
+		{"openai", ""},
+		{"qwen", ""}, // unknown provider names no knob
+	}
+	for _, tt := range tests {
+		t.Run(tt.provider, func(t *testing.T) {
+			if got := TurnLimitEnv(tt.provider); got != tt.want {
+				t.Fatalf("TurnLimitEnv(%q) = %q, want %q", tt.provider, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestBuildRejectsUnknownProvider(t *testing.T) {
 	runner, opts, info, err := Build(config.Config{AIBackend: "qwen"})
 	if !errors.Is(err, ErrUnknownProvider) {

--- a/internal/airunner/backend_test.go
+++ b/internal/airunner/backend_test.go
@@ -142,7 +142,9 @@ const testTurnCap = 40
 // yet the terminal message would stay silent about the knob that raises it, and
 // every other test would still pass. Asserting the biconditional over the whole
 // registry also covers providers that do not exist yet: enforcing a cap and naming
-// its env var must always come together, in both directions.
+// its env var must always come together, in both directions — provided the new
+// provider's cap field follows turnCapFieldSuffix. A cap wired from a differently
+// named field reads back as zero from the probe config and is NOT covered.
 func TestTurnLimitEnvMatchesProviderTurnCap(t *testing.T) {
 	registry := DefaultRegistry()
 	if len(registry.providers) == 0 {
@@ -194,18 +196,23 @@ func turnCapProbeConfig(t *testing.T) config.Config {
 	}
 	value := reflect.ValueOf(&cfg).Elem()
 	fields := value.Type()
-	filled := 0
 	for i := 0; i < fields.NumField(); i++ {
 		field := fields.Field(i)
-		if !strings.HasSuffix(field.Name, turnCapFieldSuffix) || field.Type.Kind() != reflect.Int {
+		if !field.IsExported() || !strings.HasSuffix(field.Name, turnCapFieldSuffix) ||
+			field.Type.Kind() != reflect.Int {
 			continue
 		}
 		value.Field(i).SetInt(testTurnCap)
-		filled++
 	}
-	if filled == 0 {
-		t.Fatalf("no config field ends in %q: the turn-cap naming convention changed, "+
-			"so this config no longer feeds any provider a cap", turnCapFieldSuffix)
+	// Counting the fields filled above cannot catch a rename: GoalEvalMaxTurns — the
+	// goal evaluator's own cap — matches the suffix while feeding no provider, so the
+	// count never reaches zero. Assert the one field that DOES feed a provider today,
+	// so renaming it away from the convention fails here, naming the cause, instead of
+	// surfacing as a Claude backend that mysteriously stopped capping turns.
+	if cfg.ClaudeMaxTurns != testTurnCap {
+		t.Fatalf("ClaudeMaxTurns = %d, want %d: no field named <Provider>%s fed the Claude backend, "+
+			"so the turn-cap naming convention changed and this probe no longer sets a cap",
+			cfg.ClaudeMaxTurns, testTurnCap, turnCapFieldSuffix)
 	}
 	return cfg
 }

--- a/internal/airunner/backend_test.go
+++ b/internal/airunner/backend_test.go
@@ -3,6 +3,8 @@ package airunner
 
 import (
 	"errors"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/duckbugio/flock/internal/config"
@@ -122,6 +124,90 @@ func TestTurnLimitEnv(t *testing.T) {
 			}
 		})
 	}
+}
+
+// turnCapFieldSuffix is the naming convention every turn-cap config field
+// follows (ClaudeMaxTurns today), so turnCapProbeConfig can fill the ones a
+// provider added later brings with it.
+const turnCapFieldSuffix = "MaxTurns"
+
+// testTurnCap is the positive cap fed to every turn-cap config field.
+const testTurnCap = 40
+
+// TestTurnLimitEnvMatchesProviderTurnCap guards the fact TurnLimitEnv hardcodes:
+// that Claude is the only backend actually passing a turn cap down. That fact
+// lives in the providers' Build methods, while TurnLimitEnv and TestTurnLimitEnv
+// both just repeat it — so nothing today notices the two drifting apart. Concretely:
+// a provider that starts setting agent.Options.MaxTurns really does enforce a cap,
+// yet the terminal message would stay silent about the knob that raises it, and
+// every other test would still pass. Asserting the biconditional over the whole
+// registry also covers providers that do not exist yet: enforcing a cap and naming
+// its env var must always come together, in both directions.
+func TestTurnLimitEnvMatchesProviderTurnCap(t *testing.T) {
+	registry := DefaultRegistry()
+	if len(registry.providers) == 0 {
+		t.Fatal("DefaultRegistry() registered no providers")
+	}
+	for name, p := range registry.providers {
+		t.Run(name, func(t *testing.T) {
+			cfg := turnCapProbeConfig(t)
+			cfg.AIBackend = name
+			_, opts, _, err := registry.Build(cfg)
+			if err != nil {
+				// A provider that fails to build proves nothing: opts.MaxTurns stays zero
+				// and the assertion below would pass vacuously. Every provider registered
+				// today builds from turnCapProbeConfig; one that needs more (real
+				// credentials, say) must either get them there or be skipped right here
+				// with the reason spelled out — never let the error slide.
+				t.Fatalf("Build(%q) error = %v, want a provider that builds from turnCapProbeConfig", name, err)
+			}
+			capped := opts.MaxTurns > 0
+			knob := TurnLimitEnv(p.Name())
+			if capped != (knob != "") {
+				t.Fatalf("provider %q: Options.MaxTurns = %d, TurnLimitEnv = %q — a provider that caps turns must "+
+					"name the env var that sets it, and only such a provider may name one",
+					p.Name(), opts.MaxTurns, knob)
+			}
+		})
+	}
+}
+
+// turnCapProbeConfig returns a config every registered provider can build from,
+// with EVERY turn-cap field set to a positive value. Those fields are filled by
+// reflection rather than named one by one on purpose: a provider that gains a cap
+// brings its own <Provider>MaxTurns field, and a probe config that only sets
+// ClaudeMaxTurns would read back a zero cap for it and pass vacuously — missing
+// exactly the drift the caller exists to catch. The credentials are the same
+// throwaway values the other Build tests use.
+func turnCapProbeConfig(t *testing.T) config.Config {
+	t.Helper()
+	cfg := config.Config{
+		ClaudeBin:              "claude",
+		CodexBin:               "codex",
+		CodexAuthMode:          config.CodexAuthSubscription,
+		CodexRequireAuth:       false,
+		OpenAICompatBaseURL:    "https://example.test/v1",
+		OpenAICompatModel:      "qwen-plus",
+		OpenAICompatAuthMode:   config.OpenAICompatAuthAPIKey,
+		OpenAICompatAPIKey:     "sk-test",
+		OpenAICompatBillingAck: true,
+	}
+	value := reflect.ValueOf(&cfg).Elem()
+	fields := value.Type()
+	filled := 0
+	for i := 0; i < fields.NumField(); i++ {
+		field := fields.Field(i)
+		if !strings.HasSuffix(field.Name, turnCapFieldSuffix) || field.Type.Kind() != reflect.Int {
+			continue
+		}
+		value.Field(i).SetInt(testTurnCap)
+		filled++
+	}
+	if filled == 0 {
+		t.Fatalf("no config field ends in %q: the turn-cap naming convention changed, "+
+			"so this config no longer feeds any provider a cap", turnCapFieldSuffix)
+	}
+	return cfg
 }
 
 func TestBuildRejectsUnknownProvider(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -81,6 +81,12 @@ var (
 	ErrOpenAICompatUnknownAuthMode = errors.New("unknown OPENAI_COMPAT_AUTH_MODE")
 )
 
+// ClaudeMaxTurnsEnv is the environment variable that configures the Claude
+// backend's agent turn cap. It is exported so a user-facing message can name the
+// knob that raises the cap without hardcoding the string outside this package.
+// It must stay equal to the ClaudeMaxTurns struct tag below; a test asserts it.
+const ClaudeMaxTurnsEnv = "CLAUDE_MAX_TURNS"
+
 // Config holds all runtime configuration sourced from the environment. Field
 // names and env keys mirror adapters/telegram/.env.example for deploy parity.
 // The per-transport tokens are parsed but NOT marked env-required: each binary

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -86,6 +87,19 @@ func TestLoad(t *testing.T) {
 				t.Fatalf("SlogLevel() = %v, want %v", cfg.SlogLevel(), tt.wantLevel)
 			}
 		})
+	}
+}
+
+// TestClaudeMaxTurnsEnvMatchesStructTag pins the exported knob name to the struct
+// tag that actually parses it, so renaming one without the other cannot silently
+// make the terminal turn-limit message point at a variable nobody reads.
+func TestClaudeMaxTurnsEnvMatchesStructTag(t *testing.T) {
+	field, ok := reflect.TypeOf(Config{}).FieldByName("ClaudeMaxTurns")
+	if !ok {
+		t.Fatal("Config has no ClaudeMaxTurns field")
+	}
+	if got := field.Tag.Get("env"); got != ClaudeMaxTurnsEnv {
+		t.Fatalf("ClaudeMaxTurns env tag = %q, want ClaudeMaxTurnsEnv %q", got, ClaudeMaxTurnsEnv)
 	}
 }
 


### PR DESCRIPTION
## Summary

A run that exhausted the agent turn cap was reported to the user as a generic failure. The
delivered message was whatever the provider put in the result envelope — for this subtype a fixed
`Reached the maximum number of turns.` — under a `⚠️ Failed after …` notice. That wording is wrong
in a way that costs the user real time: a turn-limit stop is a **configured cutoff**, not a crash,
and nothing in the message said which knob controls it or what it was currently set to.

This PR makes that stop explain itself.

**Before**

> ⚠️ Reached the maximum number of turns.
>
> `⚠️ Failed after 1m 35s`

**After**

> ⚠️ The run stopped because it reached its turn limit (250 of 250 turns) — not a crash, timeout or
> API error. Everything already written, committed or pushed is kept in the workspace, but the
> stopped run's chat context may not carry over — restate anything you want continued in your next
> message. To allow longer runs, raise `CLAUDE_MAX_TURNS` (current: 250) and restart the bot.
> (error_max_turns)
>
> `⏹ Turn limit reached after 1m 35s`

Every clause appears **only when the fact behind it is actually known**. With no cap configured the
message names no value and does not claim to know the provider's fallback:

> …No turn cap is configured for this bot, so the run was bound by whatever default the provider
> applies. Set `CLAUDE_MAX_TURNS` and restart the bot to control it. (error_max_turns)

## Related issue

None.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / internal change
- [ ] Documentation
- [ ] Build / CI / dependencies

## What changed, per acceptance criterion

- [x] **AC1 — the message states the cause and keeps the raw token.** It names the turn limit,
  explicitly rules out a crash/timeout/API error, and retains `error_max_turns`. The token is the
  provider's own stable, unlocalized name for the stop; nothing on this path logs it, so the
  delivered message is the only place it ever surfaces.
- [x] **AC2 — it names the knob and the cap actually in force.** `RunLimits{MaxTurns, MaxTurnsEnv}`
  is threaded into the renderer. `finish()` passes `s.opts.MaxTurns`, which is the cap that bound
  the run: `s.opts` is written only in `New` and never mutated, `run()` copies it and overwrites
  only `Images`/`Workdir`/`SessionID`, and the one other override (`runEvaluator`'s `EvalMaxTurns`)
  produces a result consumed inside the post-run loop that never reaches `finish` — which has a
  single call site.
- [x] **AC3 — the completion notice no longer says "failed".** It reads `⏹ Turn limit reached`, and
  only when the stop is genuinely clean (`runErr == nil`); with a run error set, `finish` renders
  `FinalError` instead, so the notice keeps the failure wording that matches the delivered answer.
- [x] **AC4 — `core/chat` stays free of provider env names.** The adapter supplies the name via the
  new `chat.Config.MaxTurnsEnv`, derived from `airunner.TurnLimitEnv(provider)`. There is no
  `CLAUDE_*` string anywhere under `core/`. `config.ClaudeMaxTurnsEnv` is exported and pinned equal
  to the struct tag by a reflection test.
- [x] **AC5 — the knob name cannot break out of its code span.** It is operator-supplied, so it is
  sanitized (backticks and all Unicode whitespace stripped) before interpolation; a name that
  sanitizes to empty drops the clause rather than emitting empty backticks.
- [x] **AC6 — the turn count rides along only when it corroborates the cap.** `num_turns` semantics
  are not verified, so a count that contradicts the sentence is dropped rather than shown.

The zero value of `chat.Config.MaxTurnsEnv` reproduces the previous behaviour byte-for-byte, so
embedders that do not set it are unaffected.

## How it was verified

```bash
task lint    # 0 issues
task tests   # go test -race ./... — all 30 packages ok
task build   # ok
```

Run in the foreground on the final tree. Coverage added for the message itself (11 table cases
spanning every combination of known/unknown cap and knob, plus a hostile knob name), the delivered
end-to-end message carrying the runtime cap, the notice wording, and the provider→knob mapping.
`TestFinalKeepsWordingOutsideTurnLimit` pins every **other** error subtype's rendering byte-for-byte
so this change cannot have moved them.

One unrelated flake was observed and characterised, not ignored: `core/ghstar TestIsStarred/starred`
failed once under full-suite parallel load with `http: CloseIdleConnections called`. It is a
`t.Parallel()` test against a local `httptest` server, `core/ghstar` imports nothing from this diff,
and it passed 5/5 in isolation and on the following full-suite run.

## Pre-PR review

Two independent critics reviewed the local diff (correctness/security, and the reuse /
simplification / efficiency / altitude design lenses), then a third re-derived a pass from scratch
over the fixes. **No round found a blocker or a major.** Both later rounds were spent on findings
the critics converged on, all of which are fixed here:

- The provider's boilerplate `result` text was being echoed **above** the explanation, so the
  message opened with a duplicate of its own next line. Dropped — gated on the subtype rather than
  on matching the sentence, so a reworded boilerplate cannot start leaking back in.
- The no-cap clause contradicted the sentence it followed ("reached its turn limit" / "no turn cap
  is configured"). It now names the connective without claiming to know the provider's fallback.
- A new test reused `assertMarkdownSafe`, a helper documented for *stage lines* where all markup is
  stripped. The turn-limit message deliberately keeps `_` in the knob name, so the helper passed
  only because both fixtures happened to have an even underscore count — a realistic
  `MAX_TURNS` would have failed a perfectly safe message, pressuring the next reader into stripping
  `_`. Replaced with a code-span-aware assertion, and covered by a case with an odd underscore
  count that fails under the old helper.
- The turn-cap probe's `filled == 0` guard could never fire (`GoalEvalMaxTurns` also matches the
  suffix while feeding no provider), so a rename left it silent and blamed the provider instead.
  Now asserts the field that actually feeds a provider; mutation-tested to fail with the right
  diagnostic.
- A comment justified keeping the raw subtype as "what an operator greps for in the logs". It is
  logged in exactly one place repo-wide — the goal-evaluator path, which never renders this
  message. Rationale corrected.

### Residual risks — what still needs a human eye

1. **No live envelope was captured.** Every claim about the provider's payload rests on
   `core/claude/testdata/error.jsonl`, not on a real CLI run. Two things ride on it: that the
   `result` text for this subtype is always that fixed boilerplate, and that `num_turns` equals the
   cap. If a CLI version ever puts a partial answer in `result`, this PR **drops it from chat**
   entirely — assistant text otherwise only feeds the transient progress ring. Worth one real
   `error_max_turns` run to confirm before trusting the drop.
2. **A turn-limit stop still clears the chat session** (`core/chat/service.go:631` treats any
   `is_error` result as a poisoned session). That is precisely what forces the message to hedge
   "chat context may not carry over" — the one stop where the user most wants to continue. Both
   critics called this the highest-value follow-up. It changes resume semantics, so it deserves its
   own acceptance criteria and its own PR rather than being slipped in here.
3. **`Final` is an exported symbol** of a public module path; its signature change is breaking for
   any external importer.
4. **The provider→knob drift guard is convention-bound.** It catches a future provider that gains a
   cap via a `<Provider>MaxTurns` config field; a cap wired from a differently named field reads
   back as zero and passes silently. The limitation is stated in the helper's comment.
5. **The `⚠️` prefix on the answer** now sits slightly at odds with the `⏹` notice and with the
   sentence's own "not a crash" — deliberate for now, since `⚠️` is what flags a non-clean result
   generally, but it is a reasonable thing to challenge in review.

## Checklist

- [x] `task lint`, `task tests`, and `task build` pass locally
- [x] Tests added/updated for the change
- [x] Docs updated if behavior or configuration changed — `CLAUDE_MAX_TURNS` already documented in
      both `.env.example` files; no new variable is introduced
- [x] The change is focused — no unrelated churn
- [x] Commits follow Conventional Commits
