### PR TITLE
feat(lo): add bot adapter with optional streaming progress

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,9 +10,11 @@ adapters/telegram/deploy
 
 # Local runtime env (the image is configured at runtime, not build time).
 adapters/telegram/.env
+adapters/lo/.env
 
 # Go build/test caches and any locally-built binaries — never part of the image
 # (the binary is compiled fresh in the build stage).
+bin
 .gocache
 .cache
 flock-telegram

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,8 +143,7 @@ jobs:
       - uses: docker/build-push-action@v7
         with:
           context: .
-          file: ./adapters/telegram/Dockerfile
-          build-args: FLOCK_COMMAND=flock-lo
+          file: ./adapters/lo/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: false
           cache-from: type=gha,scope=lo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,3 +131,21 @@ jobs:
           push: false
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  lo-image:
+    name: Build LO image (no push)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v7
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./adapters/telegram/Dockerfile
+          build-args: FLOCK_COMMAND=flock-lo
+          platforms: linux/amd64,linux/arm64
+          push: false
+          cache-from: type=gha,scope=lo
+          cache-to: type=gha,mode=max,scope=lo

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Everything else in [`.env.example`](adapters/telegram/.env.example) has sensible
 | `VK_GROUP_ID` | your community's numeric id (long-poll server + mention parse) |
 | `VK_ALLOWED_USERS` | comma-separated VK user IDs allowed to use the bot |
 
-**LO** has a text-first adapter with its own allow-list and workspace namespace. Build it locally using [`adapters/lo/`](adapters/lo/README.md); no prebuilt LO image is published by this change. See the [LO / Telegram compatibility audit](docs/lo-telegram-compatibility.md) for supported commands, optional streaming, and platform gaps.
+**LO** has a text-first adapter with its own allow-list and workspace namespace. LO images are not published; build locally using [`adapters/lo/`](adapters/lo/README.md). The LO entry point does not wire PR-comment polling, CI watch or interrupted-run recovery. See the [LO / Telegram compatibility audit](docs/lo-telegram-compatibility.md) for supported commands, optional streaming, and platform gaps.
 
 ## Highlights
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 # Flock
 
-**Run a Claude Code AI dev team on your server and drive it from chat.** Describe a feature in Telegram or VK; the team plans it, builds it on a branch, tests it, reviews it, and opens a PR — each chat in its own isolated workspace.
+**Run a Claude Code AI dev team on your server and drive it from chat.** Describe a feature in Telegram, VK or LO; the team plans it, builds it on a branch, tests it, reviews it, and opens a PR — each chat in its own isolated workspace.
 
 [![CI](https://github.com/duckbugio/flock/actions/workflows/ci.yml/badge.svg)](https://github.com/duckbugio/flock/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
@@ -50,12 +50,14 @@ Everything else in [`.env.example`](adapters/telegram/.env.example) has sensible
 | `VK_GROUP_ID` | your community's numeric id (long-poll server + mention parse) |
 | `VK_ALLOWED_USERS` | comma-separated VK user IDs allowed to use the bot |
 
+**LO** has a text-first adapter with its own allow-list and workspace namespace. Build it locally using [`adapters/lo/`](adapters/lo/README.md); no prebuilt LO image is published by this change. See the [LO / Telegram compatibility audit](docs/lo-telegram-compatibility.md) for supported commands, optional streaming, and platform gaps.
+
 ## Highlights
 
 - **The conversation is the task source** — describe what you want in chat and review the PR that comes back; the agent's shell and editor are sandboxed inside the container.
 - **A real dev-team pipeline, not a single prompt** — spec-first acceptance criteria, build/regression gates, and an arbiter that breaks loops.
 - **Autonomy loops** — the bot **verifies its own "done"** by re-running the repo's check gate itself; `/goal` arms an **independent evaluator** that loops the team until your criterion actually holds; `/schedule` runs recurring jobs; an optional **CI watch** reacts to red builds (and can auto-merge green PRs) — all under a per-chat daily autonomy budget. See [Autonomy loops](#autonomy-loops).
-- **Multi-transport** — **Telegram** and **VK** today, both on the same core; a new platform is a thin adapter, not a fork.
+- **Multi-transport** — **Telegram**, **VK** and a text-first **LO** adapter on the same core; a new platform is a thin adapter, not a fork.
 - **PR reactions without inbound webhooks** — the bot *polls* your git host for new review comments and routes each back to the chat that opened the PR.
 - **Subscription-friendly** — authenticate with a Claude Pro/Max token (no per-token cost) or an Anthropic API key.
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -95,3 +95,4 @@ tasks:
     cmds:
       - echo "- Build"
       - "{{.DEV_TOOLS}} go build -o bin/flock-telegram ./cmd/flock-telegram"
+      - "{{.DEV_TOOLS}} go build -o bin/flock-lo ./cmd/flock-lo"

--- a/adapters/lo/.env.example
+++ b/adapters/lo/.env.example
@@ -1,0 +1,26 @@
+# Required. Use LO credentials and LO user IDs, never Telegram credentials/IDs.
+# HTTPS base URL of the deployed LO Bot API, without /bot<TOKEN>/<method>.
+# No public endpoint is guessed here; obtain it from your LO deployment.
+LO_API_URL=
+LO_BOT_TOKEN=
+LO_ALLOWED_USERS=
+
+# Choose the same AI backend/auth options as other Flock adapters.
+CLAUDE_CODE_OAUTH_TOKEN=
+# ANTHROPIC_API_KEY=
+# AI_BACKEND=codex
+# Codex subscription auth uses the dedicated codex_home volume.
+
+# Defaults work with the current LO main Bot API subset.
+# Enable only after the corresponding server AND client changes are released.
+LO_ENABLE_DRAFTS=false
+LO_REGISTER_COMMANDS=false
+REQUIRE_GROUP_MENTION=true
+
+# The LO binary adds /lo automatically to isolate chat IDs from other adapters.
+APPROVED_DIRECTORY=/workspace
+# Shared Flock options (Git, limits, MCP, /goal, /schedule) are documented in
+# ../telegram/.env.example. Explicit *_STORE_PATH overrides must be LO-specific.
+# GIT_HOST=github.com
+# GIT_TOKEN=
+# ENABLE_SCHEDULER=false

--- a/adapters/lo/.env.example
+++ b/adapters/lo/.env.example
@@ -26,3 +26,6 @@ SHUTDOWN_DRAIN_SECONDS=45
 # GIT_HOST=github.com
 # GIT_TOKEN=
 # ENABLE_SCHEDULER=false
+
+# Consumed by docker-compose mem_limit, not the bot.
+BOT_MEM_LIMIT=3g

--- a/adapters/lo/.env.example
+++ b/adapters/lo/.env.example
@@ -19,6 +19,8 @@ REQUIRE_GROUP_MENTION=true
 
 # The LO binary adds /lo automatically to isolate chat IDs from other adapters.
 APPROVED_DIRECTORY=/workspace
+# Shared graceful drain; capped at 60s to fit the Compose 75s stop window.
+SHUTDOWN_DRAIN_SECONDS=45
 # Shared Flock options (Git, limits, MCP, /goal, /schedule) are documented in
 # ../telegram/.env.example. Explicit *_STORE_PATH overrides must be LO-specific.
 # GIT_HOST=github.com

--- a/adapters/lo/Dockerfile
+++ b/adapters/lo/Dockerfile
@@ -1,9 +1,9 @@
-# Self-contained image for the Flock AI dev-team Telegram bot (Go rewrite).
+# Self-contained image for the Flock AI dev-team LO bot (Go rewrite).
 # A multi-stage build: compile the static Go binary, then assemble a slim runtime
 # with Node + the `claude`/`codex` CLIs and the tools the team shells out to.
 # Behaviour is toggled at RUNTIME via env (see .env.example).
-# Built & published by .github/workflows/publish-telegram.yml -> ghcr.io/duckbugio/flock-telegram
-# Build context is the REPO ROOT (COPY paths are root-relative): docker build -f adapters/telegram/Dockerfile .
+# Built locally and validated by the LO image CI job.
+# Build context is the REPO ROOT (COPY paths are root-relative): docker build -f adapters/lo/Dockerfile .
 
 # --- Build stage: compile the Go binary ---------------------------------------
 # Build on the native BUILDPLATFORM and cross-compile to TARGETARCH (CGO off), so
@@ -25,7 +25,7 @@ COPY internal/ ./internal/
 ARG TARGETOS
 ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
-    go build -buildvcs=false -trimpath -ldflags "-s -w" -o /out/flock-telegram ./cmd/flock-telegram
+    go build -buildvcs=false -trimpath -ldflags "-s -w" -o /out/flock-lo ./cmd/flock-lo
 
 # --- Runtime stage ------------------------------------------------------------
 # node:24 (current LTS) supplies Node (for the `claude` CLI). Add git/ripgrep/ffmpeg
@@ -178,7 +178,7 @@ RUN userdel -r node 2>/dev/null || true; \
  && chown -R claude:claude /workspace /app /home/claude/.claude /home/claude/.codex /opt/duck
 
 # The compiled bot.
-COPY --from=build /out/flock-telegram /usr/local/bin/flock-telegram
+COPY --from=build /out/flock-lo /usr/local/bin/flock-lo
 
 # Shared team config — rendered per chat into the workspace by core/workspace at runtime.
 COPY --chown=claude:claude core/agents/*.md /opt/duck/agents/
@@ -192,4 +192,4 @@ ENV HOME=/home/claude \
 
 WORKDIR /app
 # The Go binary wires git + renders the workspace itself (no shell entrypoint needed).
-ENTRYPOINT ["/usr/local/bin/flock-telegram"]
+ENTRYPOINT ["/usr/local/bin/flock-lo"]

--- a/adapters/lo/Dockerfile
+++ b/adapters/lo/Dockerfile
@@ -8,7 +8,7 @@
 # --- Build stage: compile the Go binary ---------------------------------------
 # Build on the native BUILDPLATFORM and cross-compile to TARGETARCH (CGO off), so
 # multi-arch builds don't pay for emulation.
-FROM --platform=$BUILDPLATFORM golang:1.26-bookworm AS build
+FROM --platform=$BUILDPLATFORM golang:1.27-bookworm AS build
 
 WORKDIR /src
 

--- a/adapters/lo/README.md
+++ b/adapters/lo/README.md
@@ -40,8 +40,15 @@ stores live below `<APPROVED_DIRECTORY>/lo`, isolating equal numeric chat IDs.
 Explicit store-path overrides and authentication volumes should also be unique
 to the LO deployment.
 
+Graceful shutdown honors `SHUTDOWN_DRAIN_SECONDS` (45 seconds by default, capped
+at 60 with a startup warning). Compose allows 75 seconds, leaving room for the
+shared dispatcher's ten-second post-cancel delivery window.
+
 Run one polling replica per token. Startup checks `getMe` and `getWebhookInfo`;
-an existing webhook is an error, never automatically deleted. `getUpdates`
+an existing webhook is an error, never automatically deleted. Explicit API
+404/501 from `getWebhookInfo` logs a warning and continues to polling; `getUpdates`
+still refuses a webhook/poller conflict with 409. Authentication failures and other
+startup-check errors remain fatal. `getUpdates`
 retains queued messages, advances the offset after dispatch, and does not request
 callback/edited-message updates it cannot handle. As with ordinary long polling,
 a crash before the next offset acknowledgement can redeliver the last batch;

--- a/adapters/lo/README.md
+++ b/adapters/lo/README.md
@@ -62,7 +62,9 @@ this adapter does not promise exactly-once agent execution or automatic resume.
   `reply_markup`, `reply_parameters`, `parse_mode` or `rich_message` is sent.
 - `LO_ENABLE_DRAFTS=true` opts into private-chat `sendMessageDraft`: stable
   nonzero draft ID per run, full accumulated progress text, final `sendMessage`.
-  The core keeps draft IDs separate from message IDs. Initial refusal (including
+  The core keeps draft IDs separate from message IDs and explicitly clears the
+  draft with empty text before final delivery, including cancellation. Cleanup
+  has a separate two-second budget; its failure never prevents the final send. Initial refusal (including
   groups or older LO versions) falls back to the editable anchor. The core's
   three-second cadence respects the existing backoff behavior; no token-by-token
   database edits are needed. This streams **Flock's progress frame**, not every

--- a/adapters/lo/README.md
+++ b/adapters/lo/README.md
@@ -17,10 +17,9 @@ docker compose up --build -d
 `LO_API_URL` is the deployed Bot API base, for example an operator-supplied HTTPS
 origin with an optional gateway path. Requests are posted to
 `<base>/bot<LO_BOT_TOKEN>/<method>`. Do not use the Mini App Connect endpoint.
-There is deliberately no guessed production URL or published LO image. The build
-reuses Flock's existing AI runtime Dockerfile, selecting `FLOCK_COMMAND=flock-lo`.
-The historical executable path inside that image remains `flock-telegram`; the
-compiled program is `cmd/flock-lo`.
+There is deliberately no guessed production URL or published LO image. The dedicated
+`adapters/lo/Dockerfile` builds and runs `/usr/local/bin/flock-lo`, with the same
+AI tooling as the other adapters. Compose caps memory with `BOT_MEM_LIMIT` (3g by default).
 
 For a host with Go and the selected AI CLI installed:
 
@@ -47,7 +46,7 @@ shared dispatcher's ten-second post-cancel delivery window.
 Run one polling replica per token. Startup checks `getMe` and `getWebhookInfo`;
 an existing webhook is an error, never automatically deleted. Explicit API
 404/501 from `getWebhookInfo` logs a warning and continues to polling; `getUpdates`
-still refuses a webhook/poller conflict with 409. Authentication failures and other
+retries transient 409 conflicts and stops after five consecutive conflicts. Authentication failures and other
 startup-check errors remain fatal. `getUpdates`
 retains queued messages, advances the offset after dispatch, and does not request
 callback/edited-message updates it cannot handle. As with ordinary long polling,
@@ -60,6 +59,8 @@ this adapter does not promise exactly-once agent execution or automatic resume.
   `/command@botname` when `REQUIRE_GROUP_MENTION=true`. This requires a bot
   username from LO. Startup warns if it is missing; use private chats or disable
   the mention requirement until the bot has a username.
+- Reserved commands bypass the group mention requirement; `/command@other_bot`
+  is still rejected and the user allow-list always applies.
 - `/start`, `/help`, `/new`, `/stop`, `/goal`, `/schedule`; other slash commands
   reach the selected AI provider unchanged. `/stop` works while another run is
   active because admission uses Flock's nonblocking dispatcher.

--- a/adapters/lo/README.md
+++ b/adapters/lo/README.md
@@ -1,0 +1,91 @@
+# LO adapter
+
+`flock-lo` connects a dedicated LO bot to the shared Flock agent service. It uses
+LO's Telegram-shaped **supported subset**, not the Telegram adapter with a new
+base URL. Telegram and VK behavior remain unchanged unless their transports
+explicitly opt into the new draft capability.
+
+## Start
+
+```sh
+cd adapters/lo
+cp .env.example .env
+# Set LO_API_URL, LO_BOT_TOKEN, LO_ALLOWED_USERS and AI provider authentication.
+docker compose up --build -d
+```
+
+`LO_API_URL` is the deployed Bot API base, for example an operator-supplied HTTPS
+origin with an optional gateway path. Requests are posted to
+`<base>/bot<LO_BOT_TOKEN>/<method>`. Do not use the Mini App Connect endpoint.
+There is deliberately no guessed production URL or published LO image. The build
+reuses Flock's existing AI runtime Dockerfile, selecting `FLOCK_COMMAND=flock-lo`.
+The historical executable path inside that image remains `flock-telegram`; the
+compiled program is `cmd/flock-lo`.
+
+For a host with Go and the selected AI CLI installed:
+
+```sh
+go build -o bin/flock-lo ./cmd/flock-lo
+# Export the variables from your deployment configuration, then:
+./bin/flock-lo
+```
+
+The host run also needs `TEAM_TEMPLATE_PATH`, `TEAM_AGENTS_DIR`, and
+`TEAM_SKILLS_DIR` pointing at this checkout's `core` files (the container sets up
+those paths). See the shared env template for exact option names and defaults.
+
+Only positive IDs listed in `LO_ALLOWED_USERS` can invoke commands or agents.
+This allow-list never falls back to Telegram/VK IDs. Workspaces and default state
+stores live below `<APPROVED_DIRECTORY>/lo`, isolating equal numeric chat IDs.
+Explicit store-path overrides and authentication volumes should also be unique
+to the LO deployment.
+
+Run one polling replica per token. Startup checks `getMe` and `getWebhookInfo`;
+an existing webhook is an error, never automatically deleted. `getUpdates`
+retains queued messages, advances the offset after dispatch, and does not request
+callback/edited-message updates it cannot handle. As with ordinary long polling,
+a crash before the next offset acknowledgement can redeliver the last batch;
+this adapter does not promise exactly-once agent execution or automatic resume.
+
+## Behavior
+
+- Private chats and groups; group prompts require an exact `@botname` token or
+  `/command@botname` when `REQUIRE_GROUP_MENTION=true`.
+- `/start`, `/help`, `/new`, `/stop`, `/goal`, `/schedule`; other slash commands
+  reach the selected AI provider unchanged. `/stop` works while another run is
+  active because admission uses Flock's nonblocking dispatcher.
+- Rate/cost guards, per-chat workspaces and sessions, optional post-run checks,
+  goal evaluation, follow-ups and scheduler use the shared core. Store failures
+  at startup do not silently disable the cost cap.
+- Plain-text progress is edited in place by default, followed by the final
+  answer. Native replies degrade to ordinary notices. No unsupported
+  `reply_markup`, `reply_parameters`, `parse_mode` or `rich_message` is sent.
+- `LO_ENABLE_DRAFTS=true` opts into private-chat `sendMessageDraft`: stable
+  nonzero draft ID per run, full accumulated progress text, final `sendMessage`.
+  The core keeps draft IDs separate from message IDs. Initial refusal (including
+  groups or older LO versions) falls back to the editable anchor. The core's
+  three-second cadence respects the existing backoff behavior; no token-by-token
+  database edits are needed. This streams **Flock's progress frame**, not every
+  raw model token (the runner's final answer is delivered normally).
+- `LO_REGISTER_COMMANDS=true` opts into `setMyCommands`. Failure is logged and
+  does not disable text commands. It remains off by default for LO main versions
+  where the method is still a 501 stub.
+- Files, voice, native callback buttons, rich messages, and the interactive star
+  nudge are unavailable. Incoming attachments get a clear notice; they are not
+  silently stripped from an AI prompt. Outbox delivery is disabled. Agent-created
+  files remain in the workspace/repository and must be retrieved there. LO
+  workspace instructions explicitly disable automatic file-delivery promises.
+- The LO command does not yet wire Telegram's interrupted-run recovery, CI watch
+  or PR-comment polling. These are **Flock adapter gaps**, not missing LO API
+  methods. The scheduler and goal evaluator are supported.
+
+The shared chunker currently measures runes rather than UTF-16. LO advertises a
+conservative 2048-rune limit, guaranteeing every chunk fits 4096 UTF-16 units even
+when all characters are astral emoji. This intentionally uses smaller chunks for
+BMP-only text; the transport also validates the actual UTF-16 length.
+
+## Verification and migration findings
+
+See [the compatibility audit](../../docs/lo-telegram-compatibility.md). Local
+contract tests use HTTP fixtures derived from the LO handlers; they do not claim
+that a public LO deployment, mobile build or real bot token has been exercised.

--- a/adapters/lo/README.md
+++ b/adapters/lo/README.md
@@ -46,7 +46,9 @@ shared dispatcher's ten-second post-cancel delivery window.
 Run one polling replica per token. Startup checks `getMe` and `getWebhookInfo`;
 an existing webhook is an error, never automatically deleted. Explicit API
 404/501 from `getWebhookInfo` logs a warning and continues to polling; `getUpdates`
-retries transient 409 conflicts and stops after five consecutive conflicts. Authentication failures and other
+retries transient 409 conflicts with ten-second waits and stops on the fifth
+consecutive conflict (40 seconds of waiting, covering the 30-second long poll).
+Cancellation interrupts the wait immediately. Authentication failures and other
 startup-check errors remain fatal. `getUpdates`
 retains queued messages, advances the offset after dispatch, and does not request
 callback/edited-message updates it cannot handle. As with ordinary long polling,
@@ -80,8 +82,8 @@ this adapter does not promise exactly-once agent execution or automatic resume.
   database edits are needed. This streams **Flock's progress frame**, not every
   raw model token (the runner's final answer is delivered normally).
 - `LO_REGISTER_COMMANDS=true` opts into `setMyCommands`. Failure is logged and
-  does not disable text commands. It remains off by default for LO main versions
-  where the method is still a 501 stub.
+  does not disable text commands. The current server implements this method; registration remains
+  opt-in until live acceptance with the deployment's bot token is complete.
 - Files, voice, native callback buttons, rich messages, and the interactive star
   nudge are unavailable. Incoming attachments get a clear notice; they are not
   silently stripped from an AI prompt. Outbox delivery is disabled. Agent-created

--- a/adapters/lo/README.md
+++ b/adapters/lo/README.md
@@ -57,7 +57,9 @@ this adapter does not promise exactly-once agent execution or automatic resume.
 ## Behavior
 
 - Private chats and groups; group prompts require an exact `@botname` token or
-  `/command@botname` when `REQUIRE_GROUP_MENTION=true`.
+  `/command@botname` when `REQUIRE_GROUP_MENTION=true`. This requires a bot
+  username from LO. Startup warns if it is missing; use private chats or disable
+  the mention requirement until the bot has a username.
 - `/start`, `/help`, `/new`, `/stop`, `/goal`, `/schedule`; other slash commands
   reach the selected AI provider unchanged. `/stop` works while another run is
   active because admission uses Flock's nonblocking dispatcher.

--- a/adapters/lo/bot.go
+++ b/adapters/lo/bot.go
@@ -1,0 +1,180 @@
+package lo
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"io"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/duckbugio/flock/core/chat"
+)
+
+// ErrUnsupported identifies an operation absent from LO's supported bot surface.
+var ErrUnsupported = errors.New("operation is not supported by the LO adapter")
+
+const (
+	maxTextUnits    = 4096
+	maxUnitsPerRune = 2
+	maxBMPRune      = 0xffff
+)
+
+// Transport implements text delivery and optional ephemeral progress for LO.
+// Markdown is kept as plain source until LO's formatter is released and verified.
+type Transport struct {
+	api    *Client
+	drafts bool
+}
+
+// NewTransport enables drafts only when the deployment explicitly advertises them.
+func NewTransport(api *Client, drafts bool) *Transport { return &Transport{api: api, drafts: drafts} }
+
+// Capabilities deliberately disables file outbox and rich messages. A half-size
+// rune budget guarantees the 4096 UTF-16 unit limit even for all-emoji answers.
+func (t *Transport) Capabilities() chat.Capabilities {
+	return chat.Capabilities{MaxMessageRunes: maxTextUnits / maxUnitsPerRune, CanSendDraft: t.drafts}
+}
+
+func numericID(value string) (int64, error) {
+	id, err := strconv.ParseInt(value, 10, 64)
+	if err != nil || id == 0 {
+		return 0, errors.New("invalid LO identifier")
+	}
+	return id, nil
+}
+
+func messageText(text string) error {
+	if !utf8.ValidString(text) || strings.TrimSpace(text) == "" {
+		return errors.New("LO text is empty or invalid UTF-8")
+	}
+	units := 0
+	for _, r := range text {
+		units++
+		if r > maxBMPRune {
+			units++
+		}
+	}
+	if units > maxTextUnits {
+		return errors.New("LO text exceeds 4096 UTF-16 units")
+	}
+	return nil
+}
+
+// Send posts only fields implemented by LO; /stop replaces the unavailable Stop keyboard.
+func (t *Transport) Send(ctx context.Context, chatID, text, _ string, _ bool) (chat.MessageID, error) {
+	id, err := numericID(chatID)
+	if err != nil {
+		return "", err
+	}
+	if err := messageText(text); err != nil {
+		return "", err
+	}
+	var result Message
+	if err := t.api.call(ctx, "sendMessage", map[string]any{"chat_id": id, "text": text}, &result); err != nil {
+		return "", err
+	}
+	if result.ID <= 0 {
+		return "", errors.New("LO sendMessage returned no message ID")
+	}
+	return strconv.FormatInt(result.ID, 10), nil
+}
+
+// SendReply degrades to a plain send: LO rejects reply_parameters rather than ignoring them.
+func (t *Transport) SendReply(ctx context.Context, chatID, _ chat.MessageID, text string, markdown bool) (chat.MessageID, error) {
+	return t.Send(ctx, chatID, text, "", markdown)
+}
+
+// Edit updates the persistent anchor in deployments without sendMessageDraft.
+func (t *Transport) Edit(ctx context.Context, chatID, messageID, text, _ string, _ bool) error {
+	id, err := numericID(chatID)
+	if err != nil {
+		return err
+	}
+	msgID, err := numericID(messageID)
+	if err != nil || msgID < 0 {
+		return errors.New("invalid LO message ID")
+	}
+	if err := messageText(text); err != nil {
+		return err
+	}
+	var result Message
+	body := map[string]any{"chat_id": id, "message_id": msgID, "text": text}
+	if err := t.api.call(ctx, "editMessageText", body, &result); err != nil {
+		return err
+	}
+	if result.ID != msgID {
+		return errors.New("LO editMessageText returned a different message ID")
+	}
+	return nil
+}
+
+// Delete removes the bot's own message.
+func (t *Transport) Delete(ctx context.Context, chatID, messageID string) error {
+	id, err := numericID(chatID)
+	if err != nil {
+		return err
+	}
+	msgID, err := numericID(messageID)
+	if err != nil || msgID < 0 {
+		return errors.New("invalid LO message ID")
+	}
+	var result bool
+	if err := t.api.call(ctx, "deleteMessage", map[string]any{"chat_id": id, "message_id": msgID}, &result); err != nil {
+		return err
+	}
+	if !result {
+		return errors.New("LO did not confirm message deletion")
+	}
+	return nil
+}
+
+// SendDocument is unavailable; Capabilities prevents the core outbox from invoking it.
+func (*Transport) SendDocument(context.Context, chat.ChatID, string, io.Reader) error {
+	return ErrUnsupported
+}
+
+// SendStarNudge is unavailable because its confirmation callback is not implemented in LO.
+func (*Transport) SendStarNudge(context.Context, chat.ChatID, string) (chat.MessageID, error) {
+	return "", ErrUnsupported
+}
+
+// SendDraft maps one run to a stable, non-zero int64 draft ID. It never returns a
+// synthetic message ID; the shared service persists the final text with Send.
+func (t *Transport) SendDraft(ctx context.Context, chatID, runID, text string) error {
+	if !t.drafts {
+		return ErrUnsupported
+	}
+	id, err := numericID(chatID)
+	if err != nil {
+		return err
+	}
+	if id < 0 {
+		return ErrUnsupported
+	} // LO drafts are private-chat only.
+	if err := messageText(text); err != nil {
+		return err
+	}
+	digest := sha256.Sum256([]byte(runID))
+	const positiveMask = uint64(1<<63 - 1)
+	draftID := binary.BigEndian.Uint64(digest[:8]) & positiveMask
+	if draftID == 0 {
+		draftID = 1
+	}
+	var result bool
+	body := map[string]any{"chat_id": id, "draft_id": draftID, "text": text}
+	if err := t.api.call(ctx, "sendMessageDraft", body, &result); err != nil {
+		return err
+	}
+	if !result {
+		return errors.New("LO did not confirm draft delivery")
+	}
+	return nil
+}
+
+var (
+	_ chat.Transport      = (*Transport)(nil)
+	_ chat.DraftTransport = (*Transport)(nil)
+)

--- a/adapters/lo/bot.go
+++ b/adapters/lo/bot.go
@@ -144,6 +144,18 @@ func (*Transport) SendStarNudge(context.Context, chat.ChatID, string) (chat.Mess
 // SendDraft maps one run to a stable, non-zero int64 draft ID. It never returns a
 // synthetic message ID; the shared service persists the final text with Send.
 func (t *Transport) SendDraft(ctx context.Context, chatID, runID, text string) error {
+	if err := messageText(text); err != nil {
+		return err
+	}
+	return t.sendDraft(ctx, chatID, runID, text)
+}
+
+// ClearDraft explicitly removes the run's ephemeral progress using LO's empty-text contract.
+func (t *Transport) ClearDraft(ctx context.Context, chatID, runID string) error {
+	return t.sendDraft(ctx, chatID, runID, "")
+}
+
+func (t *Transport) sendDraft(ctx context.Context, chatID, runID, text string) error {
 	if !t.drafts {
 		return ErrUnsupported
 	}
@@ -154,9 +166,6 @@ func (t *Transport) SendDraft(ctx context.Context, chatID, runID, text string) e
 	if id < 0 {
 		return ErrUnsupported
 	} // LO drafts are private-chat only.
-	if err := messageText(text); err != nil {
-		return err
-	}
 	digest := sha256.Sum256([]byte(runID))
 	const positiveMask = uint64(1<<63 - 1)
 	draftID := binary.BigEndian.Uint64(digest[:8]) & positiveMask

--- a/adapters/lo/client.go
+++ b/adapters/lo/client.go
@@ -91,7 +91,12 @@ func (c *Client) call(ctx context.Context, method string, body, out any) error {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
-		return errors.New("LO request failed before receiving a response")
+		var urlErr *url.Error
+		if errors.As(err, &urlErr) {
+			err = urlErr.Err // The outer URL contains the bot credential.
+		}
+		reason := strings.ReplaceAll(err.Error(), c.token, "[REDACTED]")
+		return fmt.Errorf("LO request failed before receiving a response: %s", reason)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	data, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes+1))

--- a/adapters/lo/client.go
+++ b/adapters/lo/client.go
@@ -116,6 +116,9 @@ func (c *Client) call(ctx context.Context, method string, body, out any) error {
 		} `json:"parameters"`
 	}
 	if err := json.Unmarshal(data, &envelope); err != nil {
+		if resp.StatusCode >= http.StatusMultipleChoices {
+			return &APIError{Code: resp.StatusCode, Description: "non-JSON HTTP error response"}
+		}
 		return fmt.Errorf("LO returned an invalid API envelope (HTTP %d)", resp.StatusCode)
 	}
 	if !envelope.OK || resp.StatusCode != http.StatusOK {

--- a/adapters/lo/client.go
+++ b/adapters/lo/client.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -196,12 +197,18 @@ func (c *Client) GetUpdates(ctx context.Context, offset int64) ([]Update, error)
 	return updates, err
 }
 
-// CheckPolling refuses a webhook deployment rather than silently removing its webhook.
+// CheckPolling refuses an active webhook without mutating it. Older deployments
+// that explicitly lack this read method fall back to getUpdates' conflict check.
 func (c *Client) CheckPolling(ctx context.Context) error {
 	var info struct {
 		URL string `json:"url"`
 	}
 	if err := c.call(ctx, "getWebhookInfo", struct{}{}, &info); err != nil {
+		var apiErr *APIError
+		if errors.As(err, &apiErr) && (apiErr.Code == http.StatusNotFound || apiErr.Code == http.StatusNotImplemented) {
+			slog.Warn("LO deployment does not support getWebhookInfo; continuing with polling")
+			return nil
+		}
 		return err
 	}
 	if info.URL != "" {

--- a/adapters/lo/client.go
+++ b/adapters/lo/client.go
@@ -1,0 +1,210 @@
+// Package lo adapts LO's supported Bot API subset to Flock's chat service.
+package lo
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	requestTimeout     = 65 * time.Second
+	maxResponseBytes   = 2 << 20
+	pollTimeoutSeconds = 30
+	pollBatchSize      = 100
+)
+
+// Client sends Bot API requests only to its configured LO endpoint.
+type Client struct {
+	base, token string
+	http        *http.Client
+}
+
+// NewClient accepts HTTPS endpoints or loopback HTTP for local integration tests.
+// Redirects are refused: the bot credential is part of every request path.
+func NewClient(base, token string, hc *http.Client) (*Client, error) {
+	u, err := url.Parse(base)
+	if err != nil || u.Hostname() == "" || u.User != nil || u.RawQuery != "" || u.Fragment != "" {
+		return nil, errors.New("LO_API_URL must be a base URL without credentials, query or fragment")
+	}
+	loopback := u.Hostname() == "localhost" || u.Hostname() == "127.0.0.1" || u.Hostname() == "::1"
+	if u.Scheme != "https" && (u.Scheme != "http" || !loopback) {
+		return nil, errors.New("LO_API_URL requires HTTPS (loopback HTTP is allowed for development)")
+	}
+	if token == "" || strings.ContainsAny(token, "/?#% \t\r\n") {
+		return nil, errors.New("LO_BOT_TOKEN is missing or malformed")
+	}
+	var client http.Client
+	if hc != nil {
+		client = *hc
+	}
+	if client.Timeout == 0 {
+		client.Timeout = requestTimeout
+	}
+	client.CheckRedirect = func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse }
+	return &Client{base: strings.TrimRight(base, "/"), token: token, http: &client}, nil
+}
+
+// APIError preserves the numeric status and retry delay without exposing credentials.
+type APIError struct {
+	Code        int
+	Description string
+	Delay       time.Duration
+}
+
+func (e *APIError) Error() string { return fmt.Sprintf("LO Bot API %d: %s", e.Code, e.Description) }
+
+// RetryAfter classifies the Bot API 429 envelope for the shared delivery loop.
+func RetryAfter(err error) (time.Duration, bool) {
+	var apiErr *APIError
+	if errors.As(err, &apiErr) && apiErr.Code == http.StatusTooManyRequests {
+		if apiErr.Delay > 0 {
+			return apiErr.Delay, true
+		}
+		return time.Second, true
+	}
+	return 0, false
+}
+
+func (c *Client) call(ctx context.Context, method string, body, out any) error {
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("encode LO request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.base+"/bot"+c.token+"/"+method, bytes.NewReader(raw))
+	if err != nil {
+		return errors.New("cannot construct LO request")
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		return errors.New("LO request failed before receiving a response")
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes+1))
+	if err != nil {
+		return errors.New("cannot read LO response")
+	}
+	if len(data) > maxResponseBytes {
+		return errors.New("LO response exceeds size limit")
+	}
+	var envelope struct {
+		OK          bool            `json:"ok"`
+		Code        int             `json:"error_code"` //nolint:tagliatelle // Bot API wire spelling.
+		Description string          `json:"description"`
+		Result      json.RawMessage `json:"result"`
+		Parameters  struct {
+			RetryAfter int64 `json:"retry_after"` //nolint:tagliatelle // Bot API wire spelling.
+		} `json:"parameters"`
+	}
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return fmt.Errorf("LO returned an invalid API envelope (HTTP %d)", resp.StatusCode)
+	}
+	if !envelope.OK || resp.StatusCode != http.StatusOK {
+		code := envelope.Code
+		if code == 0 {
+			code = resp.StatusCode
+		}
+		delay := envelope.Parameters.RetryAfter
+		if delay <= 0 {
+			delay, _ = strconv.ParseInt(resp.Header.Get("Retry-After"), 10, 64)
+		}
+		// Preserve the server minimum without overflowing time.Duration.
+		const maxBackoffSeconds = int64((1<<63 - 1) / time.Second)
+		if delay > maxBackoffSeconds {
+			delay = maxBackoffSeconds
+		}
+		return &APIError{
+			Code: code, Description: strings.ReplaceAll(envelope.Description, c.token, "[redacted]"),
+			Delay: time.Duration(max(delay, 0)) * time.Second,
+		}
+	}
+	if len(envelope.Result) == 0 || string(envelope.Result) == "null" {
+		return errors.New("LO response contains no result")
+	}
+	if err := json.Unmarshal(envelope.Result, out); err != nil {
+		return errors.New("LO response contains an invalid result")
+	}
+	return nil
+}
+
+// User is the Bot API actor; LO and Telegram IDs are independent.
+type User struct {
+	ID       int64  `json:"id"`
+	IsBot    bool   `json:"is_bot"` //nolint:tagliatelle // Bot API wire spelling.
+	Username string `json:"username"`
+}
+
+// Message is the inbound subset the text adapter understands.
+type Message struct {
+	ID   int64 `json:"message_id"` //nolint:tagliatelle // Bot API wire spelling.
+	From *User `json:"from"`
+	Chat struct {
+		ID   int64  `json:"id"`
+		Type string `json:"type"`
+	} `json:"chat"`
+	Text      string          `json:"text"`
+	Caption   string          `json:"caption"`
+	Photo     json.RawMessage `json:"photo"`
+	Document  json.RawMessage `json:"document"`
+	Voice     json.RawMessage `json:"voice"`
+	Audio     json.RawMessage `json:"audio"`
+	Video     json.RawMessage `json:"video"`
+	Animation json.RawMessage `json:"animation"`
+	Sticker   json.RawMessage `json:"sticker"`
+	VideoNote json.RawMessage `json:"video_note"`       //nolint:tagliatelle // Bot API wire spelling.
+	Reply     *Message        `json:"reply_to_message"` //nolint:tagliatelle // Bot API wire spelling.
+}
+
+// Update is an ordered getUpdates item. Unsupported event kinds are acknowledged and ignored.
+type Update struct {
+	ID      int64    `json:"update_id"` //nolint:tagliatelle // Bot API wire spelling.
+	Message *Message `json:"message"`
+}
+
+// GetMe validates the token and discovers the authoritative username at startup.
+func (c *Client) GetMe(ctx context.Context) (User, error) {
+	var user User
+	if err := c.call(ctx, "getMe", struct{}{}, &user); err != nil {
+		return User{}, err
+	}
+	if user.ID <= 0 || !user.IsBot {
+		return User{}, errors.New("LO getMe did not return a bot")
+	}
+	return user, nil
+}
+
+// GetUpdates requests only new messages; it never drops queued updates or disables webhooks.
+func (c *Client) GetUpdates(ctx context.Context, offset int64) ([]Update, error) {
+	var updates []Update
+	body := map[string]any{
+		"offset": offset, "timeout": pollTimeoutSeconds, "limit": pollBatchSize, "allowed_updates": []string{"message"},
+	}
+	err := c.call(ctx, "getUpdates", body, &updates)
+	return updates, err
+}
+
+// CheckPolling refuses a webhook deployment rather than silently removing its webhook.
+func (c *Client) CheckPolling(ctx context.Context) error {
+	var info struct {
+		URL string `json:"url"`
+	}
+	if err := c.call(ctx, "getWebhookInfo", struct{}{}, &info); err != nil {
+		return err
+	}
+	if info.URL != "" {
+		return errors.New("LO bot has an active webhook; use a dedicated polling bot or remove its webhook explicitly")
+	}
+	return nil
+}

--- a/adapters/lo/client.go
+++ b/adapters/lo/client.go
@@ -19,7 +19,8 @@ const (
 	requestTimeout     = 65 * time.Second
 	maxResponseBytes   = 2 << 20
 	pollTimeoutSeconds = 30
-	pollBatchSize      = 100
+	// Leave room for full-size Unicode text plus quoted messages under the response cap.
+	pollBatchSize = 25
 )
 
 // Client sends Bot API requests only to its configured LO endpoint.

--- a/adapters/lo/client_test.go
+++ b/adapters/lo/client_test.go
@@ -222,3 +222,67 @@ func TestActiveWebhookIsNeverDeleted(t *testing.T) {
 		t.Fatal("accepted active webhook")
 	}
 }
+
+func TestClearDraftUsesSameIDAndEmptyText(t *testing.T) {
+	t.Parallel()
+	type payload struct {
+		ID   json.Number `json:"draft_id"` //nolint:tagliatelle // Bot API wire spelling.
+		Text string      `json:"text"`
+	}
+	var mu sync.Mutex
+	var requests []payload
+	api := client(t, func(w http.ResponseWriter, r *http.Request) {
+		var body payload
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Error(err)
+		}
+		mu.Lock()
+		requests = append(requests, body)
+		mu.Unlock()
+		reply(w, `{"ok":true,"result":true}`)
+	})
+	transport := lo.NewTransport(api, true)
+	if err := transport.SendDraft(t.Context(), "77", "run", "working"); err != nil {
+		t.Fatal(err)
+	}
+	if err := transport.ClearDraft(t.Context(), "77", "run"); err != nil {
+		t.Fatal(err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requests) != 2 || requests[0].ID != requests[1].ID || requests[1].Text != "" {
+		t.Fatalf("requests=%+v", requests)
+	}
+}
+
+func TestPollingBatchFitsFullSizeUnicodeReplies(t *testing.T) {
+	t.Parallel()
+	const batchSize = 25
+	text := strings.Repeat("界", 4096)
+	api := client(t, func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Limit int `json:"limit"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Error(err)
+		}
+		if body.Limit != batchSize {
+			t.Errorf("limit=%d", body.Limit)
+		}
+		updates := make([]lo.Update, batchSize)
+		for i := range updates {
+			message := inbound(text)
+			message.Reply = inbound(text)
+			updates[i] = lo.Update{ID: int64(i + 1), Message: message}
+		}
+		raw, err := json.Marshal(map[string]any{"ok": true, "result": updates})
+		if err != nil {
+			t.Error(err)
+		}
+		reply(w, string(raw))
+	})
+	updates, err := api.GetUpdates(t.Context(), 0)
+	if err != nil || len(updates) != batchSize {
+		t.Fatalf("count=%d err=%v", len(updates), err)
+	}
+}

--- a/adapters/lo/client_test.go
+++ b/adapters/lo/client_test.go
@@ -1,0 +1,224 @@
+package lo_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/duckbugio/flock/adapters/lo"
+)
+
+const testToken = "123:secret-token"
+
+func client(t *testing.T, handler http.HandlerFunc) *lo.Client {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	api, err := lo.NewClient(server.URL, testToken, server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return api
+}
+
+func reply(w http.ResponseWriter, value string) {
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write([]byte(value))
+}
+
+func TestTransportUsesOnlySupportedLOParameters(t *testing.T) {
+	t.Parallel()
+	var methods []string
+	var mu sync.Mutex
+	api := client(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Error("expected POST")
+		}
+		method := strings.TrimPrefix(r.URL.Path, "/bot"+testToken+"/")
+		mu.Lock()
+		methods = append(methods, method)
+		mu.Unlock()
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Error(err)
+		}
+		allowed := map[string]bool{"chat_id": true, "text": true}
+		if method != "sendMessage" {
+			allowed["message_id"] = true
+		}
+		for key := range body {
+			if !allowed[key] {
+				t.Errorf("unsupported field %s", key)
+			}
+		}
+		if method == "deleteMessage" {
+			reply(w, `{"ok":true,"result":true}`)
+			return
+		}
+		reply(w, `{"ok":true,"result":{"message_id":17}}`)
+	})
+	transport := lo.NewTransport(api, false)
+	id, err := transport.Send(t.Context(), "77", "**answer**", "run", true)
+	if err != nil || id != "17" {
+		t.Fatalf("id=%s err=%v", id, err)
+	}
+	if err := transport.Edit(t.Context(), "77", id, "updated", "run", true); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := transport.SendReply(t.Context(), "77", id, "done", true); err != nil {
+		t.Fatal(err)
+	}
+	if err := transport.Delete(t.Context(), "77", id); err != nil {
+		t.Fatal(err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if strings.Join(methods, ",") != "sendMessage,editMessageText,sendMessage,deleteMessage" {
+		t.Fatal(methods)
+	}
+	caps := transport.Capabilities()
+	if caps.CanSendDocument || caps.CanSendRich || caps.CanSendDraft || caps.MaxMessageRunes != 2048 {
+		t.Fatal(caps)
+	}
+}
+
+func TestRetryAfterAndCredentialRedaction(t *testing.T) {
+	t.Parallel()
+	api := client(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		reply(w, `{"ok":false,"error_code":429,"description":"`+testToken+`","parameters":{"retry_after":3}}`)
+	})
+	_, err := api.GetMe(t.Context())
+	delay, ok := lo.RetryAfter(err)
+	if !ok || delay != 3*time.Second || strings.Contains(err.Error(), testToken) {
+		t.Fatalf("delay=%v err=%v", delay, err)
+	}
+}
+
+func TestClientRefusesRedirects(t *testing.T) {
+	t.Parallel()
+	var reached atomic.Bool
+	destination := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { reached.Store(true) }))
+	defer destination.Close()
+	api := client(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, destination.URL, http.StatusTemporaryRedirect)
+	})
+	_, err := api.GetMe(t.Context())
+	if err == nil || reached.Load() {
+		t.Fatalf("err=%v reached=%v", err, reached.Load())
+	}
+}
+
+func TestMalformedResponsesNeverLookLikeSuccess(t *testing.T) {
+	t.Parallel()
+	for _, body := range []string{
+		`{"ok":true}`, `{"ok":true,"result":null}`, `{"ok":true,"result":{}}`, `not json`,
+		`{"ok":false,"error_code":501}`,
+	} {
+		t.Run(body, func(t *testing.T) {
+			t.Parallel()
+			api := client(t, func(w http.ResponseWriter, _ *http.Request) { reply(w, body) })
+			if _, err := api.GetMe(t.Context()); err == nil {
+				t.Fatal("accepted invalid result")
+			}
+		})
+	}
+}
+
+func TestDraftIDAndUTF16Budget(t *testing.T) {
+	t.Parallel()
+	var ids []json.Number
+	var mu sync.Mutex
+	api := client(t, func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]json.RawMessage
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Error(err)
+		}
+		var id json.Number
+		if err := json.Unmarshal(body["draft_id"], &id); err != nil {
+			t.Error(err)
+		}
+		mu.Lock()
+		ids = append(ids, id)
+		mu.Unlock()
+		reply(w, `{"ok":true,"result":true}`)
+	})
+	transport := lo.NewTransport(api, true)
+	for _, text := range []string{"first", "second"} {
+		if err := transport.SendDraft(t.Context(), "77", "same-run", text); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(ids) != 2 || ids[0] != ids[1] || ids[0] == "0" {
+		t.Fatal(ids)
+	}
+	if _, err := transport.Send(t.Context(), "77", strings.Repeat("😀", 2049), "", false); err == nil {
+		t.Fatal("accepted oversized UTF-16 text")
+	}
+	if err := transport.SendDraft(t.Context(), "-77", "same-run", "text"); !errors.Is(err, lo.ErrUnsupported) {
+		t.Fatal(err)
+	}
+}
+
+func TestGetUpdatesPreservesInt64AndOffset(t *testing.T) {
+	t.Parallel()
+	const offset = int64(9007199254740993)
+	api := client(t, func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Offset int64 `json:"offset"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Error(err)
+		}
+		if body.Offset != offset {
+			t.Errorf("offset=%d", body.Offset)
+		}
+		reply(w, fmt.Sprintf(`{"ok":true,"result":[{"update_id":%d,"message":{
+"message_id":17,"from":{"id":77},"chat":{"id":77,"type":"private"},"text":"hello"}}]}`, offset))
+	})
+	updates, err := api.GetUpdates(t.Context(), offset)
+	if err != nil || len(updates) != 1 || updates[0].ID != offset {
+		t.Fatalf("updates=%+v err=%v", updates, err)
+	}
+}
+
+func TestClientValidationAndCancellation(t *testing.T) {
+	t.Parallel()
+	for _, base := range []string{
+		"https://user:pass@example.com", "http://example.com", "https://example.com?token=secret", "not-url",
+	} {
+		if _, err := lo.NewClient(base, testToken, nil); err == nil {
+			t.Fatal(base)
+		}
+	}
+	api := client(t, func(w http.ResponseWriter, _ *http.Request) { reply(w, `{"ok":true,"result":[]}`) })
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err := api.GetUpdates(ctx, 0)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatal(err)
+	}
+}
+
+func TestActiveWebhookIsNeverDeleted(t *testing.T) {
+	t.Parallel()
+	api := client(t, func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/getWebhookInfo") {
+			t.Errorf("unexpected mutation: %s", r.URL.Path)
+		}
+		reply(w, `{"ok":true,"result":{"url":"https://example.com/hook"}}`)
+	})
+	if err := api.CheckPolling(t.Context()); err == nil {
+		t.Fatal("accepted active webhook")
+	}
+}

--- a/adapters/lo/client_test.go
+++ b/adapters/lo/client_test.go
@@ -313,3 +313,21 @@ func TestWebhookPreflightOnlyFallsBackForUnsupportedMethods(t *testing.T) {
 		})
 	}
 }
+
+type failingTransport struct{}
+
+func (failingTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, errors.New("connection refused for " + testToken)
+}
+
+func TestNetworkErrorKeepsReasonWithoutCredential(t *testing.T) {
+	t.Parallel()
+	api, err := lo.NewClient("https://lo.example", testToken, &http.Client{Transport: failingTransport{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = api.GetMe(t.Context())
+	if err == nil || !strings.Contains(err.Error(), "connection refused") || strings.Contains(err.Error(), testToken) {
+		t.Fatalf("unsafe or unhelpful error: %v", err)
+	}
+}

--- a/adapters/lo/client_test.go
+++ b/adapters/lo/client_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -284,5 +285,31 @@ func TestPollingBatchFitsFullSizeUnicodeReplies(t *testing.T) {
 	updates, err := api.GetUpdates(t.Context(), 0)
 	if err != nil || len(updates) != batchSize {
 		t.Fatalf("count=%d err=%v", len(updates), err)
+	}
+}
+
+func TestWebhookPreflightOnlyFallsBackForUnsupportedMethods(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		code      int
+		wantError bool
+	}{
+		{http.StatusNotFound, false},
+		{http.StatusNotImplemented, false},
+		{http.StatusUnauthorized, true},
+		{http.StatusForbidden, true},
+		{http.StatusInternalServerError, true},
+		{http.StatusTooManyRequests, true},
+	} {
+		t.Run(strconv.Itoa(test.code), func(t *testing.T) {
+			t.Parallel()
+			api := client(t, func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(test.code)
+				reply(w, fmt.Sprintf(`{"ok":false,"error_code":%d,"description":"fixture"}`, test.code))
+			})
+			if err := api.CheckPolling(t.Context()); (err != nil) != test.wantError {
+				t.Fatalf("error=%v wantError=%v", err, test.wantError)
+			}
+		})
 	}
 }

--- a/adapters/lo/commands.go
+++ b/adapters/lo/commands.go
@@ -93,10 +93,13 @@ func addressedText(text, username string) (string, bool) {
 		}
 	}
 	if username != "" {
+		pos := 0
 		for _, field := range fields {
+			index := pos + strings.Index(text[pos:], field)
 			if strings.EqualFold(field, "@"+username) {
-				return strings.TrimSpace(strings.Replace(text, field, "", 1)), true
+				return strings.TrimSpace(text[:index] + text[index+len(field):]), true
 			}
+			pos = index + len(field)
 		}
 	}
 	return text, true

--- a/adapters/lo/commands.go
+++ b/adapters/lo/commands.go
@@ -1,0 +1,125 @@
+package lo
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/duckbugio/flock/core/chat"
+)
+
+// HelpText describes the functional fallback when LO cannot display callback keyboards.
+const HelpText = `Flock LO assistant
+
+/start, /help — show commands
+/new — reset the session
+/stop — stop the current run
+/goal <criterion> — arm a goal (/goal off to disarm)
+/schedule — manage scheduled jobs
+
+Send text to work with the assistant. Use /stop instead of a Stop button.
+Attachments, rich messages and native replies are not supported yet.`
+
+func (r *Receiver) reserved(ctx context.Context, chatID string, userID int64, name, args string) {
+	switch name {
+	case "start", "help":
+		r.notify(ctx, chatID, HelpText)
+	case "stop":
+		text := "No active run."
+		if r.cfg.Service.StopChat(chatID) {
+			text = "Stopping the current run."
+		}
+		r.notify(ctx, chatID, text)
+	case "new":
+		if err := r.cfg.Service.NewSession(chatID); err != nil {
+			r.cfg.Logger.Warn("lo: reset session failed", "error", err)
+			r.notify(ctx, chatID, "Could not reset the session. Please retry.")
+			return
+		}
+		r.notify(ctx, chatID, "Started a fresh session.")
+	case "schedule":
+		if r.cfg.Scheduler == nil {
+			r.notify(ctx, chatID, "Scheduler is disabled. Set ENABLE_SCHEDULER=true to enable it.")
+			return
+		}
+		r.notify(ctx, chatID, r.cfg.Scheduler.Dispatch(chatID, userID, args))
+	case "goal":
+		r.goal(ctx, chatID, args)
+	}
+}
+
+func (r *Receiver) goal(ctx context.Context, chatID, args string) {
+	switch strings.ToLower(args) {
+	case "":
+		if g, ok := r.cfg.Service.GoalStatus(chatID); ok {
+			r.notify(ctx, chatID, fmt.Sprintf("Goal (%d/%d): %s", g.Attempts, g.MaxAttempts, g.Criterion))
+			return
+		}
+		r.notify(ctx, chatID, "No goal armed. Use /goal <criterion>.")
+	case "off", "clear", "stop":
+		r.cfg.Service.DisarmGoal(chatID)
+		r.notify(ctx, chatID, "Goal disarmed.")
+	default:
+		if _, ok := r.cfg.Service.ArmGoal(chatID, args); !ok {
+			r.notify(ctx, chatID, "The goal evaluator is disabled on this deployment.")
+			return
+		}
+		r.notify(ctx, chatID, "Goal armed. The evaluator will check completed runs.")
+	}
+}
+
+func command(text string) (name, args string) {
+	fields := strings.Fields(text)
+	if len(fields) == 0 || !strings.HasPrefix(fields[0], "/") {
+		return "", ""
+	}
+	return strings.ToLower(strings.TrimPrefix(fields[0], "/")), strings.TrimSpace(strings.TrimPrefix(text, fields[0]))
+}
+
+// addressedText rejects /command@other_bot and removes only exact mention tokens.
+func addressedText(text, username string) (string, bool) {
+	fields := strings.Fields(text)
+	if len(fields) == 0 {
+		return text, true
+	}
+	if strings.HasPrefix(fields[0], "/") {
+		if cmd, target, ok := strings.Cut(fields[0], "@"); ok {
+			if username == "" || !strings.EqualFold(target, username) {
+				return "", false
+			}
+			return cmd + strings.TrimPrefix(text, fields[0]), true
+		}
+	}
+	if username != "" {
+		for _, field := range fields {
+			if strings.EqualFold(field, "@"+username) {
+				return strings.TrimSpace(strings.Replace(text, field, "", 1)), true
+			}
+		}
+	}
+	return text, true
+}
+
+func fatalAPIError(err error) bool {
+	var apiErr *APIError
+	return errors.As(err, &apiErr) &&
+		(apiErr.Code == http.StatusUnauthorized || apiErr.Code == http.StatusForbidden || apiErr.Code == http.StatusConflict)
+}
+
+// SetCommands registers the shared reserved command list only when explicitly enabled.
+func (c *Client) SetCommands(ctx context.Context) error {
+	commands := make([]map[string]string, 0, len(chat.ReservedCommands))
+	for _, cmd := range chat.ReservedCommands {
+		commands = append(commands, map[string]string{"command": cmd.Name, "description": cmd.Description})
+	}
+	var result bool
+	if err := c.call(ctx, "setMyCommands", map[string]any{"commands": commands}, &result); err != nil {
+		return err
+	}
+	if !result {
+		return errors.New("LO did not confirm command registration")
+	}
+	return nil
+}

--- a/adapters/lo/commands.go
+++ b/adapters/lo/commands.go
@@ -78,19 +78,20 @@ func command(text string) (name, args string) {
 	return strings.ToLower(strings.TrimPrefix(fields[0], "/")), strings.TrimSpace(strings.TrimPrefix(text, fields[0]))
 }
 
-// addressedText rejects /command@other_bot and removes only exact mention tokens.
-func addressedText(text, username string) (string, bool) {
+// addressedText rejects commands for other bots only in groups, and removes exact mentions.
+func addressedText(text, username string, group bool) (string, bool) {
 	fields := strings.Fields(text)
 	if len(fields) == 0 {
 		return text, true
 	}
-	if strings.HasPrefix(fields[0], "/") {
-		if cmd, target, ok := strings.Cut(fields[0], "@"); ok {
-			if username == "" || !strings.EqualFold(target, username) {
-				return "", false
+	if cmd, target, ok := strings.Cut(fields[0], "@"); ok && strings.HasPrefix(cmd, "/") {
+		if username == "" || !strings.EqualFold(target, username) {
+			if !group {
+				return text, true
 			}
-			return cmd + strings.TrimPrefix(text, fields[0]), true
+			return "", false
 		}
+		return cmd + strings.TrimPrefix(text, fields[0]), true
 	}
 	if username != "" {
 		pos := 0

--- a/adapters/lo/commands.go
+++ b/adapters/lo/commands.go
@@ -107,8 +107,12 @@ func addressedText(text, username string) (string, bool) {
 
 func fatalAPIError(err error) bool {
 	var apiErr *APIError
-	return errors.As(err, &apiErr) &&
-		(apiErr.Code == http.StatusUnauthorized || apiErr.Code == http.StatusForbidden || apiErr.Code == http.StatusConflict)
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	return (apiErr.Code >= 400 && apiErr.Code < 500 &&
+		apiErr.Code != http.StatusRequestTimeout && apiErr.Code != http.StatusTooManyRequests) ||
+		apiErr.Code == http.StatusNotImplemented
 }
 
 // SetCommands registers the shared reserved command list only when explicitly enabled.

--- a/adapters/lo/docker-compose.yml
+++ b/adapters/lo/docker-compose.yml
@@ -4,13 +4,12 @@ services:
     image: flock-lo:local
     build:
       context: ../..
-      dockerfile: adapters/telegram/Dockerfile
-      args:
-        FLOCK_COMMAND: flock-lo
+      dockerfile: adapters/lo/Dockerfile
     restart: unless-stopped
     env_file: .env
     # Default drain 45s, capped at 60s, plus 10s post-cancel delivery: at most 70s < 75s.
     stop_grace_period: 75s
+    mem_limit: ${BOT_MEM_LIMIT:-3g}
     volumes:
       - workspace:/workspace
       - claude_home:/home/claude/.claude

--- a/adapters/lo/docker-compose.yml
+++ b/adapters/lo/docker-compose.yml
@@ -1,0 +1,23 @@
+# Build locally: no prebuilt flock-lo image is assumed or published by this change.
+services:
+  bot:
+    image: flock-lo:local
+    build:
+      context: ../..
+      dockerfile: adapters/telegram/Dockerfile
+      args:
+        FLOCK_COMMAND: flock-lo
+    restart: unless-stopped
+    env_file: .env
+    stop_grace_period: 15s
+    volumes:
+      - workspace:/workspace
+      - claude_home:/home/claude/.claude
+      - codex_home:/home/claude/.codex
+    logging:
+      driver: json-file
+      options: { max-size: "10m", max-file: "3" }
+volumes:
+  workspace:
+  claude_home:
+  codex_home:

--- a/adapters/lo/docker-compose.yml
+++ b/adapters/lo/docker-compose.yml
@@ -9,8 +9,8 @@ services:
         FLOCK_COMMAND: flock-lo
     restart: unless-stopped
     env_file: .env
-    # 5s dispatcher drain + 10s post-cancel delivery; leave 15s before SIGKILL.
-    stop_grace_period: 30s
+    # Default drain 45s, capped at 60s, plus 10s post-cancel delivery: at most 70s < 75s.
+    stop_grace_period: 75s
     volumes:
       - workspace:/workspace
       - claude_home:/home/claude/.claude

--- a/adapters/lo/docker-compose.yml
+++ b/adapters/lo/docker-compose.yml
@@ -9,7 +9,8 @@ services:
         FLOCK_COMMAND: flock-lo
     restart: unless-stopped
     env_file: .env
-    stop_grace_period: 15s
+    # 5s dispatcher drain + 10s post-cancel delivery; leave 15s before SIGKILL.
+    stop_grace_period: 30s
     volumes:
       - workspace:/workspace
       - claude_home:/home/claude/.claude

--- a/adapters/lo/receiver.go
+++ b/adapters/lo/receiver.go
@@ -126,18 +126,18 @@ func (r *Receiver) HandleUpdate(ctx context.Context, update Update) {
 		r.reserved(ctx, chatID, msg.From.ID, name, args)
 		return
 	}
-	if r.cfg.Guards != nil {
-		if allowed, reason := r.cfg.Guards(msg.From.ID); !allowed {
-			r.notify(ctx, chatID, reason)
-			return
-		}
-	}
 	if hasMedia(msg) {
 		r.notify(ctx, chatID, "Attachments are not supported yet. Please send the relevant text or a repository path.")
 		return
 	}
 	if text == "" {
 		return
+	}
+	if r.cfg.Guards != nil {
+		if allowed, reason := r.cfg.Guards(msg.From.ID); !allowed {
+			r.notify(ctx, chatID, reason)
+			return
+		}
 	}
 	if msg.Reply != nil {
 		quoted := msg.Reply.Text

--- a/adapters/lo/receiver.go
+++ b/adapters/lo/receiver.go
@@ -1,0 +1,184 @@
+package lo
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/duckbugio/flock/core/chat"
+	"github.com/duckbugio/flock/core/goal"
+	"github.com/duckbugio/flock/core/schedule"
+)
+
+// Service is the transport-neutral inbound seam; no Telegram handlers are reused.
+type Service interface {
+	Handle(ctx context.Context, chatID chat.ChatID, userID int64, messageID chat.MessageID, text string)
+	StopChat(chatID chat.ChatID) bool
+	NewSession(chatID chat.ChatID) error
+	ArmGoal(chatID chat.ChatID, criterion string) (goal.Goal, bool)
+	GoalStatus(chatID chat.ChatID) (goal.Goal, bool)
+	DisarmGoal(chatID chat.ChatID) bool
+}
+
+// ReceiverConfig owns the LO allow-list separately from Telegram/VK identities.
+type ReceiverConfig struct {
+	Service        Service
+	Client         *Client
+	Transport      *Transport
+	Username       string
+	IsAllowed      func(int64) bool
+	Guards         func(int64) (bool, string)
+	RequireMention bool
+	Scheduler      *schedule.Manager
+	Logger         *slog.Logger
+}
+
+// Receiver serially admits updates while the shared dispatcher runs chats concurrently.
+type Receiver struct{ cfg ReceiverConfig }
+
+// NewReceiver defaults to denying users unless an allow-list is wired.
+func NewReceiver(cfg ReceiverConfig) *Receiver {
+	if cfg.IsAllowed == nil {
+		cfg.IsAllowed = func(int64) bool { return false }
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+	return &Receiver{cfg: cfg}
+}
+
+// Run uses normal positive-offset acknowledgement, retaining queued updates on startup.
+// Only one polling process should run for a bot token; 409 is returned to the operator.
+func (r *Receiver) Run(ctx context.Context) error {
+	var offset int64
+	for ctx.Err() == nil {
+		updates, err := r.cfg.Client.GetUpdates(ctx, offset)
+		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if fatalAPIError(err) {
+				return err
+			}
+			delay, ok := RetryAfter(err)
+			if !ok {
+				delay = time.Second
+			}
+			r.cfg.Logger.Warn("lo: polling failed; retrying", "error", err)
+			if !wait(ctx, delay) {
+				return ctx.Err()
+			}
+			continue
+		}
+		sort.SliceStable(updates, func(i, j int) bool { return updates[i].ID < updates[j].ID })
+		for _, update := range updates {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if update.ID < offset || update.ID < 0 {
+				continue
+			}
+			if update.ID == math.MaxInt64 {
+				return errors.New("LO update ID exceeds acknowledgement range")
+			}
+			r.HandleUpdate(ctx, update)
+			offset = update.ID + 1
+		}
+		// Empty immediate responses from a proxy must not become a busy polling loop.
+		if len(updates) == 0 && !wait(ctx, time.Second) {
+			return ctx.Err()
+		}
+	}
+	return ctx.Err()
+}
+
+// HandleUpdate gates every command and message before invoking the shared service.
+func (r *Receiver) HandleUpdate(ctx context.Context, update Update) {
+	msg := update.Message
+	if msg == nil || msg.From == nil || msg.From.IsBot || msg.From.ID <= 0 || msg.ID <= 0 ||
+		msg.Chat.ID == 0 || !r.cfg.IsAllowed(msg.From.ID) {
+		return
+	}
+	if msg.Chat.Type != "private" && msg.Chat.Type != "group" && msg.Chat.Type != "supergroup" {
+		return
+	}
+	text := strings.TrimSpace(msg.Text)
+	if text == "" {
+		text = strings.TrimSpace(msg.Caption)
+	}
+	cleaned, addressed := addressedText(text, r.cfg.Username)
+	if !addressed {
+		return
+	}
+	if msg.Chat.Type != "private" && r.cfg.RequireMention && cleaned == text {
+		return
+	}
+	text = cleaned
+	chatID := strconv.FormatInt(msg.Chat.ID, 10)
+	name, args := command(text)
+	if chat.IsReservedCommand(name) {
+		r.reserved(ctx, chatID, msg.From.ID, name, args)
+		return
+	}
+	if r.cfg.Guards != nil {
+		if allowed, reason := r.cfg.Guards(msg.From.ID); !allowed {
+			r.notify(ctx, chatID, reason)
+			return
+		}
+	}
+	if hasMedia(msg) {
+		r.notify(ctx, chatID, "Attachments are not supported yet. Please send the relevant text or a repository path.")
+		return
+	}
+	if text == "" {
+		return
+	}
+	if msg.Reply != nil {
+		quoted := msg.Reply.Text
+		if quoted == "" {
+			quoted = msg.Reply.Caption
+		}
+		author := ""
+		if msg.Reply.From != nil {
+			author = msg.Reply.From.Username
+		}
+		text = chat.QuotedPrompt(author, quoted, text)
+	}
+	r.cfg.Service.Handle(ctx, chatID, msg.From.ID, strconv.FormatInt(msg.ID, 10), text)
+}
+
+func hasMedia(msg *Message) bool {
+	for _, raw := range []json.RawMessage{
+		msg.Photo, msg.Document, msg.Voice, msg.Audio, msg.Video,
+		msg.Animation, msg.Sticker, msg.VideoNote,
+	} {
+		value := strings.TrimSpace(string(raw))
+		if value != "" && value != "null" && value != "[]" {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *Receiver) notify(ctx context.Context, chatID, text string) {
+	if _, err := r.cfg.Transport.Send(ctx, chatID, text, "", false); err != nil {
+		r.cfg.Logger.Warn("lo: notice delivery failed", "error", err)
+	}
+}
+
+func wait(ctx context.Context, delay time.Duration) bool {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}

--- a/adapters/lo/receiver.go
+++ b/adapters/lo/receiver.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"log/slog"
 	"math"
+	"net/http"
 	"sort"
 	"strconv"
 	"strings"
@@ -98,10 +99,13 @@ func (r *Receiver) Run(ctx context.Context) error {
 	return ctx.Err()
 }
 
-const maxPollingConflicts = 5
+const (
+	maxPollingConflicts  = 5
+	pollingConflictDelay = 10 * time.Second
+)
 
 // stopPolling tolerates an old in-flight poll after restart, but bounds conflicts
-// so a second persistent poller does not silently contend forever.
+// with four ten-second waits (40s > our 30s long poll), while bounding contention.
 func (r *Receiver) stopPolling(err error, conflicts *int) bool {
 	var apiErr *APIError
 	if errors.As(err, &apiErr) && apiErr.Code == 409 {
@@ -208,6 +212,10 @@ func wait(ctx context.Context, delay time.Duration) bool {
 // Match the delivery loop's maximum wait while retaining shorter server hints.
 func pollingRetryDelay(err error) time.Duration {
 	const maxWait = 30 * time.Second
+	var apiErr *APIError
+	if errors.As(err, &apiErr) && apiErr.Code == http.StatusConflict {
+		return pollingConflictDelay
+	}
 	delay, ok := RetryAfter(err)
 	if !ok {
 		return time.Second

--- a/adapters/lo/receiver.go
+++ b/adapters/lo/receiver.go
@@ -66,10 +66,7 @@ func (r *Receiver) Run(ctx context.Context) error {
 			if fatalAPIError(err) {
 				return err
 			}
-			delay, ok := RetryAfter(err)
-			if !ok {
-				delay = time.Second
-			}
+			delay := pollingRetryDelay(err)
 			r.cfg.Logger.Warn("lo: polling failed; retrying", "error", err)
 			if !wait(ctx, delay) {
 				return ctx.Err()
@@ -185,4 +182,15 @@ func wait(ctx context.Context, delay time.Duration) bool {
 	case <-timer.C:
 		return true
 	}
+}
+
+// pollingRetryDelay keeps a faulty server hint from suspending reception for hours.
+// Match the delivery loop's maximum wait while retaining shorter server hints.
+func pollingRetryDelay(err error) time.Duration {
+	const maxWait = 30 * time.Second
+	delay, ok := RetryAfter(err)
+	if !ok {
+		return time.Second
+	}
+	return min(delay, maxWait)
 }

--- a/adapters/lo/receiver.go
+++ b/adapters/lo/receiver.go
@@ -142,6 +142,9 @@ func (r *Receiver) HandleUpdate(ctx context.Context, update Update) {
 		if quoted == "" {
 			quoted = msg.Reply.Caption
 		}
+		if hasMedia(msg.Reply) {
+			quoted += "\n[Quoted attachment is unavailable to this bot; ask the user for its contents if needed.]"
+		}
 		author := ""
 		if msg.Reply.From != nil {
 			author = msg.Reply.From.Username

--- a/adapters/lo/receiver.go
+++ b/adapters/lo/receiver.go
@@ -167,8 +167,11 @@ func hasMedia(msg *Message) bool {
 }
 
 func (r *Receiver) notify(ctx context.Context, chatID, text string) {
-	if _, err := r.cfg.Transport.Send(ctx, chatID, text, "", false); err != nil {
-		r.cfg.Logger.Warn("lo: notice delivery failed", "error", err)
+	for _, chunk := range chat.ChunkFencedSize(text, r.cfg.Transport.Capabilities().MaxMessageRunes) {
+		if _, err := r.cfg.Transport.Send(ctx, chatID, chunk, "", false); err != nil {
+			r.cfg.Logger.Warn("lo: notice delivery failed", "error", err)
+			return
+		}
 	}
 }
 

--- a/adapters/lo/receiver.go
+++ b/adapters/lo/receiver.go
@@ -54,16 +54,17 @@ func NewReceiver(cfg ReceiverConfig) *Receiver {
 }
 
 // Run uses normal positive-offset acknowledgement, retaining queued updates on startup.
-// Only one polling process should run for a bot token; 409 is returned to the operator.
+// Only one polling process should run for a bot token; persistent conflicts stop polling.
 func (r *Receiver) Run(ctx context.Context) error {
 	var offset int64
+	conflicts := 0
 	for ctx.Err() == nil {
 		updates, err := r.cfg.Client.GetUpdates(ctx, offset)
 		if err != nil {
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}
-			if fatalAPIError(err) {
+			if r.stopPolling(err, &conflicts) {
 				return err
 			}
 			delay := pollingRetryDelay(err)
@@ -73,6 +74,7 @@ func (r *Receiver) Run(ctx context.Context) error {
 			}
 			continue
 		}
+		conflicts = 0
 		previousOffset := offset
 		sort.SliceStable(updates, func(i, j int) bool { return updates[i].ID < updates[j].ID })
 		for _, update := range updates {
@@ -96,6 +98,21 @@ func (r *Receiver) Run(ctx context.Context) error {
 	return ctx.Err()
 }
 
+const maxPollingConflicts = 5
+
+// stopPolling tolerates an old in-flight poll after restart, but bounds conflicts
+// so a second persistent poller does not silently contend forever.
+func (r *Receiver) stopPolling(err error, conflicts *int) bool {
+	var apiErr *APIError
+	if errors.As(err, &apiErr) && apiErr.Code == 409 {
+		*conflicts++
+		r.cfg.Logger.Error("lo: polling conflict", "attempt", *conflicts)
+		return *conflicts >= maxPollingConflicts
+	}
+	*conflicts = 0
+	return fatalAPIError(err)
+}
+
 // HandleUpdate gates every command and message before invoking the shared service.
 func (r *Receiver) HandleUpdate(ctx context.Context, update Update) {
 	msg := update.Message
@@ -114,12 +131,12 @@ func (r *Receiver) HandleUpdate(ctx context.Context, update Update) {
 	if !addressed {
 		return
 	}
-	if msg.Chat.Type != "private" && r.cfg.RequireMention && cleaned == text {
+	name, args := command(cleaned)
+	if msg.Chat.Type != "private" && r.cfg.RequireMention && cleaned == text && !chat.IsReservedCommand(name) {
 		return
 	}
 	text = cleaned
 	chatID := strconv.FormatInt(msg.Chat.ID, 10)
-	name, args := command(text)
 	if chat.IsReservedCommand(name) {
 		r.reserved(ctx, chatID, msg.From.ID, name, args)
 		return

--- a/adapters/lo/receiver.go
+++ b/adapters/lo/receiver.go
@@ -76,11 +76,7 @@ func (r *Receiver) Run(ctx context.Context) error {
 			if r.stopPolling(err, &conflicts) {
 				return err
 			}
-			delay := pollingRetryDelay(err)
-			var apiErr *APIError
-			if errors.As(err, &apiErr) && apiErr.Code == http.StatusConflict {
-				delay = r.cfg.ConflictDelay
-			}
+			delay := r.pollingRetryDelay(err)
 			r.cfg.Logger.Warn("lo: polling failed; retrying", "error", err)
 			if !wait(ctx, delay) {
 				return ctx.Err()
@@ -171,20 +167,7 @@ func (r *Receiver) HandleUpdate(ctx context.Context, update Update) {
 			return
 		}
 	}
-	if msg.Reply != nil {
-		quoted := msg.Reply.Text
-		if quoted == "" {
-			quoted = msg.Reply.Caption
-		}
-		if hasMedia(msg.Reply) {
-			quoted += "\n[Quoted attachment is unavailable to this bot; ask the user for its contents if needed.]"
-		}
-		author := ""
-		if msg.Reply.From != nil {
-			author = msg.Reply.From.Username
-		}
-		text = chat.QuotedPrompt(author, quoted, text)
-	}
+	text = replyPrompt(msg, replyToBot, text)
 	r.cfg.Service.Handle(ctx, chatID, msg.From.ID, strconv.FormatInt(msg.ID, 10), text)
 }
 
@@ -223,15 +206,39 @@ func wait(ctx context.Context, delay time.Duration) bool {
 
 // pollingRetryDelay keeps a faulty server hint from suspending reception for hours.
 // Match the delivery loop's maximum wait while retaining shorter server hints.
-func pollingRetryDelay(err error) time.Duration {
+func (r *Receiver) pollingRetryDelay(err error) time.Duration {
 	const maxWait = 30 * time.Second
 	var apiErr *APIError
 	if errors.As(err, &apiErr) && apiErr.Code == http.StatusConflict {
-		return pollingConflictDelay
+		return r.cfg.ConflictDelay
 	}
 	delay, ok := RetryAfter(err)
 	if !ok {
 		return time.Second
 	}
 	return min(delay, maxWait)
+}
+
+func replyPrompt(msg *Message, replyToBot bool, text string) string {
+	if msg.Reply == nil {
+		return text
+	}
+	quoted := msg.Reply.Text
+	if quoted == "" {
+		quoted = msg.Reply.Caption
+	}
+	if hasMedia(msg.Reply) {
+		quoted += "\n[Quoted attachment is unavailable to this bot; ask the user for its contents if needed.]"
+	}
+	if quoted == "" {
+		quoted = "[media]"
+	}
+	author := ""
+	if msg.Reply.From != nil {
+		author = msg.Reply.From.Username
+	}
+	if replyToBot {
+		author = chat.AssistantAuthorLabel
+	}
+	return chat.QuotedPrompt(author, quoted, text)
 }

--- a/adapters/lo/receiver.go
+++ b/adapters/lo/receiver.go
@@ -76,6 +76,7 @@ func (r *Receiver) Run(ctx context.Context) error {
 			}
 			continue
 		}
+		previousOffset := offset
 		sort.SliceStable(updates, func(i, j int) bool { return updates[i].ID < updates[j].ID })
 		for _, update := range updates {
 			if ctx.Err() != nil {
@@ -90,8 +91,8 @@ func (r *Receiver) Run(ctx context.Context) error {
 			r.HandleUpdate(ctx, update)
 			offset = update.ID + 1
 		}
-		// Empty immediate responses from a proxy must not become a busy polling loop.
-		if len(updates) == 0 && !wait(ctx, time.Second) {
+		// Empty or stale-only immediate responses must not become a busy polling loop.
+		if offset == previousOffset && !wait(ctx, time.Second) {
 			return ctx.Err()
 		}
 	}

--- a/adapters/lo/receiver.go
+++ b/adapters/lo/receiver.go
@@ -17,6 +17,8 @@ import (
 	"github.com/duckbugio/flock/core/schedule"
 )
 
+const privateChatType = "private"
+
 // Service is the transport-neutral inbound seam; no Telegram handlers are reused.
 type Service interface {
 	Handle(ctx context.Context, chatID chat.ChatID, userID int64, messageID chat.MessageID, text string)
@@ -29,10 +31,13 @@ type Service interface {
 
 // ReceiverConfig owns the LO allow-list separately from Telegram/VK identities.
 type ReceiverConfig struct {
-	Service        Service
-	Client         *Client
-	Transport      *Transport
-	Username       string
+	Service   Service
+	Client    *Client
+	Transport *Transport
+	Username  string
+	BotID     int64
+	// ConflictDelay overrides retry timing; nonpositive values use the production default.
+	ConflictDelay  time.Duration
 	IsAllowed      func(int64) bool
 	Guards         func(int64) (bool, string)
 	RequireMention bool
@@ -45,6 +50,9 @@ type Receiver struct{ cfg ReceiverConfig }
 
 // NewReceiver defaults to denying users unless an allow-list is wired.
 func NewReceiver(cfg ReceiverConfig) *Receiver {
+	if cfg.ConflictDelay <= 0 {
+		cfg.ConflictDelay = pollingConflictDelay
+	}
 	if cfg.IsAllowed == nil {
 		cfg.IsAllowed = func(int64) bool { return false }
 	}
@@ -69,6 +77,10 @@ func (r *Receiver) Run(ctx context.Context) error {
 				return err
 			}
 			delay := pollingRetryDelay(err)
+			var apiErr *APIError
+			if errors.As(err, &apiErr) && apiErr.Code == http.StatusConflict {
+				delay = r.cfg.ConflictDelay
+			}
 			r.cfg.Logger.Warn("lo: polling failed; retrying", "error", err)
 			if !wait(ctx, delay) {
 				return ctx.Err()
@@ -124,19 +136,20 @@ func (r *Receiver) HandleUpdate(ctx context.Context, update Update) {
 		msg.Chat.ID == 0 || !r.cfg.IsAllowed(msg.From.ID) {
 		return
 	}
-	if msg.Chat.Type != "private" && msg.Chat.Type != "group" && msg.Chat.Type != "supergroup" {
+	if msg.Chat.Type != privateChatType && msg.Chat.Type != "group" && msg.Chat.Type != "supergroup" {
 		return
 	}
 	text := strings.TrimSpace(msg.Text)
 	if text == "" {
 		text = strings.TrimSpace(msg.Caption)
 	}
-	cleaned, addressed := addressedText(text, r.cfg.Username)
+	cleaned, addressed := addressedText(text, r.cfg.Username, msg.Chat.Type != privateChatType)
 	if !addressed {
 		return
 	}
 	name, args := command(cleaned)
-	if msg.Chat.Type != "private" && r.cfg.RequireMention && cleaned == text && !chat.IsReservedCommand(name) {
+	replyToBot := r.cfg.BotID > 0 && msg.Reply != nil && msg.Reply.From != nil && msg.Reply.From.ID == r.cfg.BotID
+	if msg.Chat.Type != privateChatType && r.cfg.RequireMention && cleaned == text && !replyToBot && !chat.IsReservedCommand(name) {
 		return
 	}
 	text = cleaned

--- a/adapters/lo/receiver_backoff_test.go
+++ b/adapters/lo/receiver_backoff_test.go
@@ -3,6 +3,7 @@ package lo
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -15,6 +16,8 @@ func TestPollingRetryDelayIsBounded(t *testing.T) {
 		err  error
 		want time.Duration
 	}{
+		{"conflict", &APIError{Code: http.StatusConflict}, 10 * time.Second},
+		{"wrapped conflict", fmt.Errorf("poll: %w", &APIError{Code: http.StatusConflict}), 10 * time.Second},
 		{"network", errors.New("connection refused"), time.Second},
 		{"missing hint", &APIError{Code: http.StatusTooManyRequests}, time.Second},
 		{"short hint", &APIError{Code: http.StatusTooManyRequests, Delay: 3 * time.Second}, 3 * time.Second},
@@ -37,5 +40,13 @@ func TestTransientPollingErrorsRemainRetryable(t *testing.T) {
 		if fatalAPIError(&APIError{Code: code}) {
 			t.Fatalf("status %d classified as permanent", code)
 		}
+	}
+}
+
+func TestConflictWindowCoversLongPoll(t *testing.T) {
+	t.Parallel()
+	delay := pollingRetryDelay(&APIError{Code: http.StatusConflict})
+	if budget := time.Duration(maxPollingConflicts-1) * delay; budget <= time.Duration(pollTimeoutSeconds)*time.Second {
+		t.Fatalf("conflict budget %v does not cover long poll", budget)
 	}
 }

--- a/adapters/lo/receiver_backoff_test.go
+++ b/adapters/lo/receiver_backoff_test.go
@@ -1,0 +1,30 @@
+//nolint:testpackage // whitebox: verify the private delay policy without sleeping for 30 seconds
+package lo
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestPollingRetryDelayIsBounded(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		err  error
+		want time.Duration
+	}{
+		{"network", errors.New("connection refused"), time.Second},
+		{"missing hint", &APIError{Code: http.StatusTooManyRequests}, time.Second},
+		{"short hint", &APIError{Code: http.StatusTooManyRequests, Delay: 3 * time.Second}, 3 * time.Second},
+		{"long hint", &APIError{Code: http.StatusTooManyRequests, Delay: 24 * time.Hour}, 30 * time.Second},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := pollingRetryDelay(tc.err); got != tc.want {
+				t.Fatalf("delay=%v want=%v", got, tc.want)
+			}
+		})
+	}
+}

--- a/adapters/lo/receiver_backoff_test.go
+++ b/adapters/lo/receiver_backoff_test.go
@@ -25,7 +25,7 @@ func TestPollingRetryDelayIsBounded(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			if got := pollingRetryDelay(tc.err); got != tc.want {
+			if got := NewReceiver(ReceiverConfig{}).pollingRetryDelay(tc.err); got != tc.want {
 				t.Fatalf("delay=%v want=%v", got, tc.want)
 			}
 		})
@@ -45,8 +45,16 @@ func TestTransientPollingErrorsRemainRetryable(t *testing.T) {
 
 func TestConflictWindowCoversLongPoll(t *testing.T) {
 	t.Parallel()
-	delay := pollingRetryDelay(&APIError{Code: http.StatusConflict})
+	delay := NewReceiver(ReceiverConfig{}).cfg.ConflictDelay
 	if budget := time.Duration(maxPollingConflicts-1) * delay; budget <= time.Duration(pollTimeoutSeconds)*time.Second {
 		t.Fatalf("conflict budget %v does not cover long poll", budget)
+	}
+}
+
+func TestConflictDelayOverrideControlsRetry(t *testing.T) {
+	t.Parallel()
+	receiver := NewReceiver(ReceiverConfig{ConflictDelay: 2 * time.Second})
+	if delay := receiver.pollingRetryDelay(fmt.Errorf("poll: %w", &APIError{Code: http.StatusConflict})); delay != 2*time.Second {
+		t.Fatalf("delay=%v", delay)
 	}
 }

--- a/adapters/lo/receiver_backoff_test.go
+++ b/adapters/lo/receiver_backoff_test.go
@@ -28,3 +28,14 @@ func TestPollingRetryDelayIsBounded(t *testing.T) {
 		})
 	}
 }
+
+func TestTransientPollingErrorsRemainRetryable(t *testing.T) {
+	t.Parallel()
+	for _, code := range []int{
+		http.StatusRequestTimeout, http.StatusTooManyRequests, http.StatusInternalServerError, http.StatusBadGateway,
+	} {
+		if fatalAPIError(&APIError{Code: code}) {
+			t.Fatalf("status %d classified as permanent", code)
+		}
+	}
+}

--- a/adapters/lo/receiver_test.go
+++ b/adapters/lo/receiver_test.go
@@ -156,9 +156,13 @@ func TestPollingAcknowledgesInOrderAndStopsOnConflict(t *testing.T) {
 	receiver := lo.NewReceiver(lo.ReceiverConfig{
 		Service: svc, Client: api, Transport: lo.NewTransport(api, false), IsAllowed: func(int64) bool { return true },
 	})
-	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 55*time.Second)
 	defer cancel()
+	started := time.Now()
 	err := receiver.Run(ctx)
+	if elapsed := time.Since(started); elapsed < 40*time.Second {
+		t.Fatalf("conflicts stopped polling before long-poll expiry: %v", elapsed)
+	}
 	var apiErr *lo.APIError
 	if !errors.As(err, &apiErr) || apiErr.Code != http.StatusConflict {
 		t.Fatal(err)
@@ -316,7 +320,7 @@ func TestQuotedAttachmentIsExplicitInPrompt(t *testing.T) {
 
 func TestPollingRecoversFromTransientConflict(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Second)
 	defer cancel()
 	var calls atomic.Int32
 	api := client(t, func(w http.ResponseWriter, _ *http.Request) {
@@ -331,5 +335,29 @@ func TestPollingRecoversFromTransientConflict(t *testing.T) {
 	err := lo.NewReceiver(lo.ReceiverConfig{Client: api}).Run(ctx)
 	if !errors.Is(err, context.Canceled) || calls.Load() != 2 {
 		t.Fatalf("polls=%d err=%v", calls.Load(), err)
+	}
+}
+
+func TestPollingCancellationInterruptsConflictWait(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	responded := make(chan struct{})
+	api := client(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		reply(w, `{"ok":false,"error_code":409,"description":"previous poll still closing"}`)
+		close(responded)
+	})
+	done := make(chan error, 1)
+	go func() { done <- lo.NewReceiver(lo.ReceiverConfig{Client: api}).Run(ctx) }()
+	<-responded
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("cancellation did not interrupt polling")
 	}
 }

--- a/adapters/lo/receiver_test.go
+++ b/adapters/lo/receiver_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/duckbugio/flock/core/goal"
 )
 
+const groupChatType = "group"
+
 type serviceSpy struct {
 	prompts     []string
 	stopped     int
@@ -61,7 +63,7 @@ func TestReceiverGatesCommandsAndPreservesProviderCommands(t *testing.T) {
 	}
 	group := inbound("hello")
 	group.Chat.ID = -42
-	group.Chat.Type = "group"
+	group.Chat.Type = groupChatType
 	receiver.HandleUpdate(t.Context(), lo.Update{Message: group})
 	group.Text = "/stop"
 	receiver.HandleUpdate(t.Context(), lo.Update{Message: group})
@@ -74,7 +76,7 @@ func TestReceiverGatesCommandsAndPreservesProviderCommands(t *testing.T) {
 	}
 	group.Text = "@flock hello"
 	receiver.HandleUpdate(t.Context(), lo.Update{Message: group})
-	if len(svc.prompts) != 2 || svc.prompts[1] != "hello" {
+	if len(svc.prompts) != 3 || svc.prompts[1] != "/stop@other" || svc.prompts[2] != "hello" {
 		t.Fatal(svc.prompts)
 	}
 }
@@ -154,15 +156,12 @@ func TestPollingAcknowledgesInOrderAndStopsOnConflict(t *testing.T) {
 	})
 	svc := &serviceSpy{}
 	receiver := lo.NewReceiver(lo.ReceiverConfig{
-		Service: svc, Client: api, Transport: lo.NewTransport(api, false), IsAllowed: func(int64) bool { return true },
+		ConflictDelay: 10 * time.Millisecond,
+		Service:       svc, Client: api, Transport: lo.NewTransport(api, false), IsAllowed: func(int64) bool { return true },
 	})
-	ctx, cancel := context.WithTimeout(t.Context(), 55*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
-	started := time.Now()
 	err := receiver.Run(ctx)
-	if elapsed := time.Since(started); elapsed < 40*time.Second {
-		t.Fatalf("conflicts stopped polling before long-poll expiry: %v", elapsed)
-	}
 	var apiErr *lo.APIError
 	if !errors.As(err, &apiErr) || apiErr.Code != http.StatusConflict {
 		t.Fatal(err)
@@ -231,7 +230,7 @@ func TestIgnoredMessagesDoNotSpendGuardBudget(t *testing.T) {
 	media.Photo = json.RawMessage(`[{}]`)
 	receiver.HandleUpdate(t.Context(), lo.Update{Message: media})
 	empty := inbound("@flock")
-	empty.Chat.ID, empty.Chat.Type = -42, "group"
+	empty.Chat.ID, empty.Chat.Type = -42, groupChatType
 	receiver.HandleUpdate(t.Context(), lo.Update{Message: empty})
 	receiver.HandleUpdate(t.Context(), lo.Update{Message: inbound("")})
 	if calls != 0 {
@@ -320,7 +319,7 @@ func TestQuotedAttachmentIsExplicitInPrompt(t *testing.T) {
 
 func TestPollingRecoversFromTransientConflict(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 	var calls atomic.Int32
 	api := client(t, func(w http.ResponseWriter, _ *http.Request) {
@@ -332,7 +331,7 @@ func TestPollingRecoversFromTransientConflict(t *testing.T) {
 		cancel()
 		reply(w, `{"ok":true,"result":[]}`)
 	})
-	err := lo.NewReceiver(lo.ReceiverConfig{Client: api}).Run(ctx)
+	err := lo.NewReceiver(lo.ReceiverConfig{Client: api, ConflictDelay: 10 * time.Millisecond}).Run(ctx)
 	if !errors.Is(err, context.Canceled) || calls.Load() != 2 {
 		t.Fatalf("polls=%d err=%v", calls.Load(), err)
 	}
@@ -349,7 +348,9 @@ func TestPollingCancellationInterruptsConflictWait(t *testing.T) {
 		close(responded)
 	})
 	done := make(chan error, 1)
-	go func() { done <- lo.NewReceiver(lo.ReceiverConfig{Client: api}).Run(ctx) }()
+	go func() {
+		done <- lo.NewReceiver(lo.ReceiverConfig{Client: api}).Run(ctx)
+	}()
 	<-responded
 	cancel()
 	select {
@@ -359,5 +360,42 @@ func TestPollingCancellationInterruptsConflictWait(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("cancellation did not interrupt polling")
+	}
+}
+
+func TestReplyToBotPassesGroupMentionGate(t *testing.T) {
+	t.Parallel()
+	for _, replyID := range []int64{99, 100, 0} {
+		svc := &serviceSpy{}
+		r := lo.NewReceiver(lo.ReceiverConfig{
+			Service: svc, BotID: 99, Username: "flock",
+			RequireMention: true, IsAllowed: func(int64) bool { return true },
+		})
+		msg := inbound("continue")
+		msg.Chat.Type = groupChatType
+		msg.Chat.ID = -42
+		msg.Reply = &lo.Message{From: &lo.User{ID: replyID}, Text: "question"}
+		r.HandleUpdate(t.Context(), lo.Update{Message: msg})
+		if (len(svc.prompts) == 1) != (replyID == 99) {
+			t.Fatalf("reply author %d: %v", replyID, svc.prompts)
+		}
+	}
+}
+
+func TestProviderCommandTargetIsPreservedInPrivateChat(t *testing.T) {
+	t.Parallel()
+	for _, kind := range []string{"private", groupChatType} {
+		svc := &serviceSpy{}
+		r := lo.NewReceiver(lo.ReceiverConfig{Service: svc, Username: "flock", IsAllowed: func(int64) bool { return true }})
+		msg := inbound("/deploy@staging ship")
+		msg.Chat.Type = kind
+		r.HandleUpdate(t.Context(), lo.Update{Message: msg})
+		if kind == "private" {
+			if len(svc.prompts) != 1 || svc.prompts[0] != msg.Text {
+				t.Fatal(svc.prompts)
+			}
+		} else if len(svc.prompts) != 0 {
+			t.Fatal(svc.prompts)
+		}
 	}
 }

--- a/adapters/lo/receiver_test.go
+++ b/adapters/lo/receiver_test.go
@@ -1,0 +1,158 @@
+package lo_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/duckbugio/flock/adapters/lo"
+	"github.com/duckbugio/flock/core/goal"
+)
+
+type serviceSpy struct {
+	prompts     []string
+	stopped     int
+	newSessions int
+}
+
+func (s *serviceSpy) Handle(_ context.Context, _ string, _ int64, _, prompt string) {
+	s.prompts = append(s.prompts, prompt)
+}
+func (s *serviceSpy) StopChat(string) bool                   { s.stopped++; return true }
+func (s *serviceSpy) NewSession(string) error                { s.newSessions++; return nil }
+func (*serviceSpy) ArmGoal(string, string) (goal.Goal, bool) { return goal.Goal{}, false }
+func (*serviceSpy) GoalStatus(string) (goal.Goal, bool)      { return goal.Goal{}, false }
+func (*serviceSpy) DisarmGoal(string) bool                   { return false }
+
+func inbound(text string) *lo.Message {
+	msg := &lo.Message{ID: 1, From: &lo.User{ID: 77}, Text: text}
+	msg.Chat.ID = 77
+	msg.Chat.Type = "private"
+	return msg
+}
+
+func TestReceiverGatesCommandsAndPreservesProviderCommands(t *testing.T) {
+	t.Parallel()
+	svc := &serviceSpy{}
+	api := client(t, func(w http.ResponseWriter, _ *http.Request) { reply(w, `{"ok":true,"result":{"message_id":1}}`) })
+	receiver := lo.NewReceiver(lo.ReceiverConfig{
+		Service: svc, Transport: lo.NewTransport(api, false), Username: "flock",
+		IsAllowed: func(id int64) bool { return id == 77 }, RequireMention: true,
+	})
+	for _, text := range []string{"/help", "/stop", "/new", "/loop 5m"} {
+		receiver.HandleUpdate(t.Context(), lo.Update{Message: inbound(text)})
+	}
+	if svc.stopped != 1 || svc.newSessions != 1 || len(svc.prompts) != 1 || svc.prompts[0] != "/loop 5m" {
+		t.Fatalf("spy=%+v", svc)
+	}
+	other := inbound("/stop")
+	other.From.ID = 88
+	receiver.HandleUpdate(t.Context(), lo.Update{Message: other})
+	receiver.HandleUpdate(t.Context(), lo.Update{Message: inbound("/stop@other")})
+	if svc.stopped != 1 {
+		t.Fatal("unauthorized stop")
+	}
+	group := inbound("hello")
+	group.Chat.ID = -42
+	group.Chat.Type = "group"
+	receiver.HandleUpdate(t.Context(), lo.Update{Message: group})
+	group.Text = "@flock hello"
+	receiver.HandleUpdate(t.Context(), lo.Update{Message: group})
+	if len(svc.prompts) != 2 || svc.prompts[1] != "hello" {
+		t.Fatal(svc.prompts)
+	}
+}
+
+func TestReceiverDoesNotDropAttachmentsOrQuoteContextSilently(t *testing.T) {
+	t.Parallel()
+	svc := &serviceSpy{}
+	var notices atomic.Int32
+	api := client(t, func(w http.ResponseWriter, _ *http.Request) {
+		notices.Add(1)
+		reply(w, `{"ok":true,"result":{"message_id":1}}`)
+	})
+	receiver := lo.NewReceiver(lo.ReceiverConfig{
+		Service: svc, Transport: lo.NewTransport(api, false), IsAllowed: func(int64) bool { return true },
+	})
+	media := inbound("review this file")
+	media.Document = []byte(`{"file_id":"lo-file"}`)
+	receiver.HandleUpdate(t.Context(), lo.Update{Message: media})
+	if len(svc.prompts) != 0 || notices.Load() != 1 {
+		t.Fatal("attachment silently discarded")
+	}
+	quoted := inbound("explain")
+	quoted.Reply = inbound("original code")
+	receiver.HandleUpdate(t.Context(), lo.Update{Message: quoted})
+	if len(svc.prompts) != 1 || !strings.Contains(svc.prompts[0], "original code") {
+		t.Fatal(svc.prompts)
+	}
+}
+
+func TestReceiverStopBypassesNewWorkGuards(t *testing.T) {
+	t.Parallel()
+	svc := &serviceSpy{}
+	api := client(t, func(w http.ResponseWriter, _ *http.Request) {
+		reply(w, `{"ok":true,"result":{"message_id":1}}`)
+	})
+	receiver := lo.NewReceiver(lo.ReceiverConfig{
+		Service: svc, Transport: lo.NewTransport(api, false), IsAllowed: func(int64) bool { return true },
+		Guards: func(int64) (bool, string) { return false, "Daily cap reached." },
+	})
+	receiver.HandleUpdate(t.Context(), lo.Update{Message: inbound("do work")})
+	receiver.HandleUpdate(t.Context(), lo.Update{Message: inbound("/stop")})
+	if len(svc.prompts) != 0 || svc.stopped != 1 {
+		t.Fatalf("spy=%+v", svc)
+	}
+}
+
+func TestPollingAcknowledgesInOrderAndStopsOnConflict(t *testing.T) {
+	t.Parallel()
+	const lastID = int64(9007199254740995)
+	var calls atomic.Int32
+	api := client(t, func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Offset int64 `json:"offset"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Error(err)
+		}
+		if calls.Add(1) == 1 {
+			if body.Offset != 0 {
+				t.Errorf("initial offset=%d", body.Offset)
+			}
+			a, b := inbound("second"), inbound("first")
+			data, err := json.Marshal(map[string]any{"ok": true, "result": []lo.Update{
+				{ID: lastID, Message: a}, {ID: lastID - 1, Message: b}, {ID: lastID - 1, Message: b},
+			}})
+			if err != nil {
+				t.Error(err)
+			}
+			reply(w, string(data))
+			return
+		}
+		if body.Offset != lastID+1 {
+			t.Errorf("ack offset=%d", body.Offset)
+		}
+		w.WriteHeader(http.StatusConflict)
+		reply(w, `{"ok":false,"error_code":409,"description":"another poller"}`)
+	})
+	svc := &serviceSpy{}
+	receiver := lo.NewReceiver(lo.ReceiverConfig{
+		Service: svc, Client: api, Transport: lo.NewTransport(api, false), IsAllowed: func(int64) bool { return true },
+	})
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	err := receiver.Run(ctx)
+	var apiErr *lo.APIError
+	if !errors.As(err, &apiErr) || apiErr.Code != http.StatusConflict {
+		t.Fatal(err)
+	}
+	if strings.Join(svc.prompts, ",") != "first,second" {
+		t.Fatal(svc.prompts)
+	}
+}

--- a/adapters/lo/receiver_test.go
+++ b/adapters/lo/receiver_test.go
@@ -247,3 +247,45 @@ func TestStaleOnlyPollingBatchBacksOff(t *testing.T) {
 		t.Fatalf("polls=%d; expected initial batch then one stale batch", got)
 	}
 }
+
+func TestPollingStopsOnPermanentHTTPFailure(t *testing.T) {
+	t.Parallel()
+	for _, status := range []int{
+		http.StatusBadRequest, http.StatusNotFound, http.StatusMethodNotAllowed, http.StatusNotImplemented,
+	} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			t.Parallel()
+			var calls atomic.Int32
+			api := client(t, func(w http.ResponseWriter, _ *http.Request) {
+				calls.Add(1)
+				w.WriteHeader(status)
+				reply(w, "unsupported")
+			})
+			receiver := lo.NewReceiver(lo.ReceiverConfig{Client: api})
+			ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+			defer cancel()
+			err := receiver.Run(ctx)
+			var apiErr *lo.APIError
+			if !errors.As(err, &apiErr) || apiErr.Code != status || calls.Load() != 1 {
+				t.Fatalf("calls=%d err=%v", calls.Load(), err)
+			}
+		})
+	}
+}
+
+func TestQuotedAttachmentIsExplicitInPrompt(t *testing.T) {
+	t.Parallel()
+	for _, caption := range []string{"", "diagram caption"} {
+		svc := &serviceSpy{}
+		receiver := lo.NewReceiver(lo.ReceiverConfig{Service: svc, IsAllowed: func(int64) bool { return true }})
+		msg := inbound("explain this")
+		msg.Reply = inbound("")
+		msg.Reply.Caption = caption
+		msg.Reply.Photo = json.RawMessage(`[{}]`)
+		receiver.HandleUpdate(t.Context(), lo.Update{Message: msg})
+		if len(svc.prompts) != 1 ||
+			!strings.Contains(svc.prompts[0], "Quoted attachment is unavailable") || !strings.Contains(svc.prompts[0], caption) {
+			t.Fatalf("prompts=%v", svc.prompts)
+		}
+	}
+}

--- a/adapters/lo/receiver_test.go
+++ b/adapters/lo/receiver_test.go
@@ -229,3 +229,21 @@ func TestIgnoredMessagesDoNotSpendGuardBudget(t *testing.T) {
 		t.Fatalf("calls=%d prompts=%v", calls, svc.prompts)
 	}
 }
+
+func TestStaleOnlyPollingBatchBacksOff(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int32
+	api := client(t, func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		reply(w, `{"ok":true,"result":[{"update_id":1}]}`)
+	})
+	receiver := lo.NewReceiver(lo.ReceiverConfig{Client: api})
+	ctx, cancel := context.WithTimeout(t.Context(), 150*time.Millisecond)
+	defer cancel()
+	if err := receiver.Run(ctx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatal(err)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("polls=%d; expected initial batch then one stale batch", got)
+	}
+}

--- a/adapters/lo/receiver_test.go
+++ b/adapters/lo/receiver_test.go
@@ -63,6 +63,15 @@ func TestReceiverGatesCommandsAndPreservesProviderCommands(t *testing.T) {
 	group.Chat.ID = -42
 	group.Chat.Type = "group"
 	receiver.HandleUpdate(t.Context(), lo.Update{Message: group})
+	group.Text = "/stop"
+	receiver.HandleUpdate(t.Context(), lo.Update{Message: group})
+	group.Text = "/new"
+	receiver.HandleUpdate(t.Context(), lo.Update{Message: group})
+	group.Text = "/stop@other"
+	receiver.HandleUpdate(t.Context(), lo.Update{Message: group})
+	if svc.stopped != 2 || svc.newSessions != 2 {
+		t.Fatalf("group commands must bypass mention gating but reject other bots: %+v", svc)
+	}
 	group.Text = "@flock hello"
 	receiver.HandleUpdate(t.Context(), lo.Update{Message: group})
 	if len(svc.prompts) != 2 || svc.prompts[1] != "hello" {
@@ -147,7 +156,7 @@ func TestPollingAcknowledgesInOrderAndStopsOnConflict(t *testing.T) {
 	receiver := lo.NewReceiver(lo.ReceiverConfig{
 		Service: svc, Client: api, Transport: lo.NewTransport(api, false), IsAllowed: func(int64) bool { return true },
 	})
-	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
 	defer cancel()
 	err := receiver.Run(ctx)
 	var apiErr *lo.APIError
@@ -233,14 +242,29 @@ func TestIgnoredMessagesDoNotSpendGuardBudget(t *testing.T) {
 func TestStaleOnlyPollingBatchBacksOff(t *testing.T) {
 	t.Parallel()
 	var calls atomic.Int32
+	stale := make(chan struct{})
 	api := client(t, func(w http.ResponseWriter, _ *http.Request) {
-		calls.Add(1)
+		if calls.Add(1) == 2 {
+			close(stale)
+		}
 		reply(w, `{"ok":true,"result":[{"update_id":1}]}`)
 	})
 	receiver := lo.NewReceiver(lo.ReceiverConfig{Client: api})
-	ctx, cancel := context.WithTimeout(t.Context(), 150*time.Millisecond)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
-	if err := receiver.Run(ctx); !errors.Is(err, context.DeadlineExceeded) {
+	done := make(chan error, 1)
+	go func() { done <- receiver.Run(ctx) }()
+	select {
+	case <-stale:
+	case <-ctx.Done():
+		t.Fatal("poller did not reach the stale batch")
+	}
+	// Start the observation window after the second request, not at process startup.
+	timer := time.NewTimer(150 * time.Millisecond)
+	defer timer.Stop()
+	<-timer.C
+	cancel()
+	if err := <-done; !errors.Is(err, context.Canceled) {
 		t.Fatal(err)
 	}
 	if got := calls.Load(); got != 2 {
@@ -287,5 +311,25 @@ func TestQuotedAttachmentIsExplicitInPrompt(t *testing.T) {
 			!strings.Contains(svc.prompts[0], "Quoted attachment is unavailable") || !strings.Contains(svc.prompts[0], caption) {
 			t.Fatalf("prompts=%v", svc.prompts)
 		}
+	}
+}
+
+func TestPollingRecoversFromTransientConflict(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	var calls atomic.Int32
+	api := client(t, func(w http.ResponseWriter, _ *http.Request) {
+		if calls.Add(1) == 1 {
+			w.WriteHeader(http.StatusConflict)
+			reply(w, `{"ok":false,"error_code":409,"description":"previous poll still closing"}`)
+			return
+		}
+		cancel()
+		reply(w, `{"ok":true,"result":[]}`)
+	})
+	err := lo.NewReceiver(lo.ReceiverConfig{Client: api}).Run(ctx)
+	if !errors.Is(err, context.Canceled) || calls.Load() != 2 {
+		t.Fatalf("polls=%d err=%v", calls.Load(), err)
 	}
 }

--- a/adapters/lo/receiver_test.go
+++ b/adapters/lo/receiver_test.go
@@ -203,3 +203,29 @@ func TestLongCommandNoticeIsChunkedWithoutLosingText(t *testing.T) {
 		t.Fatal("long notice was lost or truncated")
 	}
 }
+
+func TestIgnoredMessagesDoNotSpendGuardBudget(t *testing.T) {
+	t.Parallel()
+	svc := &serviceSpy{}
+	api := client(t, func(w http.ResponseWriter, _ *http.Request) { reply(w, `{"ok":true,"result":{"message_id":1}}`) })
+	calls := 0
+	receiver := lo.NewReceiver(lo.ReceiverConfig{
+		Service: svc, Transport: lo.NewTransport(api, false), Username: "flock",
+		IsAllowed: func(int64) bool { return true }, RequireMention: true,
+		Guards: func(int64) (bool, string) { calls++; return true, "" },
+	})
+	media := inbound("photo")
+	media.Photo = json.RawMessage(`[{}]`)
+	receiver.HandleUpdate(t.Context(), lo.Update{Message: media})
+	empty := inbound("@flock")
+	empty.Chat.ID, empty.Chat.Type = -42, "group"
+	receiver.HandleUpdate(t.Context(), lo.Update{Message: empty})
+	receiver.HandleUpdate(t.Context(), lo.Update{Message: inbound("")})
+	if calls != 0 {
+		t.Fatalf("ignored messages spent %d guard calls", calls)
+	}
+	receiver.HandleUpdate(t.Context(), lo.Update{Message: inbound("hello")})
+	if calls != 1 || len(svc.prompts) != 1 {
+		t.Fatalf("calls=%d prompts=%v", calls, svc.prompts)
+	}
+}

--- a/adapters/lo/receiver_test.go
+++ b/adapters/lo/receiver_test.go
@@ -6,9 +6,11 @@ import (
 	"errors"
 	"net/http"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/duckbugio/flock/adapters/lo"
 	"github.com/duckbugio/flock/core/goal"
@@ -154,5 +156,50 @@ func TestPollingAcknowledgesInOrderAndStopsOnConflict(t *testing.T) {
 	}
 	if strings.Join(svc.prompts, ",") != "first,second" {
 		t.Fatal(svc.prompts)
+	}
+}
+
+func TestMentionRemovalPreservesEarlierPrefixAndWhitespace(t *testing.T) {
+	t.Parallel()
+	svc := &serviceSpy{}
+	receiver := lo.NewReceiver(lo.ReceiverConfig{
+		Service: svc, Username: "flock", IsAllowed: func(int64) bool { return true },
+	})
+	receiver.HandleUpdate(t.Context(), lo.Update{Message: inbound("@flockbot  and\n@FLOCK fix this")})
+	if len(svc.prompts) != 1 || svc.prompts[0] != "@flockbot  and\n fix this" {
+		t.Fatal(svc.prompts)
+	}
+}
+
+func TestLongCommandNoticeIsChunkedWithoutLosingText(t *testing.T) {
+	t.Parallel()
+	const reasonRunes = 5000
+	reason := strings.Repeat("😀", reasonRunes)
+	var mu sync.Mutex
+	var parts []string
+	api := client(t, func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Text string `json:"text"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Error(err)
+		}
+		if utf8.RuneCountInString(body.Text) > 2048 {
+			t.Error("oversized chunk")
+		}
+		mu.Lock()
+		parts = append(parts, body.Text)
+		mu.Unlock()
+		reply(w, `{"ok":true,"result":{"message_id":1}}`)
+	})
+	receiver := lo.NewReceiver(lo.ReceiverConfig{
+		Service: &serviceSpy{}, Transport: lo.NewTransport(api, false), IsAllowed: func(int64) bool { return true },
+		Guards: func(int64) (bool, string) { return false, reason },
+	})
+	receiver.HandleUpdate(t.Context(), lo.Update{Message: inbound("work")})
+	mu.Lock()
+	defer mu.Unlock()
+	if len(parts) < 2 || strings.Join(parts, "") != reason {
+		t.Fatal("long notice was lost or truncated")
 	}
 }

--- a/adapters/lo/receiver_test.go
+++ b/adapters/lo/receiver_test.go
@@ -399,3 +399,15 @@ func TestProviderCommandTargetIsPreservedInPrivateChat(t *testing.T) {
 		}
 	}
 }
+
+func TestReplyContextIdentifiesAssistantAndEmptyMessage(t *testing.T) {
+	t.Parallel()
+	svc := &serviceSpy{}
+	receiver := lo.NewReceiver(lo.ReceiverConfig{Service: svc, BotID: 99, IsAllowed: func(int64) bool { return true }})
+	msg := inbound("continue")
+	msg.Reply = &lo.Message{From: &lo.User{ID: 99, Username: "flock"}}
+	receiver.HandleUpdate(t.Context(), lo.Update{Message: msg})
+	if len(svc.prompts) != 1 || !strings.Contains(svc.prompts[0], "the assistant") || !strings.Contains(svc.prompts[0], "[media]") {
+		t.Fatalf("prompts=%v", svc.prompts)
+	}
+}

--- a/adapters/telegram/Dockerfile
+++ b/adapters/telegram/Dockerfile
@@ -22,10 +22,12 @@ COPY core/ ./core/
 COPY adapters/ ./adapters/
 COPY internal/ ./internal/
 
+ARG FLOCK_COMMAND=flock-telegram
 ARG TARGETOS
 ARG TARGETARCH
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
-    go build -buildvcs=false -trimpath -ldflags "-s -w" -o /out/flock-telegram ./cmd/flock-telegram
+RUN case "$FLOCK_COMMAND" in flock-telegram|flock-lo) ;; *) exit 1 ;; esac && \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build -buildvcs=false -trimpath -ldflags "-s -w" -o /out/flock-telegram "./cmd/${FLOCK_COMMAND}"
 
 # --- Runtime stage ------------------------------------------------------------
 # node:24 (current LTS) supplies Node (for the `claude` CLI). Add git/ripgrep/ffmpeg

--- a/cmd/flock-lo/main.go
+++ b/cmd/flock-lo/main.go
@@ -1,0 +1,192 @@
+// Command flock-lo connects LO bot messages to the shared Flock agent runtime.
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+	_ "time/tzdata" // Keep scheduler timezones available in minimal containers.
+
+	"github.com/duckbugio/flock/adapters/lo"
+	"github.com/duckbugio/flock/core/chat"
+	"github.com/duckbugio/flock/core/claude"
+	"github.com/duckbugio/flock/core/cost"
+	"github.com/duckbugio/flock/core/dispatch"
+	"github.com/duckbugio/flock/core/gitsetup"
+	"github.com/duckbugio/flock/core/ratelimit"
+	"github.com/duckbugio/flock/core/schedule"
+	"github.com/duckbugio/flock/core/session"
+	"github.com/duckbugio/flock/core/workspace"
+	"github.com/duckbugio/flock/internal/airunner"
+	"github.com/duckbugio/flock/internal/autonomy"
+	"github.com/duckbugio/flock/internal/config"
+)
+
+const (
+	shutdownTimeout = 5 * time.Second
+	workspaceMode   = 0o700
+)
+
+func main() { os.Exit(run()) }
+
+func run() int {
+	cfg, err := config.Load()
+	if err != nil {
+		slog.Error("load config", "error", err)
+		return 1
+	}
+	if err := cfg.ValidateLO(); err != nil {
+		slog.Error("invalid LO config", "error", err)
+		return 1
+	}
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: cfg.SlogLevel()}))
+	slog.SetDefault(logger)
+	// A Telegram/VK chat with the same numeric ID must never reuse an LO workspace.
+	cfg.ApprovedDirectory = filepath.Join(cfg.ApprovedDirectory, "lo")
+	if err := os.MkdirAll(cfg.ApprovedDirectory, workspaceMode); err != nil {
+		logger.Error("create LO workspace", "error", err)
+		return 1
+	}
+	api, err := lo.NewClient(cfg.LOAPIURL, cfg.LOBotToken, nil)
+	if err != nil {
+		logger.Error("configure LO client", "error", err)
+		return 1
+	}
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+	self, err := api.GetMe(ctx)
+	if err != nil {
+		logger.Error("authenticate LO bot", "error", err)
+		return 1
+	}
+	if err := api.CheckPolling(ctx); err != nil {
+		logger.Error("LO polling unavailable", "error", err)
+		return 1
+	}
+	if cfg.LORegisterCommands {
+		if err := api.SetCommands(ctx); err != nil {
+			logger.Warn("LO command menu unavailable; text commands still work", "error", err)
+		}
+	}
+	runner, opts, provider, err := airunner.Build(cfg)
+	if err != nil {
+		logger.Error("configure AI backend", "error", err)
+		return 1
+	}
+	logger.Info("AI backend configured", "provider", provider.Name)
+	if err := gitsetup.Apply(ctx, gitsetup.Config{
+		Host:        cfg.GitHost,
+		Scheme:      cfg.GitScheme,
+		AuthorName:  cfg.GitAuthorName,
+		AuthorEmail: cfg.GitAuthorEmail,
+		HasToken:    cfg.GitToken != "",
+	}); err != nil {
+		logger.Warn("git setup", "error", err)
+	}
+	if provider.Name == config.AIBackendClaude {
+		servers := map[string]claude.MCPServer{}
+		if cfg.EnableContext7 {
+			servers["context7"] = claude.MCPServer{URL: claude.Context7URL}
+		}
+		if cfg.DuckBugMCPEnabled() {
+			servers["duckbug"] = claude.MCPServer{URL: cfg.DuckBugMCPURL, BearerToken: cfg.DuckBugMCPToken}
+		}
+		path := filepath.Join(cfg.ApprovedDirectory, ".flock-mcp.json")
+		if ok, err := claude.WriteMCPConfig(path, servers); err != nil {
+			logger.Warn("write MCP config", "error", err)
+		} else if ok {
+			opts.MCPConfig = path
+		}
+	}
+	ws := &workspace.Renderer{
+		FileDeliveryDisabled: true,
+		AutoApproveScope:     cfg.AutoApproveScopeLevel(),
+		BaseDir:              cfg.ApprovedDirectory,
+		TemplatePath:         cfg.TeamTemplatePath,
+		AgentsDir:            cfg.TeamAgentsDir,
+		SkillsDir:            cfg.TeamSkillsDir,
+		PrePRCycles:          cfg.PrePRCycles,
+		PrReviewCycles:       cfg.PrReviewCycles,
+		EnablePRReview:       cfg.EnablePRReview,
+		GitHost:              cfg.GitHost,
+	}
+	sessions, err := session.Open(cfg.SessionStoreFile())
+	if err != nil {
+		logger.Error("open sessions", "error", err)
+		return 1
+	}
+	costs, err := cost.Open(cfg.CostStoreFile())
+	if err != nil {
+		logger.Error("open costs", "error", err)
+		return 1
+	}
+	limiter := ratelimit.New(cfg.RateLimitRequests, cfg.RateLimitWindow())
+	dispatcher := dispatch.New(cfg.MaxConcurrentChatRuns)
+	defer func() {
+		drain, stop := context.WithTimeout(context.Background(), shutdownTimeout)
+		defer stop()
+		if err := dispatcher.Shutdown(drain); err != nil {
+			logger.Warn("dispatcher drain", "error", err)
+		}
+	}()
+	transport := lo.NewTransport(api, cfg.LOEnableDrafts)
+	postRun := autonomy.Build(cfg, logger)
+	svc := chat.New(chat.Config{
+		Runner:     runner,
+		Transport:  transport,
+		Dispatcher: dispatcher,
+		Workspace:  ws,
+		Sessions:   sessions,
+		Costs:      costs,
+		CostCapUSD: cfg.EffectiveCostCapUSD(),
+		PostRun:    postRun,
+		Opts:       opts,
+		Timeout:    cfg.ClaudeTimeout(),
+		RetryAfter: lo.RetryAfter,
+		Logger:     logger,
+	})
+	autonomy.StartFollowups(ctx, svc, postRun, logger)
+	scheduler := startScheduler(ctx, cfg, svc, logger)
+	receiver := lo.NewReceiver(lo.ReceiverConfig{
+		Service:        svc,
+		Client:         api,
+		Transport:      transport,
+		Username:       self.Username,
+		IsAllowed:      cfg.IsLOAllowed,
+		RequireMention: cfg.RequireGroupMention,
+		Scheduler:      scheduler,
+		Logger:         logger,
+		Guards: func(id int64) (bool, string) {
+			return chat.CheckGuards(limiter, costs, chat.GuardConfig{CostCapUSD: cfg.EffectiveCostCapUSD()}, id)
+		},
+	})
+	logger.Info("starting LO adapter", "bot_id", self.ID, "drafts", cfg.LOEnableDrafts, "workspace", cfg.ApprovedDirectory)
+	logger.Info("LO compatibility: text only; /stop replaces buttons; document outbox and native replies disabled")
+	if err := receiver.Run(ctx); err != nil && ctx.Err() == nil {
+		logger.Error("LO adapter stopped", "error", err)
+		return 1
+	}
+	return 0
+}
+
+func startScheduler(ctx context.Context, cfg config.Config, svc *chat.Service, logger *slog.Logger) *schedule.Manager {
+	if !cfg.SchedulerEnabled() {
+		return nil
+	}
+	store, err := schedule.Open(cfg.ScheduleStoreFile())
+	if err != nil {
+		logger.Error("open schedules", "error", err)
+		return nil
+	}
+	manager := schedule.NewManager(store, svc.InjectScheduled, cfg.IsLOAllowed, time.Now, logger)
+	go func() {
+		if err := manager.Run(ctx); err != nil && ctx.Err() == nil {
+			logger.Error("LO scheduler stopped", "error", err)
+		}
+	}()
+	return manager
+}

--- a/cmd/flock-lo/main.go
+++ b/cmd/flock-lo/main.go
@@ -160,6 +160,7 @@ func run() int {
 		Client:         api,
 		Transport:      transport,
 		Username:       self.Username,
+		BotID:          self.ID,
 		IsAllowed:      cfg.IsLOAllowed,
 		RequireMention: cfg.RequireGroupMention,
 		Scheduler:      scheduler,

--- a/cmd/flock-lo/main.go
+++ b/cmd/flock-lo/main.go
@@ -60,6 +60,9 @@ func run() int {
 		logger.Error("authenticate LO bot", "error", err)
 		return 1
 	}
+	if self.Username == "" {
+		logger.Warn("LO bot has no username; group mentions cannot match; use private chats or set REQUIRE_GROUP_MENTION=false")
+	}
 	if err := api.CheckPolling(ctx); err != nil {
 		logger.Error("LO polling unavailable", "error", err)
 		return 1

--- a/cmd/flock-lo/main.go
+++ b/cmd/flock-lo/main.go
@@ -26,10 +26,7 @@ import (
 	"github.com/duckbugio/flock/internal/config"
 )
 
-const (
-	shutdownTimeout = 5 * time.Second
-	workspaceMode   = 0o700
-)
+const workspaceMode = 0o700
 
 func main() { os.Exit(run()) }
 
@@ -126,8 +123,12 @@ func run() int {
 	}
 	limiter := ratelimit.New(cfg.RateLimitRequests, cfg.RateLimitWindow())
 	dispatcher := dispatch.New(cfg.MaxConcurrentChatRuns)
+	if cfg.ShutdownDrainClamped() {
+		logger.Warn("SHUTDOWN_DRAIN_SECONDS above cap; clamped",
+			"configured_seconds", cfg.ShutdownDrainSeconds, "effective", cfg.ShutdownDrain())
+	}
 	defer func() {
-		drain, stop := context.WithTimeout(context.Background(), shutdownTimeout)
+		drain, stop := context.WithTimeout(context.Background(), cfg.ShutdownDrain())
 		defer stop()
 		if err := dispatcher.Shutdown(drain); err != nil {
 			logger.Warn("dispatcher drain", "error", err)

--- a/cmd/flock-telegram/main.go
+++ b/cmd/flock-telegram/main.go
@@ -739,7 +739,7 @@ func botID(b *bot.Bot) int64 {
 // assistantAuthorLabel names the bot's own earlier message when it is the quoted
 // original, so the folded context reads as coming from the assistant rather than a
 // human participant.
-const assistantAuthorLabel = "the assistant"
+const assistantAuthorLabel = chat.AssistantAuthorLabel
 
 // quotedContext extracts the quoted/replied-to original from a message so it can be
 // folded into the prompt (via chat.QuotedPrompt). It returns an empty text when the

--- a/core/chat/draft_test.go
+++ b/core/chat/draft_test.go
@@ -13,9 +13,13 @@ import (
 
 type draftChat struct {
 	*fakeChat
-	drafts   []string
-	draftErr error
-	maxRunes int
+	drafts          []string
+	draftErr        error
+	maxRunes        int
+	cleared         []string
+	clearErr        error
+	clearBeforeSend bool
+	clearCanceled   bool
 }
 
 func (c *draftChat) Capabilities() Capabilities {
@@ -31,6 +35,15 @@ func (c *draftChat) SendDraft(_ context.Context, _ ChatID, runID, text string) e
 	defer c.mu.Unlock()
 	c.drafts = append(c.drafts, runID+":"+text)
 	return c.draftErr
+}
+
+func (c *draftChat) ClearDraft(ctx context.Context, _ ChatID, runID string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.cleared = append(c.cleared, runID)
+	c.clearBeforeSend = len(c.sent) == 0
+	c.clearCanceled = ctx.Err() != nil
+	return c.clearErr
 }
 
 func TestDraftProgressPersistsOnlyTheTerminalAnswer(t *testing.T) {
@@ -52,6 +65,12 @@ func TestDraftProgressPersistsOnlyTheTerminalAnswer(t *testing.T) {
 			}
 			if !fail && (fc.edits != 0 || fc.sent[0] != finalAnswer) {
 				t.Fatalf("draft wrote a persistent anchor: sent=%v edits=%d", fc.sent, fc.edits)
+			}
+			if !fail && (len(fc.cleared) != 1 || !fc.clearBeforeSend || fc.clearCanceled) {
+				t.Fatal("draft was not cleared before final delivery")
+			}
+			if fail && len(fc.cleared) != 0 {
+				t.Fatal("cleared a draft that never started")
 			}
 			if fail && fc.sent[0] != anchorText {
 				t.Fatal("missing persistent fallback")
@@ -84,5 +103,35 @@ func TestDraftProgressUsesTransportBudgetAndStableRun(t *testing.T) {
 	}
 	if len(fc.sent) != 0 || fc.edits != 0 {
 		t.Fatal("progress created a persistent message")
+	}
+}
+
+func TestDraftClearFailureDoesNotBlockFinalAnswer(t *testing.T) {
+	fc := &draftChat{fakeChat: newFakeChat(), clearErr: errors.New("cleanup unavailable")}
+	runner := &fakeRunner{events: []agent.Event{{Type: agent.Result, Result: &agent.RunResult{Text: finalAnswer}}}}
+	svc, dispatcher := newTestService(t, runner, fc)
+	defer dispatcher.Close()
+	svc.Handle(t.Context(), "100", 100, "1", "hello")
+	waitUntil(t, func() bool { fc.mu.Lock(); defer fc.mu.Unlock(); return fc.texts["1"] == finalAnswer })
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	if len(fc.cleared) != 1 {
+		t.Fatal("cleanup was not attempted")
+	}
+}
+
+func TestDraftClearRunsAfterCancellation(t *testing.T) {
+	fc := &draftChat{fakeChat: newFakeChat()}
+	runner := &fakeRunner{gate: make(chan struct{})}
+	svc, dispatcher := newTestService(t, runner, fc)
+	defer dispatcher.Close()
+	svc.Handle(t.Context(), "100", 100, "1", "hello")
+	waitUntil(t, func() bool { fc.mu.Lock(); defer fc.mu.Unlock(); return len(fc.drafts) > 0 })
+	svc.StopChat("100")
+	waitUntil(t, func() bool { fc.mu.Lock(); defer fc.mu.Unlock(); return len(fc.sent) > 0 })
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	if len(fc.cleared) != 1 || fc.clearCanceled || !fc.clearBeforeSend {
+		t.Fatal("cancelled run leaked its draft")
 	}
 }

--- a/core/chat/draft_test.go
+++ b/core/chat/draft_test.go
@@ -1,0 +1,88 @@
+//nolint:testpackage // Tests the optional progress path with the existing run-loop harness.
+package chat
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/duckbugio/flock/core/agent"
+)
+
+type draftChat struct {
+	*fakeChat
+	drafts   []string
+	draftErr error
+	maxRunes int
+}
+
+func (c *draftChat) Capabilities() Capabilities {
+	limit := c.maxRunes
+	if limit == 0 {
+		limit = 2048
+	}
+	return Capabilities{CanSendDraft: true, MaxMessageRunes: limit}
+}
+
+func (c *draftChat) SendDraft(_ context.Context, _ ChatID, runID, text string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.drafts = append(c.drafts, runID+":"+text)
+	return c.draftErr
+}
+
+func TestDraftProgressPersistsOnlyTheTerminalAnswer(t *testing.T) {
+	for _, fail := range []bool{false, true} {
+		t.Run(map[bool]string{false: "draft", true: "fallback"}[fail], func(t *testing.T) {
+			fc := &draftChat{fakeChat: newFakeChat()}
+			if fail {
+				fc.draftErr = errors.New("not implemented")
+			}
+			runner := &fakeRunner{events: []agent.Event{{Type: agent.Result, Result: &agent.RunResult{Text: finalAnswer}}}}
+			svc, dispatcher := newTestService(t, runner, fc)
+			defer dispatcher.Close()
+			svc.Handle(t.Context(), "100", 100, "1", "hello")
+			waitUntil(t, func() bool { fc.mu.Lock(); defer fc.mu.Unlock(); return fc.texts["1"] == finalAnswer })
+			fc.mu.Lock()
+			defer fc.mu.Unlock()
+			if len(fc.drafts) == 0 {
+				t.Fatal("draft was not attempted")
+			}
+			if !fail && (fc.edits != 0 || fc.sent[0] != finalAnswer) {
+				t.Fatalf("draft wrote a persistent anchor: sent=%v edits=%d", fc.sent, fc.edits)
+			}
+			if fail && fc.sent[0] != anchorText {
+				t.Fatal("missing persistent fallback")
+			}
+		})
+	}
+}
+
+func TestDraftProgressUsesTransportBudgetAndStableRun(t *testing.T) {
+	const budget = 32
+	fc := &draftChat{fakeChat: newFakeChat(), maxRunes: budget}
+	gate := make(chan struct{})
+	runner := &fakeRunner{gate: gate, events: []agent.Event{
+		{Type: agent.Text, Text: strings.Repeat("😀", 200)},
+		{Type: agent.Result, Result: &agent.RunResult{Text: finalAnswer}},
+	}}
+	svc, dispatcher := newTestService(t, runner, fc)
+	defer dispatcher.Close()
+	defer close(gate)
+	svc.Handle(t.Context(), "100", 100, "1", "hello")
+	waitUntil(t, func() bool { fc.mu.Lock(); defer fc.mu.Unlock(); return len(fc.drafts) >= 2 })
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	firstID, _, _ := strings.Cut(fc.drafts[0], ":")
+	for _, draft := range fc.drafts {
+		id, text, _ := strings.Cut(draft, ":")
+		if id != firstID || utf8.RuneCountInString(text) > budget {
+			t.Fatalf("invalid draft: %q", draft)
+		}
+	}
+	if len(fc.sent) != 0 || fc.edits != 0 {
+		t.Fatal("progress created a persistent message")
+	}
+}

--- a/core/chat/media.go
+++ b/core/chat/media.go
@@ -30,6 +30,9 @@ const maxQuotedRunes = 2000
 // quotedEllipsis marks a quoted block that was truncated to maxQuotedRunes.
 const quotedEllipsis = "…"
 
+// AssistantAuthorLabel identifies a reply to this assistant across transports.
+const AssistantAuthorLabel = "the assistant"
+
 // QuotedPrompt folds a replied-to / quoted message into the prompt so the model
 // sees the original the user is referring to, not just their new text. The quoted
 // original is placed FIRST and framed explicitly as reference data — context the

--- a/core/chat/service.go
+++ b/core/chat/service.go
@@ -31,20 +31,18 @@ import (
 // minEditInterval), so this is the progress refresh cadence.
 const tickInterval = 1 * time.Second
 
-// minEditInterval throttles real edits in the rate-limited fallback path. Drafts
-// (the primary live path) have no Telegram rate limit and refresh every
-// tickInterval; the Edit fallback IS rate-limited, so when a run falls back to
-// editing the anchor we additionally cap real edits to at most one per
-// minEditInterval. A 1s ticker would otherwise hammer the throttled Edit endpoint,
-// drawing 429s whose back-off parks render() and freezes the counter. Drafts are
-// never throttled by this — only the fallback edit branch.
+// minEditInterval throttles both persistent edits and ephemeral drafts. Both
+// paths also share the server-provided 429 backoff in throttledUntil. The ticker
+// advances the in-memory frame every second; delivery runs at this slower cadence.
 const minEditInterval = 3 * time.Second
 
-// anchorText is the persistent progress message sent at the start of a run. It
-// carries the Stop button and is edited IN PLACE with the live "Working… (Ns)"
-// frame on each (throttled) tick, then edited into the final answer — so a whole
-// run is exactly ONE chat bubble, identical on every platform. This initial text
-// shows only until the first tick replaces it with the live frame.
+// draftClearTimeout bounds best-effort cleanup so it cannot starve final delivery.
+const draftClearTimeout = 2 * time.Second
+
+// anchorText is the initial progress text for both drafts and persistent anchors.
+// The first progress tick replaces it. A persistent anchor may carry a Stop
+// button and is edited into the final answer; a draft is cleared before sending
+// a new persistent answer.
 const anchorText = "⏳ Working…"
 
 // workspaceEnsurer resolves a chat's isolated workspace path, creating it (and
@@ -627,7 +625,11 @@ loop:
 	// which case the NEXT request is denied (the crossing request still ran).
 	s.recordCost(chatID, userID, finalResult)
 
-	s.finish(ctx, chatID, progressMsgID, markerID, finalResult, finalErr, ctx.Err(), s.nowFunc().Sub(start))
+	draftRunID := ""
+	if usingDraft {
+		draftRunID = runID
+	}
+	s.finish(ctx, chatID, progressMsgID, markerID, draftRunID, finalResult, finalErr, s.nowFunc().Sub(start))
 
 	// Self-heal a stale/poisoned resume id: when a run that USED a resume session
 	// id terminates with an is_error Result, drop the stored session for this chat
@@ -810,12 +812,22 @@ func (s *Service) clearLanePending(chatID ChatID) {
 // finish renders the terminal message and replaces the progress message with it
 // (chunked when the answer exceeds the platform's message size limit).
 func (s *Service) finish(
-	ctx context.Context, chatID ChatID, progressMsgID MessageID, markerID string,
-	res *agent.RunResult, runErr, ctxErr error, total time.Duration,
+	ctx context.Context, chatID ChatID, progressMsgID MessageID, markerID, draftRunID string,
+	res *agent.RunResult, runErr error, total time.Duration,
 ) {
 	// Use a background context for delivery: the run ctx may be cancelled by Stop
 	// or shutdown, but the final message should still reach the user.
+	ctxErr := ctx.Err()
 	deliverCtx := context.WithoutCancel(ctx)
+	if draftRunID != "" {
+		if draft, ok := s.chat.(DraftTransport); ok {
+			clearCtx, cancel := context.WithTimeout(deliverCtx, draftClearTimeout)
+			if err := draft.ClearDraft(clearCtx, chatID, draftRunID); err != nil {
+				s.log.Debug("clear progress draft", "error", err)
+			}
+			cancel()
+		}
+	}
 	// Clear this run's interrupted-run marker by id whenever the run REACHED a
 	// terminal — it delivered a Result or errored — so a finished run is never
 	// auto-resumed after a later restart. The marker is KEPT only for a run that

--- a/core/chat/service.go
+++ b/core/chat/service.go
@@ -498,15 +498,28 @@ func (s *Service) run(
 	start := s.nowFunc()
 	prog := NewProgress(func() time.Duration { return s.nowFunc().Sub(start) }, 0, workdir)
 
-	// The anchor: a persistent message that carries the Stop button and is edited in
-	// place with the live progress frame, then with the final answer. An empty id
-	// means no anchor was created (Send failed) — we can still deliver.
-	progressMsgID, err := s.chat.Send(ctx, chatID, anchorText, runID, false)
-	if err != nil {
-		// Without an anchor we can still deliver the result; keep going.
-		s.log.Error("send anchor message", "error", err)
-		progressMsgID = ""
+	// Prefer an ephemeral draft when the transport opts in. Otherwise create a
+	// persistent anchor, edited with progress and then the final answer. Drafts
+	// have no message ID; their final answer must be sent as a new message.
+
+	draft, hasDraft := s.chat.(DraftTransport)
+	usingDraft := false
+	if s.caps.CanSendDraft && hasDraft {
+		if draftErr := draft.SendDraft(ctx, chatID, runID, anchorText); draftErr == nil {
+			usingDraft = true
+		} else {
+			s.log.Debug("draft unavailable; using editable progress", "error", draftErr)
+		}
 	}
+	var progressMsgID MessageID
+	if !usingDraft {
+		progressMsgID, err = s.chat.Send(ctx, chatID, anchorText, runID, false)
+		if err != nil {
+			s.log.Error("send anchor message", "error", err)
+			progressMsgID = ""
+		}
+	}
+
 	// Record the anchor id on the marker now that it is known, so a restart can
 	// best-effort edit the dangling "Working…" message into a resume notice. The
 	// prompt was already persisted at submit; this only enriches the same entry by
@@ -528,17 +541,16 @@ func (s *Service) run(
 		finalErr    error
 	)
 
-	// render edits the single anchor message in place with the current progress
-	// frame, rate-limit aware. The anchor IS the one live progress bubble (it also
-	// carries the Stop button), so a run is exactly ONE message on every platform.
+	// render updates the draft or persistent anchor with the current progress
+	// frame, rate-limit aware. Transports may attach a Stop button to the anchor.
 	// Telegram caps message edits, so real edits are throttled to one per
 	// minEditInterval; the 1s ticker only advances the in-memory counter, and most
 	// ticks early-return on frame==lastSent or the throttle.
 	render := func() {
-		if progressMsgID == "" {
+		if progressMsgID == "" && !usingDraft {
 			return
 		}
-		frame := prog.Frame()
+		frame := truncateRunes(prog.Frame(), s.maxRunes)
 		if frame == lastSent {
 			return
 		}
@@ -553,7 +565,13 @@ func (s *Service) run(
 		if !lastEditAt.IsZero() && s.nowFunc().Sub(lastEditAt) < minEditInterval {
 			return
 		}
-		if err := s.chat.Edit(ctx, chatID, progressMsgID, frame, runID, true); err != nil {
+		var editErr error
+		if usingDraft {
+			editErr = draft.SendDraft(ctx, chatID, runID, frame)
+		} else {
+			editErr = s.chat.Edit(ctx, chatID, progressMsgID, frame, runID, true)
+		}
+		if err := editErr; err != nil {
 			if d, ok := s.retryAfterErr(err); ok {
 				throttledUntil = s.nowFunc().Add(d)
 			}
@@ -863,7 +881,7 @@ func (s *Service) finish(
 			}
 		}
 	} else {
-		// No anchor existed (the initial progress Send failed): the first chunk is a
+		// No anchor existed (draft mode or initial Send failed): the first chunk is a
 		// fresh Send, so the notice replies to its returned id.
 		if sErr := s.deliverWithBackoff(deliverCtx, "send final", func() error {
 			id, e := s.chat.Send(deliverCtx, chatID, chunks[0], "", true)

--- a/core/chat/transport.go
+++ b/core/chat/transport.go
@@ -64,6 +64,10 @@ type Transport interface {
 // defined fallback so a missing primitive never breaks delivery. Telegram and VK
 // set CanSendDocument true and MaxMessageRunes 4096.
 type Capabilities struct {
+	// CanSendDraft enables ephemeral progress when Transport also implements DraftTransport.
+	// A failed initial draft falls back to the ordinary editable anchor.
+	CanSendDraft bool
+
 	// CanSendDocument: platform supports file attachments. false → the outbox
 	// sweep is skipped. (Telegram/VK: true.)
 	CanSendDocument bool
@@ -78,4 +82,10 @@ type Capabilities struct {
 	// rich path always falls back to MarkdownToHTML/plain on any error, so the flag
 	// is a feature toggle, never a hard dependency.
 	CanSendRich bool
+}
+
+// DraftTransport is an optional ephemeral-progress channel. runID is stable for
+// a run, not a MessageID. The terminal answer is always persisted through Send.
+type DraftTransport interface {
+	SendDraft(ctx context.Context, chatID ChatID, runID, text string) error
 }

--- a/core/chat/transport.go
+++ b/core/chat/transport.go
@@ -88,4 +88,6 @@ type Capabilities struct {
 // a run, not a MessageID. The terminal answer is always persisted through Send.
 type DraftTransport interface {
 	SendDraft(ctx context.Context, chatID ChatID, runID, text string) error
+	// ClearDraft removes ephemeral progress without creating a persistent message.
+	ClearDraft(ctx context.Context, chatID ChatID, runID string) error
 }

--- a/core/workspace/workspace.go
+++ b/core/workspace/workspace.go
@@ -136,11 +136,6 @@ Keep generated artifacts in the workspace or the task repository as appropriate,
 and report their paths. Do not claim that a local path is a downloadable chat
 attachment. Summarize important findings in the text answer.
 
-The runtime image provides a screenshot command for your own inspection:
-
-    shot <url> <out.png> [--full] [--width=N] [--height=N] [--wait=ms]
-
-Screenshots stay local. Authenticated pages may require additional setup.
 `
 
 // shotConvention is appended to every rendered CLAUDE.md so the dev-team agents
@@ -157,8 +152,9 @@ page using the bundled system Chromium:
     shot <url> <out.png> [--full] [--width=N] [--height=N] [--wait=ms]
 
 Use ` + "`--full`" + ` for a full-page capture (it autoscrolls first to load lazy
-content). Writing the PNG into ` + "`outbox/`" + ` delivers it to the user in chat
-(see the outbox convention above). Known limit: pages that require authentication —
+content). Follow the file-delivery convention above: transports with an outbox can
+deliver the PNG from ` + "`outbox/`" + `; otherwise keep it local and report its path.
+Known limit: pages that require authentication —
 e.g. a Telegram Mini App that needs ` + "`initData`" + ` — will not render.
 `
 
@@ -206,8 +202,8 @@ func (r *Renderer) renderClaudeMD(ws string) error {
 		rendered += localFilesConvention
 	} else {
 		rendered += outboxConvention
-		rendered += shotConvention
 	}
+	rendered += shotConvention
 	rendered += followupConvention
 
 	dst := filepath.Join(ws, "CLAUDE.md")

--- a/core/workspace/workspace.go
+++ b/core/workspace/workspace.go
@@ -51,6 +51,9 @@ type Renderer struct {
 	// "confirm scope and wait" gate: off | trivial | standard | all. Normalized
 	// by config.AutoApproveScopeLevel (an unknown value renders as "off").
 	AutoApproveScope string
+
+	// FileDeliveryDisabled replaces outbox promises on transports without documents.
+	FileDeliveryDisabled bool
 }
 
 // Ensure creates (or refreshes) the workspace for chatID and returns its path.
@@ -123,6 +126,23 @@ in ` + "`outbox/`" + ` is sent to the user as a Telegram document and archived
 under ` + "`outbox/sent/`" + `. Do not put files you want delivered inside a repo.
 `
 
+// localFilesConvention avoids promises the transport cannot fulfill.
+const localFilesConvention = `
+
+## Files and screenshots
+
+This chat transport cannot deliver attachments or automatically send an outbox.
+Keep generated artifacts in the workspace or the task repository as appropriate,
+and report their paths. Do not claim that a local path is a downloadable chat
+attachment. Summarize important findings in the text answer.
+
+The runtime image provides a screenshot command for your own inspection:
+
+    shot <url> <out.png> [--full] [--width=N] [--height=N] [--wait=ms]
+
+Screenshots stay local. Authenticated pages may require additional setup.
+`
+
 // shotConvention is appended to every rendered CLAUDE.md so the dev-team agents
 // know the runtime image ships a screenshot tool. Like outboxConvention it lives
 // here (not in the protected template) so the template file on disk stays
@@ -182,8 +202,12 @@ func (r *Renderer) renderClaudeMD(ws string) error {
 	// Append the outbox + screenshot + follow-up conventions to the RENDERED
 	// output (after substitution), keeping the protected template file on disk
 	// byte-identical.
-	rendered += outboxConvention
-	rendered += shotConvention
+	if r.FileDeliveryDisabled {
+		rendered += localFilesConvention
+	} else {
+		rendered += outboxConvention
+		rendered += shotConvention
+	}
 	rendered += followupConvention
 
 	dst := filepath.Join(ws, "CLAUDE.md")

--- a/core/workspace/workspace_test.go
+++ b/core/workspace/workspace_test.go
@@ -345,3 +345,24 @@ func TestAutoApproveScopeSubstitution(t *testing.T) {
 		t.Fatalf("AutoApproveScope must substitute, got: %s", data)
 	}
 }
+
+func TestWorkspaceWithoutFileDeliveryDoesNotPromiseAttachments(t *testing.T) {
+	r := newTestRenderer(t)
+	r.FileDeliveryDisabled = true
+	ws, err := r.Ensure("77")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := os.ReadFile(filepath.Join(ws, "CLAUDE.md")) //nolint:gosec // Controlled test workspace.
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(body)
+	if !strings.Contains(text, "cannot deliver attachments") || !strings.Contains(text, "shot <url>") {
+		t.Fatal("missing local artifact instructions")
+	}
+	if strings.Contains(text, "sent to the user as a Telegram document") ||
+		strings.Contains(text, "delivers it to the user in chat") {
+		t.Fatal("unsupported attachment delivery promised")
+	}
+}

--- a/docs/lo-telegram-compatibility.md
+++ b/docs/lo-telegram-compatibility.md
@@ -7,15 +7,15 @@ was available during implementation.
 ## Reproducible baseline
 
 - Flock: `3858d8c37f54bbf5c7a6f9880839009418bfef82`.
-- LO messenger `origin/main`, fetched on 2026-09-06:
-  `6df9fd6cdd53f5f72bfd02f84f207be4b2540f60`.
-- [LO method registry](https://git.lo.ink/LO/messenger/src/commit/6df9fd6cdd53f5f72bfd02f84f207be4b2540f60/bots/bot-api-service/internal/usecase/botmethod/getme.go).
-- [LO sendMessage parameter allow-list](https://git.lo.ink/LO/messenger/src/commit/6df9fd6cdd53f5f72bfd02f84f207be4b2540f60/bots/bot-api-service/internal/usecase/botmethod/sendmessage.go).
+- LO messenger `origin/main`, verified on 2026-09-09:
+  `5174d1405ec409dbc67edd99ac65c1aad3f7b2b0`.
+- [LO method registry](https://git.lo.ink/LO/messenger/src/commit/5174d1405ec409dbc67edd99ac65c1aad3f7b2b0/bots/bot-api-service/internal/usecase/botmethod/getme.go).
+- [LO sendMessage parameter allow-list](https://git.lo.ink/LO/messenger/src/commit/5174d1405ec409dbc67edd99ac65c1aad3f7b2b0/bots/bot-api-service/internal/usecase/botmethod/sendmessage.go).
 
-These references describe the fetched main branch, not what is deployed. Separate
-local LO changes implement more of the draft/command/formatting surface; they are
-not treated as released capabilities. Operators must supply `LO_API_URL` and verify
-their deployment before enabling optional flags.
+These references describe server code. They do not replace a live Flock acceptance
+run. Operators must supply `LO_API_URL` and verify their deployment before enabling
+optional flags. In this revision draft and command support are implemented server-side;
+Flock live delivery remains to be verified with a dedicated bot token.
 
 ## What this integration exposes
 
@@ -24,10 +24,10 @@ their deployment before enabling optional flags.
 | Webhook preflight | `getWebhookInfo` is registered on main | Refuses active webhooks; explicit 404/501 on older deployments falls back to polling conflict detection |
 | Incoming text | `getUpdates`, positive offset acknowledgement | Long polling; separate LO user allow-list; group mention gate |
 | Persistent answer / progress edits | `sendMessage`, `editMessageText`, `deleteMessage` | Implemented with numeric IDs and plain text |
-| Ephemeral progress | `sendMessageDraft` is a 501 stub | Opt-in `LO_ENABLE_DRAFTS`; stable draft ID per run; explicit empty-text cleanup before a real final `sendMessage`; initial failure falls back to an editable anchor |
-| HTML / entities | `sendMessage` accepts only `chat_id`, `text` | Formatting source is sent as plain text; unsupported fields are never transmitted |
+| Ephemeral progress | `sendMessageDraft` supports private chats and empty-text cleanup | Opt-in `LO_ENABLE_DRAFTS`; stable draft ID per run; explicit empty-text cleanup before a real final `sendMessage`; initial failure falls back to an editable anchor |
+| HTML / entities | `sendMessage` accepts parse modes and entities | Formatting source is sent as plain text; unsupported fields are never transmitted |
 | Stop button | Callback keyboard fields rejected; `answerCallbackQuery` and `editMessageReplyMarkup` are stubs | `/stop` remains available to allowed users even when request/cost guards reject new work |
-| Command menu | `setMyCommands` / `getMyCommands` / `deleteMyCommands` are stubs | Text commands work; registration is separately opt-in |
+| Command menu | `setMyCommands` / `getMyCommands` / `deleteMyCommands` are implemented | Text commands work; registration is separately opt-in |
 | Native quoted reply | `reply_parameters` and legacy reply fields rejected | Completion notice is a separate message; inbound quoted text is included in the prompt when supplied |
 | Files / generated artifacts | `sendDocument` is a stub; photo/audio/video support does not establish general document parity | Document outbox disabled; received attachments get an explicit unsupported notice |
 | Provider slash commands | No platform-specific requirement | Non-reserved commands such as `/loop` reach the configured agent backend |
@@ -50,8 +50,8 @@ LO draft support is private-chat-only; groups use the persistent anchor fallback
 3. **Documents and inbound media:** complete upload, reusable file IDs, download,
    metadata and limits. Flock needs repository artifacts and screenshots, not only
    photo sends. The adapter will need corresponding download/outbox wiring.
-4. **Formatting and reply parity:** deploy parse modes/entities and native reply
-   fields with visible client rendering. Test code blocks, escaping, emoji offsets,
+4. **Formatting and reply parity:** wire the adapter to implemented parse modes/entities
+   and complete native reply fields with visible client rendering. Test code blocks, escaping, emoji offsets,
    quote targets and edit behavior, not merely accepted JSON.
 5. **Drafts and command discovery:** deploy and verify temporary-event delivery,
    expiration, final-message replacement and command menus. The opt-in flags in
@@ -96,10 +96,24 @@ Validation passed on 2026-09-06 using the repository dev-tools image (Go 1.26.6)
 - LO Compose configuration validation without loading a credential file.
 
 The full AI runtime image and multi-architecture CI job were not executed locally;
-the runtime is shared with the existing Telegram Dockerfile.
+the LO adapter now has its own Dockerfile and executable, with equivalent AI tooling.
 
 Before enabling it for real users, run the [setup](../adapters/lo/README.md) with a
 LO test bot and verify: allowed/denied users, a long-running request and `/stop`,
 emoji-heavy multi-part answers, restart during polling, and both draft flag values.
 Confirm that no transient draft is stored as a final answer and that the final
 answer remains visible after reconnecting the chat client.
+
+## Review follow-up (2026-09-09)
+
+The LO runtime now has its own Dockerfile and binary name, with a configurable 3g
+memory cap. Reserved group commands do not require a mention, but the allow-list
+and rejection of commands addressed to another bot still apply. Polling retries
+up to four consecutive 409 conflicts before the fifth stops the process; a successful
+poll resets this counter. The stale-batch regression test waits for the second request
+before observing backoff, avoiding a race with a slow runner startup.
+
+Server draft IDs remain int64 in Go and are serialized as decimal strings in client
+streaming events (`handler_internal_bot_draft.go`), so a 63-bit Flock draft ID is not
+converted to a JavaScript number by that delivery path. Real streaming rendering and
+cleanup still require the live acceptance run.

--- a/docs/lo-telegram-compatibility.md
+++ b/docs/lo-telegram-compatibility.md
@@ -23,7 +23,7 @@ their deployment before enabling optional flags.
 | --- | --- | --- |
 | Incoming text | `getUpdates`, positive offset acknowledgement | Long polling; separate LO user allow-list; group mention gate |
 | Persistent answer / progress edits | `sendMessage`, `editMessageText`, `deleteMessage` | Implemented with numeric IDs and plain text |
-| Ephemeral progress | `sendMessageDraft` is a 501 stub | Opt-in `LO_ENABLE_DRAFTS`; stable draft ID per run; final answer is a real `sendMessage`; initial failure falls back to an editable anchor |
+| Ephemeral progress | `sendMessageDraft` is a 501 stub | Opt-in `LO_ENABLE_DRAFTS`; stable draft ID per run; explicit empty-text cleanup before a real final `sendMessage`; initial failure falls back to an editable anchor |
 | HTML / entities | `sendMessage` accepts only `chat_id`, `text` | Formatting source is sent as plain text; unsupported fields are never transmitted |
 | Stop button | Callback keyboard fields rejected; `answerCallbackQuery` and `editMessageReplyMarkup` are stubs | `/stop` remains available to allowed users even when request/cost guards reject new work |
 | Command menu | `setMyCommands` / `getMyCommands` / `deleteMyCommands` are stubs | Text commands work; registration is separately opt-in |
@@ -82,7 +82,8 @@ These are adapter/runtime limitations, not evidence of missing LO endpoints:
 The adapter has HTTP-fixture tests for method payloads, numeric IDs, retry delays,
 credential redaction, redirect refusal, malformed envelopes, draft identity,
 UTF-16 rejection, inbound gates, ordered polling acknowledgement, webhook conflicts
-and quoted context. Core tests cover native draft completion, progress size limits,
+and quoted context. Core tests cover native draft completion and cleanup (including cancellation and
+cleanup failure), progress size limits,
 fallback to the persistent anchor and workspace instructions without file-delivery
 promises.
 

--- a/docs/lo-telegram-compatibility.md
+++ b/docs/lo-telegram-compatibility.md
@@ -1,0 +1,103 @@
+# LO integration and Telegram compatibility
+
+This audit accompanies the first Flock LO adapter. It is based on source, not a
+successful production bot session. No LO token or verified public Bot API endpoint
+was available during implementation.
+
+## Reproducible baseline
+
+- Flock: `3858d8c37f54bbf5c7a6f9880839009418bfef82`.
+- LO messenger `origin/main`, fetched on 2026-09-06:
+  `6df9fd6cdd53f5f72bfd02f84f207be4b2540f60`.
+- [LO method registry](https://git.lo.ink/LO/messenger/src/commit/6df9fd6cdd53f5f72bfd02f84f207be4b2540f60/bots/bot-api-service/internal/usecase/botmethod/getme.go).
+- [LO sendMessage parameter allow-list](https://git.lo.ink/LO/messenger/src/commit/6df9fd6cdd53f5f72bfd02f84f207be4b2540f60/bots/bot-api-service/internal/usecase/botmethod/sendmessage.go).
+
+These references describe the fetched main branch, not what is deployed. Separate
+local LO changes implement more of the draft/command/formatting surface; they are
+not treated as released capabilities. Operators must supply `LO_API_URL` and verify
+their deployment before enabling optional flags.
+
+## What this integration exposes
+
+| Flock behavior | LO main contract | Adapter behavior |
+| --- | --- | --- |
+| Incoming text | `getUpdates`, positive offset acknowledgement | Long polling; separate LO user allow-list; group mention gate |
+| Persistent answer / progress edits | `sendMessage`, `editMessageText`, `deleteMessage` | Implemented with numeric IDs and plain text |
+| Ephemeral progress | `sendMessageDraft` is a 501 stub | Opt-in `LO_ENABLE_DRAFTS`; stable draft ID per run; final answer is a real `sendMessage`; initial failure falls back to an editable anchor |
+| HTML / entities | `sendMessage` accepts only `chat_id`, `text` | Formatting source is sent as plain text; unsupported fields are never transmitted |
+| Stop button | Callback keyboard fields rejected; `answerCallbackQuery` and `editMessageReplyMarkup` are stubs | `/stop` remains available to allowed users even when request/cost guards reject new work |
+| Command menu | `setMyCommands` / `getMyCommands` / `deleteMyCommands` are stubs | Text commands work; registration is separately opt-in |
+| Native quoted reply | `reply_parameters` and legacy reply fields rejected | Completion notice is a separate message; inbound quoted text is included in the prompt when supplied |
+| Files / generated artifacts | `sendDocument` is a stub; photo/audio/video support does not establish general document parity | Document outbox disabled; received attachments get an explicit unsupported notice |
+| Provider slash commands | No platform-specific requirement | Non-reserved commands such as `/loop` reach the configured agent backend |
+| Goals and scheduled work | Uses normal bot messaging | Shared Flock goal and scheduler services wired |
+| Rate limits | 429 with `retry_after` | Progress and final-delivery backoff use the LO classifier; polling backs off too |
+| ID and text sizes | Integer IDs, 4096 UTF-16-unit text budget | Int64-safe JSON; 2048-rune chunks guarantee the LO limit even for emoji |
+
+The optional draft path streams Flock's activity/progress frames. It does not add
+model token deltas to agent providers that only report a completed answer. Current
+LO draft support is private-chat-only; groups use the persistent anchor fallback.
+
+## Remaining LO work, in migration order
+
+1. **Ship and exercise the Bot API as a deployed product:** establish the public
+   endpoint and token onboarding, then test real inbound delivery, edits, 429s,
+   restart behavior and final answer delivery against the actual chat clients.
+2. **Callbacks and keyboards:** implement `reply_markup`, callback update delivery,
+   `answerCallbackQuery`, and markup edits end to end. This restores inline Stop,
+   confirmation and navigation flows used by existing Telegram bots.
+3. **Documents and inbound media:** complete upload, reusable file IDs, download,
+   metadata and limits. Flock needs repository artifacts and screenshots, not only
+   photo sends. The adapter will need corresponding download/outbox wiring.
+4. **Formatting and reply parity:** deploy parse modes/entities and native reply
+   fields with visible client rendering. Test code blocks, escaping, emoji offsets,
+   quote targets and edit behavior, not merely accepted JSON.
+5. **Drafts and command discovery:** deploy and verify temporary-event delivery,
+   expiration, final-message replacement and command menus. The opt-in flags in
+   this adapter provide a concrete consumer for those checks.
+
+This is not a complete Telegram Bot API inventory. It covers methods exercised by
+Flock and the compatibility gaps they expose; Mini App bridge compatibility needs
+its own integration test and is outside this chatbot adapter.
+
+## Flock-specific follow-ups
+
+These are adapter/runtime limitations, not evidence of missing LO endpoints:
+
+- The LO entry point does not yet wire Flock's PR-comment polling, CI watcher,
+  pending-run restart recovery or star nudges. Do not advertise full operational
+  parity with the Telegram entry point.
+- Polling advances its in-memory offset after admission, not after an agent run
+  completes. A restart can redeliver the last unacknowledged batch; this is not an
+  exactly-once job queue. Run one polling instance per bot token.
+- The shared chunker counts Unicode runes. LO uses a conservative half-size budget;
+  a future UTF-16-aware chunker could use the full limit for BMP-only text and
+  improve the existing Telegram adapter as well.
+- Draft support is an optional core transport interface; Telegram and VK retain
+  their existing progress behavior. Telegram native drafts are not enabled by this
+  change.
+
+## Validation and live acceptance
+
+The adapter has HTTP-fixture tests for method payloads, numeric IDs, retry delays,
+credential redaction, redirect refusal, malformed envelopes, draft identity,
+UTF-16 rejection, inbound gates, ordered polling acknowledgement, webhook conflicts
+and quoted context. Core tests cover native draft completion, progress size limits,
+fallback to the persistent anchor and workspace instructions without file-delivery
+promises.
+
+Validation passed on 2026-09-06 using the repository dev-tools image (Go 1.26.6):
+
+- `task default`: tidy, formatting, lint (zero issues), all race tests and builds.
+- `task security-scan`: no vulnerabilities found.
+- Docker build stage with `FLOCK_COMMAND=flock-lo` on linux/arm64.
+- LO Compose configuration validation without loading a credential file.
+
+The full AI runtime image and multi-architecture CI job were not executed locally;
+the runtime is shared with the existing Telegram Dockerfile.
+
+Before enabling it for real users, run the [setup](../adapters/lo/README.md) with a
+LO test bot and verify: allowed/denied users, a long-running request and `/stop`,
+emoji-heavy multi-part answers, restart during polling, and both draft flag values.
+Confirm that no transient draft is stored as a final answer and that the final
+answer remains visible after reconnecting the chat client.

--- a/docs/lo-telegram-compatibility.md
+++ b/docs/lo-telegram-compatibility.md
@@ -109,8 +109,9 @@ answer remains visible after reconnecting the chat client.
 The LO runtime now has its own Dockerfile and binary name, with a configurable 3g
 memory cap. Reserved group commands do not require a mention, but the allow-list
 and rejection of commands addressed to another bot still apply. Polling retries
-up to four consecutive 409 conflicts before the fifth stops the process; a successful
-poll resets this counter. The stale-batch regression test waits for the second request
+up to four consecutive 409 conflicts with ten-second waits before the fifth stops
+the process: a 40-second wait budget covers the 30-second long poll. Cancellation
+interrupts these waits immediately; a successful poll resets the counter. The stale-batch regression test waits for the second request
 before observing backoff, avoiding a race with a slow runner startup.
 
 Server draft IDs remain int64 in Go and are serialized as decimal strings in client

--- a/docs/lo-telegram-compatibility.md
+++ b/docs/lo-telegram-compatibility.md
@@ -21,6 +21,7 @@ their deployment before enabling optional flags.
 
 | Flock behavior | LO main contract | Adapter behavior |
 | --- | --- | --- |
+| Webhook preflight | `getWebhookInfo` is registered on main | Refuses active webhooks; explicit 404/501 on older deployments falls back to polling conflict detection |
 | Incoming text | `getUpdates`, positive offset acknowledgement | Long polling; separate LO user allow-list; group mention gate |
 | Persistent answer / progress edits | `sendMessage`, `editMessageText`, `deleteMessage` | Implemented with numeric IDs and plain text |
 | Ephemeral progress | `sendMessageDraft` is a 501 stub | Opt-in `LO_ENABLE_DRAFTS`; stable draft ID per run; explicit empty-text cleanup before a real final `sendMessage`; initial failure falls back to an editable anchor |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/duckbugio/flock
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/caarlos0/env/v11 v11.4.1

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -88,6 +88,13 @@ var (
 // deployment need not set TELEGRAM_BOT_TOKEN and vice versa, while the shared
 // core config is parsed once and reused.
 type Config struct {
+	// LO uses its own credentials and user-ID namespace; no Telegram defaults apply.
+	LOBotToken         string  `env:"LO_BOT_TOKEN"`
+	LOAPIURL           string  `env:"LO_API_URL"`
+	LOAllowedUsers     []int64 `env:"LO_ALLOWED_USERS" envSeparator:","`
+	LOEnableDrafts     bool    `env:"LO_ENABLE_DRAFTS" envDefault:"false"`
+	LORegisterCommands bool    `env:"LO_REGISTER_COMMANDS" envDefault:"false"`
+
 	// Telegram (cmd/flock-telegram). Validated by ValidateTelegram, not env-required.
 	TelegramBotToken    string `env:"TELEGRAM_BOT_TOKEN"`
 	TelegramBotUsername string `env:"TELEGRAM_BOT_USERNAME"`
@@ -946,4 +953,36 @@ func (c Config) CIWatchEnabled() bool {
 		return false
 	}
 	return c.CIWatchGitHub() || c.GiteaAPIURL != ""
+}
+
+// ValidateLO rejects incomplete transport configuration before contacting any endpoint.
+func (c Config) ValidateLO() error {
+	if strings.TrimSpace(c.LOBotToken) == "" {
+		return errors.New("LO_BOT_TOKEN is required")
+	}
+	if strings.TrimSpace(c.LOAPIURL) == "" {
+		return errors.New("LO_API_URL is required")
+	}
+	if len(c.LOAllowedUsers) == 0 {
+		return errors.New("LO_ALLOWED_USERS must contain at least one LO user ID")
+	}
+	for _, id := range c.LOAllowedUsers {
+		if id <= 0 {
+			return errors.New("LO_ALLOWED_USERS must contain positive LO user IDs")
+		}
+	}
+	return nil
+}
+
+// IsLOAllowed never falls back to the Telegram or VK allow-list.
+func (c Config) IsLOAllowed(userID int64) bool {
+	if userID <= 0 {
+		return false
+	}
+	for _, allowed := range c.LOAllowedUsers {
+		if allowed == userID {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/config/lo_test.go
+++ b/internal/config/lo_test.go
@@ -1,0 +1,38 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/duckbugio/flock/internal/config"
+)
+
+func TestLOConfigRequiresIndependentIdentity(t *testing.T) {
+	t.Parallel()
+	cfg := config.Config{
+		LOAPIURL: "https://lo.example", LOBotToken: "123:test", LOAllowedUsers: []int64{77}, AllowedUsers: []int64{88},
+	}
+	if err := cfg.ValidateLO(); err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.IsLOAllowed(77) || cfg.IsLOAllowed(88) || cfg.IsLOAllowed(0) {
+		t.Fatal("LO inherited another transport's identity")
+	}
+	for _, test := range []struct {
+		name   string
+		change func(*config.Config)
+	}{
+		{"no token", func(c *config.Config) { c.LOBotToken = "" }},
+		{"no endpoint", func(c *config.Config) { c.LOAPIURL = "" }},
+		{"no users", func(c *config.Config) { c.LOAllowedUsers = nil }},
+		{"negative user", func(c *config.Config) { c.LOAllowedUsers = []int64{-1} }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			candidate := cfg
+			test.change(&candidate)
+			if err := candidate.ValidateLO(); err == nil {
+				t.Fatal("accepted invalid LO config")
+			}
+		})
+	}
+}

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.5
+FROM golang:1.26.6
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates git curl && \


### PR DESCRIPTION
## Summary

Add a dedicated LO bot entry point using the supported LO Bot API subset. Flock can receive text, edit progress, deliver answers and handle `/stop`, `/new`, `/goal` and `/schedule` with independent LO identities and workspaces.

Optional `sendMessageDraft` streams progress without creating a persistent anchor; final answers are always real messages. Older LO deployments fall back to editable progress. Unsupported keyboards, formatting, native replies and documents have explicit fallbacks. Workspace instructions no longer promise file delivery when the transport cannot provide it.

Requires Go 1.26.6 and aligns the CI tools image with that patched version: the first CI run exposed four standard-library vulnerabilities in the previous Go 1.26.5 pin.

Includes local Docker Compose, a PR-only LO image build and a source-pinned LO/Telegram compatibility audit. Drafts and command registration remain off by default until supported by the deployment.

## Related issue

User-requested LO integration and Telegram migration audit; no tracked issue.

## Type of change

- [x] New feature
- [x] Documentation
- [x] Build / CI / dependencies

## How it was verified

- `task default`: formatting, lint (zero issues), all race tests and both builds passed.
- `task security-scan`: no vulnerabilities found.
- Docker build stage with `FLOCK_COMMAND=flock-lo` passed on linux/arm64.
- LO Compose configuration validated without loading credentials.
- HTTP fixture tests cover payload compatibility, large IDs, UTF-16 limits, polling ordering, webhook conflicts, allow-list and stop guards. Core tests cover draft completion/fallback and capability-aware workspace instructions.

Live read-only checks against https://api.lo.ink passed using the actual Flock client: getMe resolves the dedicated wishlist_zay_bot identity, and CheckPolling refuses its active webhook without modifying it. The server also accepted command registration and webhook setup. Chat delivery, streaming, and restart acceptance still require a separate polling bot. Full runtime/multiarch image builds passed in CI. The LO entry point does not yet wire PR polling, CI watch or interrupted-run recovery; these are explicitly documented adapter limitations.

## Checklist

- [x] `task lint`, `task tests`, and `task build` pass locally
- [x] Tests added/updated for the change
- [x] Docs updated if behavior or configuration changed
- [x] The change is focused — no unrelated churn
- [x] Conventional feature commit: `feat(lo): add bot adapter with optional streaming progress`


## Latest review fixes

Commit 24822df handles temporary polling conflicts with a bounded retry, lets allowed reserved group commands bypass mention gating, introduces a dedicated LO Dockerfile/executable, restores the Telegram Dockerfile, and adds the memory limit. The stale-batch test now synchronizes on the second request before observing backoff.

`task default` and `task security-scan` passed locally. All five CI jobs passed on this head, including both architecture builds for LO/Telegram/VK.


## Conflict retry window (2026-09-10)

Commit f4bcf81 addresses the remaining review findings: HTTP 409 retries now wait ten seconds each, yielding a 40-second budget before the fifth consecutive conflict fails, covering the 30-second long poll. Cancellation still interrupts the wait. README and compatibility audit agree on the window and on implemented, opt-in command registration.

Validation: `task default` passed (formatting, lint, all race tests, both builds); `task security-scan` found no vulnerabilities. Regressions cover the elapsed conflict window, wrapped API errors, recovery and cancellation. Remote CI and fresh review for this commit are pending.


## Follow-up review fixes (2026-09-10)

Commit 5f3b1d6 addresses all three findings from the latest review. Private provider commands such as `/deploy@staging` are forwarded unchanged; commands addressed to other bots remain ignored in groups. Replies to this bot pass the group mention gate using the bot ID returned by getMe, while the allow-list remains enforced.

Conflict retry timing is injectable for tests, retaining the ten-second production default and the pure long-poll-window assertion. Polling tests use short retry intervals rather than spending forty seconds waiting.

Validation: `task default` passed (formatting, lint, all race tests, both builds); LO tests completed in 1.197 seconds. `task security-scan` found no vulnerabilities. Remote CI and renewed review for this commit are pending.



Review follow-up (db1c8fc): updated against main; LO quotes identify this bot as the assistant and retain empty-reply context; receiver conflict timing has one implementation and regression coverage for its configured/default delay. Root documentation now states LO entry-point limits and the environment example documents BOT_MEM_LIMIT.

Validation: task default passed (format, lint, race tests and all adapter builds); task security-scan reported no vulnerabilities. Real LO delivery, draft rendering and restart acceptance remain unverified and are not represented by these local checks.
