### PR TITLE
ci(lo): publish adapter image for Roost deployments

### DIFF
--- a/.github/workflows/publish-lo.yml
+++ b/.github/workflows/publish-lo.yml
@@ -1,0 +1,73 @@
+name: Publish lo image
+
+# Builds the self-contained LO bot image and pushes it to GitHub Container
+# Registry (ghcr.io/duckbugio/flock-lo) so adopters can just `docker compose up`.
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+    # Only rebuild when something that actually lands in the image changes: the Go
+    # sources (cmd/, internal/, core/, go.mod/go.sum) or the adapter build
+    # (Dockerfile/.dockerignore). Docs and the Ansible deploy dir don't affect the
+    # image, so they don't trigger a build.
+    paths:
+      - 'cmd/**'
+      - 'internal/**'
+      - 'core/**'
+      - 'go.mod'
+      - 'go.sum'
+      - 'adapters/lo/**'
+      - '!adapters/lo/deploy/**'
+      - '.dockerignore'
+      - '.github/workflows/publish-lo.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Image metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/duckbugio/flock-lo
+          # Tags produced per build:
+          #   :latest              — rolling, default branch only (what deploys track)
+          #   :0.1.<run_number>    — ordered, human-readable auto-version for every main
+          #                          build (no manual step); the number increments per
+          #                          publish run so images sort and read sanely
+          #   :vX.Y.Z              — milestone release: push a git tag vX.Y.Z and it lands
+          #   :sha-<commit>        — exact, immutable pin for traceability/rollback
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=0.1.${{ github.run_number }},enable={{is_default_branch}}
+            type=ref,event=tag
+            type=sha,format=short
+
+      - name: Build & push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./adapters/lo/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/publish-lo.yml
+++ b/.github/workflows/publish-lo.yml
@@ -14,6 +14,7 @@ on:
       - 'cmd/**'
       - 'internal/**'
       - 'core/**'
+      - 'tools/shotter/**'
       - 'go.mod'
       - 'go.sum'
       - 'adapters/lo/**'
@@ -69,5 +70,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=lo
+          cache-to: type=gha,mode=max,scope=lo

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The platform-agnostic dev-team brain lives in [`core/`](core/); each platform is
 |---|---|---|
 | Telegram | [`adapters/telegram/`](adapters/telegram/) | `ghcr.io/duckbugio/flock-telegram` |
 | VK | [`adapters/vk/`](adapters/vk/) | `ghcr.io/duckbugio/flock-vk` |
+| LO | [`adapters/lo/`](adapters/lo/) | `ghcr.io/duckbugio/flock-lo` |
 
 Future platforms reuse the same core — see [`docs/multi-transport-plan.md`](docs/multi-transport-plan.md).
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Everything else in [`.env.example`](adapters/telegram/.env.example) has sensible
 | `VK_GROUP_ID` | your community's numeric id (long-poll server + mention parse) |
 | `VK_ALLOWED_USERS` | comma-separated VK user IDs allowed to use the bot |
 
-**LO** has a text-first adapter with its own allow-list and workspace namespace. LO images are not published; build locally using [`adapters/lo/`](adapters/lo/README.md). The LO entry point does not wire PR-comment polling, CI watch or interrupted-run recovery. See the [LO / Telegram compatibility audit](docs/lo-telegram-compatibility.md) for supported commands, optional streaming, and platform gaps.
+**LO** has a text-first adapter with its own allow-list and workspace namespace. Its image is published as `ghcr.io/duckbugio/flock-lo`; start it using [`adapters/lo/`](adapters/lo/README.md). The LO entry point does not wire PR-comment polling, CI watch or interrupted-run recovery. See the [LO / Telegram compatibility audit](docs/lo-telegram-compatibility.md) for supported commands, optional streaming, and platform gaps.
 
 ## Highlights
 

--- a/adapters/lo/README.md
+++ b/adapters/lo/README.md
@@ -5,6 +5,15 @@ LO's Telegram-shaped **supported subset**, not the Telegram adapter with a new
 base URL. Telegram and VK behavior remain unchanged unless their transports
 explicitly opt into the new draft capability.
 
+## First publication (maintainers)
+
+Before announcing the image or enabling Roost deployments, wait for the first
+successful Publish LO workflow on main. In the organization package settings,
+link `flock-lo` to `duckbugio/flock` and set its visibility to Public. New GHCR
+packages are private by default; a successful workflow alone does not establish
+anonymous access. Verify `docker pull ghcr.io/duckbugio/flock-lo:latest` from an
+environment without registry credentials before marking publication complete.
+
 ## Start
 
 ```sh

--- a/adapters/lo/README.md
+++ b/adapters/lo/README.md
@@ -11,13 +11,15 @@ explicitly opt into the new draft capability.
 cd adapters/lo
 cp .env.example .env
 # Set LO_API_URL, LO_BOT_TOKEN, LO_ALLOWED_USERS and AI provider authentication.
-docker compose up --build -d
+docker compose pull
+docker compose up -d
 ```
 
 `LO_API_URL` is the deployed Bot API base, for example an operator-supplied HTTPS
 origin with an optional gateway path. Requests are posted to
 `<base>/bot<LO_BOT_TOKEN>/<method>`. Do not use the Mini App Connect endpoint.
-There is deliberately no guessed production URL or published LO image. The dedicated
+The production API URL must be supplied by the operator. Compose uses the published
+`ghcr.io/duckbugio/flock-lo:latest` image. The dedicated
 `adapters/lo/Dockerfile` builds and runs `/usr/local/bin/flock-lo`, with the same
 AI tooling as the other adapters. Compose caps memory with `BOT_MEM_LIMIT` (3g by default).
 

--- a/adapters/lo/docker-compose.yml
+++ b/adapters/lo/docker-compose.yml
@@ -1,10 +1,7 @@
-# Use the published image, or build locally with docker compose build.
+# Run the published LO image.
 services:
   bot:
     image: ghcr.io/duckbugio/flock-lo:latest
-    build:
-      context: ../..
-      dockerfile: adapters/lo/Dockerfile
     restart: unless-stopped
     env_file: .env
     # Default drain 45s, capped at 60s, plus 10s post-cancel delivery: at most 70s < 75s.

--- a/adapters/lo/docker-compose.yml
+++ b/adapters/lo/docker-compose.yml
@@ -1,7 +1,7 @@
-# Build locally: no prebuilt flock-lo image is assumed or published by this change.
+# Use the published image, or build locally with docker compose build.
 services:
   bot:
-    image: flock-lo:local
+    image: ghcr.io/duckbugio/flock-lo:latest
     build:
       context: ../..
       dockerfile: adapters/lo/Dockerfile


### PR DESCRIPTION
Publish the LO adapter to `ghcr.io/duckbugio/flock-lo` for Roost-managed VPS deployments. The workflow follows the existing Telegram/VK publishers, builds amd64 and arm64, and exposes latest, release and commit tags. Compose can use the published image or build locally.

Validation: workflow YAML parsed; Docker Compose configuration validated; independent contract review completed. Adapter code is unchanged. First publication requires merging this PR; no live LO acceptance is claimed, and draft/command-registration defaults remain disabled.
