### PR TITLE
feat(lo): read inbound documents and deliver the agent's files

### DIFF
--- a/adapters/lo/.env.example
+++ b/adapters/lo/.env.example
@@ -20,6 +20,11 @@ LO_REGISTER_COMMANDS=false
 # them. Turn it on only where LO's sendDocument is implemented: an older deployment answers
 # 501, and every file the agent produces then fails to deliver.
 LO_ENABLE_DOCUMENTS=false
+# The sweep the flag above turns on is bounded by these two, and this is the only place a LO
+# operator sees them named: without them the first surprise is a warning log saying the
+# file-count cap was reached.
+MAX_OUTBOX_BYTES=20971520
+MAX_OUTBOX_FILES=10
 REQUIRE_GROUP_MENTION=true
 
 # The LO binary adds /lo automatically to isolate chat IDs from other adapters.

--- a/adapters/lo/.env.example
+++ b/adapters/lo/.env.example
@@ -15,6 +15,11 @@ CLAUDE_CODE_OAUTH_TOKEN=
 # Enable only after the corresponding server AND client changes are released.
 LO_ENABLE_DRAFTS=false
 LO_REGISTER_COMMANDS=false
+# Outbound files. With this off the agent is told in its instructions that this chat cannot
+# deliver attachments, so it keeps artifacts in the workspace instead of promising to send
+# them. Turn it on only where LO's sendDocument is implemented: an older deployment answers
+# 501, and every file the agent produces then fails to deliver.
+LO_ENABLE_DOCUMENTS=false
 REQUIRE_GROUP_MENTION=true
 
 # The LO binary adds /lo automatically to isolate chat IDs from other adapters.

--- a/adapters/lo/README.md
+++ b/adapters/lo/README.md
@@ -136,9 +136,11 @@ this adapter does not promise exactly-once agent execution or automatic resume.
   are uploaded with their base name only; a full path would describe the host's filesystem to
   everyone in the chat. Turn it on after upgrading the platform, not before: a probe at
   startup cannot tell "not implemented" from a transient failure.
-- `sendPhoto`'s upload branch answered `500` on the deployments exercised so far, so outbound
-  IMAGES are still unavailable. Native callback buttons, rich messages and the interactive
-  star nudge are unavailable too.
+- `sendPhoto`'s upload branch answered `500` on the deployments exercised so far, so an image
+  is never sent AS A PHOTO. It still reaches the chat when documents are on: the outbox sweep
+  posts every regular file through `sendDocument`, a screenshot included, which is what the
+  workspace's screenshot convention already promises the agent. Native callback buttons, rich
+  messages and the interactive star nudge are unavailable.
 - The LO command does not yet wire Telegram's interrupted-run recovery, CI watch
   or PR-comment polling. These are **Flock adapter gaps**, not missing LO API
   methods. The scheduler and goal evaluator are supported.

--- a/adapters/lo/README.md
+++ b/adapters/lo/README.md
@@ -113,13 +113,16 @@ this adapter does not promise exactly-once agent execution or automatic resume.
   the cap also holds on the stream, because LO omits `file_size` for files it has not
   measured. Client-supplied names are sanitised; a saved file cannot leave the uploads
   directory.
-- **Inbound documents are downloaded the same way**, keeping the name the user gave them, so
-  the agent opens `spec.pdf` rather than an opaque id. A LO that predates document downloads
-  answers the reference WITHOUT a `file_path`; that is reported as "this LO does not hand bots
-  the bytes" rather than as a failed download, because the two need different actions. LO fills
+- **Inbound documents are downloaded the same way**, keeping the name the user gave them: the
+  saved path ENDS IN that name behind a collision-safe prefix, so the agent sees
+  `…-spec.pdf` rather than an opaque id (the prefix is `fsutil`'s, and it is what lets two
+  people send `report.pdf` into one chat). A LO that predates document downloads answers the
+  reference WITHOUT a `file_path`; that is reported as "this LO does not hand bots the bytes"
+  rather than as a failed download, because the two need different actions. LO fills
   `file_name` only usually, and a document that arrives without one is named from its declared
-  MIME type (`document_<id>.pdf`, and `.bin` for anything outside that table) — an extensionless path is
-  the same opaque id this whole paragraph exists to avoid.
+  MIME type (`document_<id>.pdf`, and `.bin` for anything outside the short table of types a
+  chat carries — `documentExtensions` in `media.go`) — an extensionless path is the same opaque
+  id this whole paragraph exists to avoid.
 - **Every other attachment gets its own sentence and stops the run.** Answering the caption
   without the file it refers to produces a confident answer about nothing, so the adapter
   refuses instead. The sentences differ by what is actually known. Audio and video answer

--- a/adapters/lo/README.md
+++ b/adapters/lo/README.md
@@ -113,21 +113,29 @@ this adapter does not promise exactly-once agent execution or automatic resume.
   the cap also holds on the stream, because LO omits `file_size` for files it has not
   measured. Client-supplied names are sanitised; a saved file cannot leave the uploads
   directory.
+- **Inbound documents are downloaded the same way**, keeping the name the user gave them, so
+  the agent opens `spec.pdf` rather than an opaque id. A LO that predates document downloads
+  answers the reference WITHOUT a `file_path`; that is reported as "this LO does not hand bots
+  the bytes" rather than as a failed download, because the two need different actions.
 - **Every other attachment gets its own sentence and stops the run.** Answering the caption
   without the file it refers to produces a confident answer about nothing, so the adapter
   refuses instead. The sentences differ by what is actually known. Audio and video answer
   `getFile` WITHOUT a `file_path` by design — an LO audio is a catalogue track, so no address
-  for the bytes exists — and can only be echoed by reference. Voice, video notes, animations
-  and documents say only that this adapter does not read them yet, and for the same reason in
-  every case: the `501` on the platform is about SENDING them, which is the OUTGOING direction,
-  and whether `getFile` serves their bytes is a separate question this change does not answer.
-  Stickers get their own sentence too, and a different one — the bytes exist, but a sticker
-  carries nothing an agent can act on, so the answer asks for the request as text.
-- **Outbound files stay disabled.** `sendDocument` is a platform stub, and `sendPhoto`'s
-  upload branch answers `500` on the deployments exercised so far, so the outbox is off and
-  agent-created files remain in the workspace/repository. LO workspace instructions
-  explicitly disable automatic file-delivery promises. Native callback buttons, rich
-  messages and the interactive star nudge are unavailable.
+  for the bytes exists — and can only be echoed by reference. Voice, video notes and animations
+  say only that this adapter does not read them yet: the `501` on the platform is about SENDING
+  them, which is the OUTGOING direction, and whether `getFile` serves their bytes is a separate
+  question this change does not answer. Stickers get their own sentence and a different one —
+  the bytes exist, but a sticker carries nothing an agent can act on, so the answer asks for
+  the request as text.
+- **Outbound files are opt-in via `LO_ENABLE_DOCUMENTS`.** With it off (the default) the
+  outbox sweep stays disabled and agent-created files remain in the workspace — the honest
+  behaviour on a LO that predates `sendDocument`, which answers `501`. With it on, artifacts
+  are uploaded with their base name only; a full path would describe the host's filesystem to
+  everyone in the chat. Turn it on after upgrading the platform, not before: a probe at
+  startup cannot tell "not implemented" from a transient failure.
+- `sendPhoto`'s upload branch answered `500` on the deployments exercised so far, so outbound
+  IMAGES are still unavailable. Native callback buttons, rich messages and the interactive
+  star nudge are unavailable too.
 - The LO command does not yet wire Telegram's interrupted-run recovery, CI watch
   or PR-comment polling. These are **Flock adapter gaps**, not missing LO API
   methods. The scheduler and goal evaluator are supported.

--- a/adapters/lo/README.md
+++ b/adapters/lo/README.md
@@ -116,7 +116,10 @@ this adapter does not promise exactly-once agent execution or automatic resume.
 - **Inbound documents are downloaded the same way**, keeping the name the user gave them, so
   the agent opens `spec.pdf` rather than an opaque id. A LO that predates document downloads
   answers the reference WITHOUT a `file_path`; that is reported as "this LO does not hand bots
-  the bytes" rather than as a failed download, because the two need different actions.
+  the bytes" rather than as a failed download, because the two need different actions. LO fills
+  `file_name` only usually, and a document that arrives without one is named from its declared
+  MIME type (`document_<id>.pdf`, `.bin` when the type is unknown) — an extensionless path is
+  the same opaque id this whole paragraph exists to avoid.
 - **Every other attachment gets its own sentence and stops the run.** Answering the caption
   without the file it refers to produces a confident answer about nothing, so the adapter
   refuses instead. The sentences differ by what is actually known. Audio and video answer

--- a/adapters/lo/README.md
+++ b/adapters/lo/README.md
@@ -118,7 +118,7 @@ this adapter does not promise exactly-once agent execution or automatic resume.
   answers the reference WITHOUT a `file_path`; that is reported as "this LO does not hand bots
   the bytes" rather than as a failed download, because the two need different actions. LO fills
   `file_name` only usually, and a document that arrives without one is named from its declared
-  MIME type (`document_<id>.pdf`, `.bin` when the type is unknown) — an extensionless path is
+  MIME type (`document_<id>.pdf`, and `.bin` for anything outside that table) — an extensionless path is
   the same opaque id this whole paragraph exists to avoid.
 - **Every other attachment gets its own sentence and stops the run.** Answering the caption
   without the file it refers to produces a confident answer about nothing, so the adapter

--- a/adapters/lo/bot.go
+++ b/adapters/lo/bot.go
@@ -27,15 +27,32 @@ const (
 type Transport struct {
 	api    *Client
 	drafts bool
+	// documents is the operator's answer to "can this LO deliver files". See WithDocuments.
+	documents bool
 }
 
 // NewTransport enables drafts only when the deployment explicitly advertises them.
 func NewTransport(api *Client, drafts bool) *Transport { return &Transport{api: api, drafts: drafts} }
 
-// Capabilities deliberately disables file outbox and rich messages. A half-size
-// rune budget guarantees the 4096 UTF-16 unit limit even for all-emoji answers.
+// WithDocuments turns on file delivery. It is OPT-IN rather than probed at startup because
+// the answer differs per deployment: sendDocument is implemented on the platform, and a LO
+// that predates it answers 501 for every artifact the agent produces. A flag the operator
+// sets after upgrading is one decision in one place; a probe would make every run's delivery
+// depend on a method call whose failure is indistinguishable from a transient one.
+func (t *Transport) WithDocuments(enabled bool) *Transport {
+	t.documents = enabled
+	return t
+}
+
+// Capabilities reports what this deployment can actually do. CanSendDocument gates the core's
+// outbox sweep: with it false the agent's files stay in the workspace and are never promised
+// to the user, which is the honest behaviour on a platform that cannot deliver them.
 func (t *Transport) Capabilities() chat.Capabilities {
-	return chat.Capabilities{MaxMessageRunes: maxTextUnits / maxUnitsPerRune, CanSendDraft: t.drafts}
+	return chat.Capabilities{
+		MaxMessageRunes: maxTextUnits / maxUnitsPerRune,
+		CanSendDraft:    t.drafts,
+		CanSendDocument: t.documents,
+	}
 }
 
 func numericID(value string) (int64, error) {
@@ -131,9 +148,20 @@ func (t *Transport) Delete(ctx context.Context, chatID, messageID string) error 
 	return nil
 }
 
-// SendDocument is unavailable; Capabilities prevents the core outbox from invoking it.
-func (*Transport) SendDocument(context.Context, chat.ChatID, string, io.Reader) error {
-	return ErrUnsupported
+// SendDocument uploads one of the agent's files to the chat.
+//
+// It refuses when documents are off rather than trying anyway: Capabilities already told the
+// core not to sweep the outbox, and a send that reached a 501 here would turn a configuration
+// choice into a per-file error the user cannot act on.
+func (t *Transport) SendDocument(ctx context.Context, chatID chat.ChatID, name string, data io.Reader) error {
+	if !t.documents {
+		return ErrUnsupported
+	}
+	id, err := numericID(chatID)
+	if err != nil {
+		return errors.New("invalid LO chat ID")
+	}
+	return t.api.UploadDocument(ctx, id, name, "", data)
 }
 
 // SendStarNudge is unavailable because its confirmation callback is not implemented in LO.

--- a/adapters/lo/bot.go
+++ b/adapters/lo/bot.go
@@ -161,7 +161,7 @@ func (t *Transport) SendDocument(ctx context.Context, chatID chat.ChatID, name s
 	if err != nil {
 		return errors.New("invalid LO chat ID")
 	}
-	return t.api.UploadDocument(ctx, id, name, "", data)
+	return t.api.UploadDocument(ctx, id, name, data)
 }
 
 // SendStarNudge is unavailable because its confirmation callback is not implemented in LO.

--- a/adapters/lo/client.go
+++ b/adapters/lo/client.go
@@ -467,9 +467,10 @@ func (c *Client) Download(ctx context.Context, filePath string) (io.ReadCloser, 
 // already gone out as the text answer. One is added when a caller has something to put in it,
 // not before — an unreachable branch cannot be tested and has to be explained forever.
 //
-// A deployment that has not implemented the method answers 501, which the caller reports as
-// "this platform cannot deliver files" rather than as a failed send: the difference decides
-// whether a user should retry.
+// A deployment that has not implemented the method answers 501, and that status reaches the
+// operator inside the outbox sweep's "send outbox document" log line, beside every other send
+// failure. There is no branch that turns it into a distinct diagnosis — the flag is what keeps
+// a deployment without the method from trying in the first place.
 func (c *Client) UploadDocument(ctx context.Context, chatID int64, filename string, data io.Reader) error {
 	// The file is STREAMED, never buffered. Only the multipart frame around it is built in
 	// memory: a copy of the file here would put a peak of twice its size on the host for every

--- a/adapters/lo/client.go
+++ b/adapters/lo/client.go
@@ -139,8 +139,9 @@ func (c *Client) call(ctx context.Context, method string, body, out any) error {
 // that needs one. Every request path goes through it — a JSON call and a multipart upload
 // alike — because the two must agree on three things a second copy always gets wrong: the
 // response size limit, the fact that an `error_code` of zero means "read the HTTP status",
-// and retry_after. That last one is not cosmetic: an APIError built without a Delay makes
-// RetryAfter fall back to one second, so a 429 that asked for a minute is retried in a second.
+// and retry_after. The last one carries no consequence TODAY — nothing re-sends a document by
+// Delay; the outbox sweep logs a failure and leaves the file for the next run — so the field is
+// filled for the same reason the other two are: one parse for every method, or two that drift.
 func (c *Client) envelope(resp *http.Response) (json.RawMessage, error) {
 	data, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes+1))
 	if err != nil {

--- a/adapters/lo/client.go
+++ b/adapters/lo/client.go
@@ -22,10 +22,11 @@ import (
 
 const (
 	requestTimeout = 65 * time.Second
-	// fileTimeout covers a whole download, body included, and is deliberately not
-	// requestTimeout. That one is sized for a 30-second long poll; reusing it here caps an
-	// upload-sized file at what fits in 65 seconds — 20 MiB needs a sustained 320 KB/s — and
-	// the user is then told to "try sending it again", which on that link never works. The
+	// fileTimeout covers a whole file transfer, body included, in either direction, and is
+	// deliberately not requestTimeout. That one is sized for a 30-second long poll; reusing it
+	// caps a file at what fits in 65 seconds — 20 MiB needs a sustained 320 KB/s. Inbound, the
+	// user is then told to "try sending it again", which on that link never works; outbound,
+	// the sweep leaves the file in outbox/ and re-uploads it from zero on every later run. The
 	// Telegram and VK adapters carry the same separate client for the same reason.
 	fileTimeout        = 120 * time.Second
 	maxResponseBytes   = 2 << 20
@@ -38,8 +39,9 @@ const (
 type Client struct {
 	base, token string
 	http        *http.Client
-	// fileHTTP reads file BYTES. A second client rather than a second timeout, because
-	// http.Client.Timeout is per-client and covers reading the body — see fileTimeout.
+	// fileHTTP carries file BYTES in BOTH directions — a download's response body and an
+	// upload's request body. A second client rather than a second timeout, because
+	// http.Client.Timeout is per-client and covers the body either way — see fileTimeout.
 	fileHTTP *http.Client
 }
 
@@ -506,7 +508,11 @@ func (c *Client) UploadDocument(ctx context.Context, chatID int64, filename stri
 	}
 	req.Header.Set("Content-Type", form.FormDataContentType())
 
-	resp, err := c.http.Do(req)
+	// fileHTTP, not http: Timeout covers writing the request BODY as well, so an upload on the
+	// short client dies at the same 65 seconds a download did. Worse here than there, because a
+	// failed delivery leaves the file in outbox/ and the next run uploads it again from zero —
+	// a loop that never converges and burns the link on every run, silently.
+	resp, err := c.fileHTTP.Do(req)
 	if err != nil {
 		if ctx.Err() != nil {
 			return ctx.Err()

--- a/adapters/lo/client.go
+++ b/adapters/lo/client.go
@@ -9,8 +9,10 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"mime/multipart"
 	"net/http"
 	"net/url"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -436,4 +438,79 @@ func (c *Client) Download(ctx context.Context, filePath string) (io.ReadCloser, 
 		return nil, &APIError{Code: resp.StatusCode, Description: "file download refused"}
 	}
 	return resp.Body, nil
+}
+
+// UploadDocument posts a local file to the chat as a document.
+//
+// Multipart, not JSON: LO's sendDocument takes either a reference this platform minted or an
+// uploaded part, and an agent's artifact has no reference — it was produced here, not shown to
+// the bot. The caption travels with it because Telegram's shape puts a document's words there.
+//
+// A deployment that has not implemented the method answers 501, which the caller reports as
+// "this platform cannot deliver files" rather than as a failed send: the difference decides
+// whether a user should retry.
+func (c *Client) UploadDocument(ctx context.Context, chatID int64, filename, caption string, data io.Reader) error {
+	body := &bytes.Buffer{}
+	form := multipart.NewWriter(body)
+	if err := form.WriteField("chat_id", strconv.FormatInt(chatID, 10)); err != nil {
+		return fmt.Errorf("encode LO upload: %w", err)
+	}
+	if caption != "" {
+		if err := form.WriteField("caption", caption); err != nil {
+			return fmt.Errorf("encode LO upload: %w", err)
+		}
+	}
+	// The name is what the user sees in the chat. Only its base travels: a path here would
+	// describe this machine's filesystem to everyone in the conversation.
+	part, err := form.CreateFormFile("document", filepath.Base(filename))
+	if err != nil {
+		return fmt.Errorf("encode LO upload: %w", err)
+	}
+	if _, err := io.Copy(part, data); err != nil {
+		return fmt.Errorf("read outbound document: %w", err)
+	}
+	if err := form.Close(); err != nil {
+		return fmt.Errorf("encode LO upload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		c.base+"/bot"+c.token+"/sendDocument", bytes.NewReader(body.Bytes()))
+	if err != nil {
+		return errors.New("cannot construct LO upload request")
+	}
+	req.Header.Set("Content-Type", form.FormDataContentType())
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		var urlErr *url.Error
+		if errors.As(err, &urlErr) {
+			err = urlErr.Err // The outer URL carries the bot credential.
+		}
+		return fmt.Errorf("LO upload failed: %s", strings.ReplaceAll(err.Error(), c.token, "[REDACTED]"))
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes+1))
+	if err != nil {
+		return errors.New("cannot read LO upload response")
+	}
+	var envelope struct {
+		OK          bool   `json:"ok"`
+		Code        int    `json:"error_code"` //nolint:tagliatelle // Bot API wire spelling.
+		Description string `json:"description"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return &APIError{Code: resp.StatusCode, Description: "non-JSON upload response"}
+	}
+	if !envelope.OK || resp.StatusCode != http.StatusOK {
+		code := envelope.Code
+		if code == 0 {
+			code = resp.StatusCode
+		}
+		return &APIError{Code: code, Description: strings.ReplaceAll(envelope.Description, c.token, "[redacted]")}
+	}
+	return nil
 }

--- a/adapters/lo/client.go
+++ b/adapters/lo/client.go
@@ -12,6 +12,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -119,12 +120,32 @@ func (c *Client) call(ctx context.Context, method string, body, out any) error {
 		return fmt.Errorf("LO request failed before receiving a response: %s", reason)
 	}
 	defer func() { _ = resp.Body.Close() }()
+	result, err := c.envelope(resp)
+	if err != nil {
+		return err
+	}
+	if len(result) == 0 || string(result) == "null" {
+		return errors.New("LO response contains no result")
+	}
+	if err := json.Unmarshal(result, out); err != nil {
+		return errors.New("LO response contains an invalid result")
+	}
+	return nil
+}
+
+// envelope reads and classifies a Bot API response, returning the raw `result` for a caller
+// that needs one. Every request path goes through it — a JSON call and a multipart upload
+// alike — because the two must agree on three things a second copy always gets wrong: the
+// response size limit, the fact that an `error_code` of zero means "read the HTTP status",
+// and retry_after. That last one is not cosmetic: an APIError built without a Delay makes
+// RetryAfter fall back to one second, so a 429 that asked for a minute is retried in a second.
+func (c *Client) envelope(resp *http.Response) (json.RawMessage, error) {
 	data, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes+1))
 	if err != nil {
-		return errors.New("cannot read LO response")
+		return nil, errors.New("cannot read LO response")
 	}
 	if len(data) > maxResponseBytes {
-		return errors.New("LO response exceeds size limit")
+		return nil, errors.New("LO response exceeds size limit")
 	}
 	var envelope struct {
 		OK          bool            `json:"ok"`
@@ -137,9 +158,9 @@ func (c *Client) call(ctx context.Context, method string, body, out any) error {
 	}
 	if err := json.Unmarshal(data, &envelope); err != nil {
 		if resp.StatusCode >= http.StatusMultipleChoices {
-			return &APIError{Code: resp.StatusCode, Description: "non-JSON HTTP error response"}
+			return nil, &APIError{Code: resp.StatusCode, Description: "non-JSON HTTP error response"}
 		}
-		return fmt.Errorf("LO returned an invalid API envelope (HTTP %d)", resp.StatusCode)
+		return nil, fmt.Errorf("LO returned an invalid API envelope (HTTP %d)", resp.StatusCode)
 	}
 	if !envelope.OK || resp.StatusCode != http.StatusOK {
 		code := envelope.Code
@@ -155,18 +176,12 @@ func (c *Client) call(ctx context.Context, method string, body, out any) error {
 		if delay > maxBackoffSeconds {
 			delay = maxBackoffSeconds
 		}
-		return &APIError{
+		return nil, &APIError{
 			Code: code, Description: strings.ReplaceAll(envelope.Description, c.token, "[redacted]"),
 			Delay: time.Duration(max(delay, 0)) * time.Second,
 		}
 	}
-	if len(envelope.Result) == 0 || string(envelope.Result) == "null" {
-		return errors.New("LO response contains no result")
-	}
-	if err := json.Unmarshal(envelope.Result, out); err != nil {
-		return errors.New("LO response contains an invalid result")
-	}
-	return nil
+	return envelope.Result, nil
 }
 
 // User is the Bot API actor; LO and Telegram IDs are independent.
@@ -444,39 +459,50 @@ func (c *Client) Download(ctx context.Context, filePath string) (io.ReadCloser, 
 //
 // Multipart, not JSON: LO's sendDocument takes either a reference this platform minted or an
 // uploaded part, and an agent's artifact has no reference — it was produced here, not shown to
-// the bot. The caption travels with it because Telegram's shape puts a document's words there.
+// the bot.
+//
+// No caption parameter: the outbox delivers files on their own, the agent's words having
+// already gone out as the text answer. One is added when a caller has something to put in it,
+// not before — an unreachable branch cannot be tested and has to be explained forever.
 //
 // A deployment that has not implemented the method answers 501, which the caller reports as
 // "this platform cannot deliver files" rather than as a failed send: the difference decides
 // whether a user should retry.
-func (c *Client) UploadDocument(ctx context.Context, chatID int64, filename, caption string, data io.Reader) error {
-	body := &bytes.Buffer{}
-	form := multipart.NewWriter(body)
+func (c *Client) UploadDocument(ctx context.Context, chatID int64, filename string, data io.Reader) error {
+	// The file is STREAMED, never buffered. Only the multipart frame around it is built in
+	// memory: a copy of the file here would put a peak of twice its size on the host for every
+	// concurrent delivery, and the size is an operator's setting (MAX_OUTBOX_BYTES), so the
+	// worst case is whatever number they picked — on the VPS these bots run on, that matters.
+	var frame bytes.Buffer
+	form := multipart.NewWriter(&frame)
 	if err := form.WriteField("chat_id", strconv.FormatInt(chatID, 10)); err != nil {
 		return fmt.Errorf("encode LO upload: %w", err)
 	}
-	if caption != "" {
-		if err := form.WriteField("caption", caption); err != nil {
-			return fmt.Errorf("encode LO upload: %w", err)
-		}
-	}
 	// The name is what the user sees in the chat. Only its base travels: a path here would
 	// describe this machine's filesystem to everyone in the conversation.
-	part, err := form.CreateFormFile("document", filepath.Base(filename))
-	if err != nil {
+	if _, err := form.CreateFormFile("document", filepath.Base(filename)); err != nil {
 		return fmt.Errorf("encode LO upload: %w", err)
 	}
-	if _, err := io.Copy(part, data); err != nil {
-		return fmt.Errorf("read outbound document: %w", err)
-	}
+	// Everything written so far precedes the file bytes; whatever Close appends follows them.
+	// Splitting the frame at this point is what lets the body be three readers in a row
+	// instead of one buffer holding the whole document.
+	prologue := bytes.Clone(frame.Bytes())
+	frame.Reset()
 	if err := form.Close(); err != nil {
 		return fmt.Errorf("encode LO upload: %w", err)
 	}
+	epilogue := frame.Bytes()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
-		c.base+"/bot"+c.token+"/sendDocument", bytes.NewReader(body.Bytes()))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.base+"/bot"+c.token+"/sendDocument",
+		io.MultiReader(bytes.NewReader(prologue), data, bytes.NewReader(epilogue)))
 	if err != nil {
 		return errors.New("cannot construct LO upload request")
+	}
+	// A known length keeps the request on identity transfer-encoding. Streaming a body of
+	// unknown size makes Go chunk it, and a chunked multipart upload is the kind of thing a
+	// proxy in front of the platform may refuse — not something to discover in production.
+	if size, ok := readerLength(data); ok {
+		req.ContentLength = int64(len(prologue)) + size + int64(len(epilogue))
 	}
 	req.Header.Set("Content-Type", form.FormDataContentType())
 
@@ -493,24 +519,34 @@ func (c *Client) UploadDocument(ctx context.Context, chatID int64, filename, cap
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	raw, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes+1))
-	if err != nil {
-		return errors.New("cannot read LO upload response")
-	}
-	var envelope struct {
-		OK          bool   `json:"ok"`
-		Code        int    `json:"error_code"` //nolint:tagliatelle // Bot API wire spelling.
-		Description string `json:"description"`
-	}
-	if err := json.Unmarshal(raw, &envelope); err != nil {
-		return &APIError{Code: resp.StatusCode, Description: "non-JSON upload response"}
-	}
-	if !envelope.OK || resp.StatusCode != http.StatusOK {
-		code := envelope.Code
-		if code == 0 {
-			code = resp.StatusCode
+	// The sent Message is discarded on purpose: the outbox has nothing to do with a delivered
+	// file beyond knowing it arrived, and an absent result is not a failure here.
+	_, err = c.envelope(resp)
+	return err
+}
+
+// readerLength reports how many bytes a reader still holds, for the readers that can say. An
+// outbox delivery is always an *os.File the sweeper has just stat-ed and opened; the rest are
+// here so a test exercises the same request shape production does.
+func readerLength(data io.Reader) (int64, bool) {
+	switch v := data.(type) {
+	case *os.File:
+		info, err := v.Stat()
+		if err != nil || !info.Mode().IsRegular() {
+			return 0, false
 		}
-		return &APIError{Code: code, Description: strings.ReplaceAll(envelope.Description, c.token, "[redacted]")}
+		// A file that has already been partly read has fewer bytes left than it has in total.
+		pos, err := v.Seek(0, io.SeekCurrent)
+		if err != nil || pos > info.Size() {
+			return 0, false
+		}
+		return info.Size() - pos, true
+	case *bytes.Reader:
+		return int64(v.Len()), true
+	case *bytes.Buffer:
+		return int64(v.Len()), true
+	case *strings.Reader:
+		return int64(v.Len()), true
 	}
-	return nil
+	return 0, false
 }

--- a/adapters/lo/client.go
+++ b/adapters/lo/client.go
@@ -139,9 +139,12 @@ func (c *Client) call(ctx context.Context, method string, body, out any) error {
 // that needs one. Every request path goes through it — a JSON call and a multipart upload
 // alike — because the two must agree on three things a second copy always gets wrong: the
 // response size limit, the fact that an `error_code` of zero means "read the HTTP status",
-// and retry_after. The last one carries no consequence TODAY — nothing re-sends a document by
-// Delay; the outbox sweep logs a failure and leaves the file for the next run — so the field is
-// filled for the same reason the other two are: one parse for every method, or two that drift.
+// and retry_after. That last one is not cosmetic where it is READ: RetryAfter feeds
+// deliverWithBackoff, which sleeps on APIError.Delay when a text send is rate-limited, so an
+// envelope that lost it would retry in a second a send the platform asked to hold for a minute.
+// On the UPLOAD path nothing reads it yet — the outbox sweep logs a failure and leaves the file
+// for the next run — and it is parsed there anyway for the reason the other two are: one parse
+// for every method, or two that drift.
 func (c *Client) envelope(resp *http.Response) (json.RawMessage, error) {
 	data, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes+1))
 	if err != nil {
@@ -576,10 +579,15 @@ func partName(filename string) string {
 			return -1
 		}
 		return r
-	}, filepath.Base(filename))
-	// The same character set the inbound path trims. filepath.Base("/") answers "/", which a
-	// trim of dots and spaces leaves intact — and a bare separator in the header is exactly the
-	// name this guard exists to keep out.
+	}, filepath.Base(strings.ReplaceAll(filename, `\`, "/")))
+	// Backslashes are folded to "/" FIRST, because filepath.Base only knows this OS's separator
+	// and `..\..\etc\passwd` is a legal file name on Linux — the agent writes these names, so
+	// the header would carry the whole path. fsutil does exactly this for the inbound
+	// direction, with the same one-line reason; the two must not drift.
+	//
+	// The trim set is the inbound path's too. filepath.Base("/") answers "/", which a trim of
+	// dots and spaces leaves intact — a bare separator in the header is the other name this
+	// guard exists to keep out.
 	if strings.Trim(name, `./\ `) == "" {
 		return "file"
 	}

--- a/adapters/lo/client.go
+++ b/adapters/lo/client.go
@@ -577,7 +577,10 @@ func partName(filename string) string {
 		}
 		return r
 	}, filepath.Base(filename))
-	if strings.Trim(name, ". ") == "" {
+	// The same character set the inbound path trims. filepath.Base("/") answers "/", which a
+	// trim of dots and spaces leaves intact — and a bare separator in the header is exactly the
+	// name this guard exists to keep out.
+	if strings.Trim(name, `./\ `) == "" {
 		return "file"
 	}
 	return name

--- a/adapters/lo/client.go
+++ b/adapters/lo/client.go
@@ -480,7 +480,7 @@ func (c *Client) UploadDocument(ctx context.Context, chatID int64, filename stri
 	}
 	// The name is what the user sees in the chat. Only its base travels: a path here would
 	// describe this machine's filesystem to everyone in the conversation.
-	if _, err := form.CreateFormFile("document", filepath.Base(filename)); err != nil {
+	if _, err := form.CreateFormFile("document", partName(filename)); err != nil {
 		return fmt.Errorf("encode LO upload: %w", err)
 	}
 	// Everything written so far precedes the file bytes; whatever Close appends follows them.
@@ -549,4 +549,28 @@ func readerLength(data io.Reader) (int64, bool) {
 		return int64(v.Len()), true
 	}
 	return 0, false
+}
+
+// partName reduces an outbound file name to something safe to put in a multipart header.
+//
+// filepath.Base strips the path and nothing else, and mime/multipart escapes only backslash and
+// quote — it does not check header values for CRLF. A name carrying "\r\n" would therefore
+// append a header of its own to the part, and "\r\n\r\n" would close the header block and
+// push the rest of the name into the file's bytes. Nobody can redirect the message that way
+// (the boundary is random and the chat_id is already written), but the request and the file
+// arrive corrupted, and these names come from an agent writing into the outbox directory,
+// where a newline is a legal character on Linux.
+//
+// The empty result also covers filepath.Base("") == ".", which names a directory.
+func partName(filename string) string {
+	name := strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return -1
+		}
+		return r
+	}, filepath.Base(filename))
+	if strings.Trim(name, ". ") == "" {
+		return "file"
+	}
+	return name
 }

--- a/adapters/lo/documents_test.go
+++ b/adapters/lo/documents_test.go
@@ -135,9 +135,10 @@ func TestSendDocumentErrorsCarryNoToken(t *testing.T) {
 }
 
 // The upload path shares the response envelope with every other method, so a 429 that names a
-// delay must survive it. Nothing re-sends a document by that delay yet — the outbox sweep just
-// leaves the file for the next run — so what this pins is the parsing: one envelope for every
-// method, rather than a second copy that answers a zero Delay where the first answers sixty.
+// delay must survive it. Nothing re-sends a DOCUMENT by that delay yet — the outbox sweep just
+// leaves the file for the next run — but the text path does (deliverWithBackoff sleeps on it),
+// and what this pins is that one envelope answers both rather than a second copy that reports
+// a zero Delay where the first reports sixty.
 func TestUploadRetryDelaySurvivesTheEnvelope(t *testing.T) {
 	t.Parallel()
 	api := client(t, func(w http.ResponseWriter, _ *http.Request) {
@@ -245,6 +246,9 @@ func TestUploadSanitisesTheNameItPutsInTheHeader(t *testing.T) {
 		"only dots":        {"..", "file"},
 		// filepath.Base("/") answers "/", which a trim of dots and spaces leaves whole.
 		"bare separator": {"/", "file"},
+		// Legal on Linux, and filepath.Base does not treat it as a separator — the names in
+		// outbox/ are the agent's, so the whole path would otherwise ride in the header.
+		"windows separators": {`..\..\etc\passwd`, "passwd"},
 	} {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/adapters/lo/documents_test.go
+++ b/adapters/lo/documents_test.go
@@ -1,0 +1,128 @@
+package lo_test
+
+import (
+	"errors"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/duckbugio/flock/adapters/lo"
+)
+
+// Off by default, and the refusal is explicit: a platform that predates sendDocument answers
+// 501 for every artifact, so the flag is the operator's one place to say "mine has it".
+func TestSendDocumentIsRefusedUntilEnabled(t *testing.T) {
+	t.Parallel()
+	var called bool
+	api := client(t, func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		reply(w, `{"ok":true,"result":{"message_id":1}}`)
+	})
+
+	err := lo.NewTransport(api, false).SendDocument(t.Context(), "77", "report.pdf", strings.NewReader("x"))
+	if !errors.Is(err, lo.ErrUnsupported) {
+		t.Fatalf("err=%v, want ErrUnsupported", err)
+	}
+	if called {
+		t.Fatal("a disabled document send still reached the platform")
+	}
+}
+
+// Capabilities is what the core's outbox sweep reads: with documents off the agent's files
+// must never be promised to the user.
+func TestCapabilitiesFollowTheDocumentFlag(t *testing.T) {
+	t.Parallel()
+	api := client(t, func(w http.ResponseWriter, _ *http.Request) { reply(w, `{"ok":true,"result":{}}`) })
+
+	if lo.NewTransport(api, false).Capabilities().CanSendDocument {
+		t.Error("documents are advertised while disabled")
+	}
+	if !lo.NewTransport(api, false).WithDocuments(true).Capabilities().CanSendDocument {
+		t.Error("documents are enabled but not advertised")
+	}
+}
+
+func TestSendDocumentUploadsTheFileWithItsBaseName(t *testing.T) {
+	t.Parallel()
+	var gotName, gotChat, gotBody string
+	api := client(t, func(w http.ResponseWriter, r *http.Request) {
+		mediaType, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+		if err != nil || !strings.HasPrefix(mediaType, "multipart/") {
+			t.Errorf("content type = %q, want multipart", r.Header.Get("Content-Type"))
+		}
+		reader := multipart.NewReader(r.Body, params["boundary"])
+		for {
+			part, err := reader.NextPart()
+			if err != nil {
+				break
+			}
+			data, _ := io.ReadAll(part)
+			switch part.FormName() {
+			case "chat_id":
+				gotChat = string(data)
+			case "document":
+				gotName, gotBody = part.FileName(), string(data)
+			}
+		}
+		reply(w, `{"ok":true,"result":{"message_id":5}}`)
+	})
+
+	transport := lo.NewTransport(api, false).WithDocuments(true)
+	// A path is deliberately passed: only its base may travel, because the full one describes
+	// this machine's filesystem to everyone in the conversation.
+	if err := transport.SendDocument(t.Context(), "77", "/workspace/repo/report.pdf",
+		strings.NewReader("%PDF-1.7")); err != nil {
+		t.Fatalf("SendDocument: %v", err)
+	}
+
+	if gotChat != "77" {
+		t.Errorf("chat_id = %q", gotChat)
+	}
+	if gotName != "report.pdf" {
+		t.Errorf("file name = %q, want only the base", gotName)
+	}
+	if gotBody != "%PDF-1.7" {
+		t.Errorf("body = %q", gotBody)
+	}
+}
+
+// A platform that has not implemented the method answers 501, and the error must carry that
+// so an operator reads "upgrade LO" rather than "the file failed to send".
+func TestSendDocumentSurfacesTheNotImplementedAnswer(t *testing.T) {
+	t.Parallel()
+	api := client(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotImplemented)
+		_, _ = w.Write([]byte(`{"ok":false,"error_code":501,"description":"Method not implemented: sendDocument"}`))
+	})
+
+	err := lo.NewTransport(api, false).WithDocuments(true).
+		SendDocument(t.Context(), "77", "report.pdf", strings.NewReader("x"))
+	if err == nil {
+		t.Fatal("a 501 was reported as a successful delivery")
+	}
+	var apiErr *lo.APIError
+	if !errors.As(err, &apiErr) || apiErr.Code != http.StatusNotImplemented {
+		t.Fatalf("err=%v, want a 501 APIError", err)
+	}
+}
+
+// The bot token is part of every upload URL. It must never reach an error a log will print.
+func TestSendDocumentErrorsCarryNoToken(t *testing.T) {
+	t.Parallel()
+	api, err := lo.NewClient("https://127.0.0.1:1", "secret-token-value", nil)
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+
+	sendErr := lo.NewTransport(api, false).WithDocuments(true).
+		SendDocument(t.Context(), "77", "a.bin", strings.NewReader("x"))
+	if sendErr == nil {
+		t.Fatal("a dead endpoint reported success")
+	}
+	if strings.Contains(sendErr.Error(), "secret-token-value") {
+		t.Fatalf("the token leaked into an error: %v", sendErr)
+	}
+}

--- a/adapters/lo/documents_test.go
+++ b/adapters/lo/documents_test.go
@@ -6,8 +6,10 @@ import (
 	"mime"
 	"mime/multipart"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/duckbugio/flock/adapters/lo"
 )
@@ -124,5 +126,99 @@ func TestSendDocumentErrorsCarryNoToken(t *testing.T) {
 	}
 	if strings.Contains(sendErr.Error(), "secret-token-value") {
 		t.Fatalf("the token leaked into an error: %v", sendErr)
+	}
+}
+
+// The upload path shares the response envelope with every other method, so a 429 that names a
+// delay must survive it. It did not before: the upload built its own APIError with a zero
+// Delay, and RetryAfter then told the delivery loop to retry in one second a send the platform
+// had asked it to hold for a minute.
+func TestUploadRetryDelaySurvivesTheEnvelope(t *testing.T) {
+	t.Parallel()
+	api := client(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"ok":false,"error_code":429,"description":"Too Many Requests","parameters":{"retry_after":60}}`))
+	})
+
+	err := lo.NewTransport(api, false).WithDocuments(true).
+		SendDocument(t.Context(), "77", "report.pdf", strings.NewReader("x"))
+	delay, ok := lo.RetryAfter(err)
+	if !ok {
+		t.Fatalf("err=%v, want a classified 429", err)
+	}
+	if delay != 60*time.Second {
+		t.Fatalf("delay=%v, want the 60s the platform asked for", delay)
+	}
+}
+
+// An oversize response is refused rather than truncated. A cut-off body parses as garbage and
+// used to surface as "non-JSON upload response" — a wrong diagnosis of a size problem.
+func TestUploadRefusesAnOversizeResponse(t *testing.T) {
+	t.Parallel()
+	api := client(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"ok":true,"padding":"` + strings.Repeat("x", 2<<20) + `"}`))
+	})
+
+	err := lo.NewTransport(api, false).WithDocuments(true).
+		SendDocument(t.Context(), "77", "report.pdf", strings.NewReader("x"))
+	if err == nil || !strings.Contains(err.Error(), "exceeds size limit") {
+		t.Fatalf("err=%v, want the size limit to be named", err)
+	}
+}
+
+// The document is streamed, not copied into memory first, and the request still declares its
+// length so the platform receives an ordinary identity-encoded upload rather than a chunked
+// one. Both halves are asserted here because either alone is the wrong trade: a buffered body
+// has a known length too, and a streamed body without a length changes the wire shape.
+func TestUploadStreamsTheFileWithAKnownLength(t *testing.T) {
+	t.Parallel()
+	var gotLength int64
+	var gotEncoding []string
+	var gotBody string
+	api := client(t, func(w http.ResponseWriter, r *http.Request) {
+		gotLength, gotEncoding = r.ContentLength, r.TransferEncoding
+		_, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+		if err != nil {
+			t.Errorf("content type: %v", err)
+		}
+		reader := multipart.NewReader(r.Body, params["boundary"])
+		for {
+			part, err := reader.NextPart()
+			if err != nil {
+				break
+			}
+			if part.FormName() == "document" {
+				data, _ := io.ReadAll(part)
+				gotBody = string(data)
+			}
+		}
+		reply(w, `{"ok":true,"result":{"message_id":1}}`)
+	})
+
+	file, err := os.CreateTemp(t.TempDir(), "artifact-*.txt")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	const content = "an artifact the agent produced"
+	if _, err := file.WriteString(content); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		t.Fatalf("seek: %v", err)
+	}
+	t.Cleanup(func() { _ = file.Close() })
+
+	if err := lo.NewTransport(api, false).WithDocuments(true).
+		SendDocument(t.Context(), "77", "artifact.txt", file); err != nil {
+		t.Fatalf("SendDocument: %v", err)
+	}
+	if gotBody != content {
+		t.Fatalf("body=%q, want the file's contents", gotBody)
+	}
+	if len(gotEncoding) != 0 {
+		t.Fatalf("transfer-encoding=%v, want an identity-encoded request", gotEncoding)
+	}
+	if gotLength <= int64(len(content)) {
+		t.Fatalf("content-length=%d, want the declared length of the whole multipart body", gotLength)
 	}
 }

--- a/adapters/lo/documents_test.go
+++ b/adapters/lo/documents_test.go
@@ -135,9 +135,9 @@ func TestSendDocumentErrorsCarryNoToken(t *testing.T) {
 }
 
 // The upload path shares the response envelope with every other method, so a 429 that names a
-// delay must survive it. It did not before: the upload built its own APIError with a zero
-// Delay, and RetryAfter then told the delivery loop to retry in one second a send the platform
-// had asked it to hold for a minute.
+// delay must survive it. Nothing re-sends a document by that delay yet — the outbox sweep just
+// leaves the file for the next run — so what this pins is the parsing: one envelope for every
+// method, rather than a second copy that answers a zero Delay where the first answers sixty.
 func TestUploadRetryDelaySurvivesTheEnvelope(t *testing.T) {
 	t.Parallel()
 	api := client(t, func(w http.ResponseWriter, _ *http.Request) {

--- a/adapters/lo/documents_test.go
+++ b/adapters/lo/documents_test.go
@@ -6,6 +6,7 @@ import (
 	"mime"
 	"mime/multipart"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
@@ -278,5 +279,37 @@ func TestUploadSanitisesTheNameItPutsInTheHeader(t *testing.T) {
 				t.Fatalf("the part carries %d headers, want the two multipart writes itself", headers)
 			}
 		})
+	}
+}
+
+// An outbound file rides the FILE client, not the polling one. http.Client.Timeout covers
+// writing the request BODY too, so a 20 MiB artifact on the short client dies mid-upload — and
+// the sweep then leaves it in outbox/ and uploads it again from zero on every later run,
+// forever, while the user sees only the agent's promise.
+//
+// The two clients are told apart by giving the caller's client a tiny timeout: NewClient keeps
+// it for the polling client and overrides it with the file budget for the other. A send that
+// outlives the tiny timeout therefore proves which one carried it.
+func TestUploadUsesTheFileClientNotThePollingOne(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(120 * time.Millisecond)
+		reply(w, `{"ok":true,"result":{"message_id":1}}`)
+	}))
+	t.Cleanup(server.Close)
+	impatient := server.Client()
+	impatient.Timeout = 40 * time.Millisecond
+	api, err := lo.NewClient(server.URL, testToken, impatient)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := lo.NewTransport(api, false).WithDocuments(true).
+		SendDocument(t.Context(), "77", "report.pdf", strings.NewReader("x")); err != nil {
+		t.Fatalf("the upload was cut by the polling client's timeout: %v", err)
+	}
+	// And the check has teeth: an ordinary message on the same client does time out.
+	if _, err := lo.NewTransport(api, false).Send(t.Context(), "77", "hi", "", false); err == nil {
+		t.Fatal("the impatient timeout applied to nothing; the test proves nothing")
 	}
 }

--- a/adapters/lo/documents_test.go
+++ b/adapters/lo/documents_test.go
@@ -14,6 +14,10 @@ import (
 	"github.com/duckbugio/flock/adapters/lo"
 )
 
+// documentPart is the multipart field name sendDocument writes the file under. A constant
+// because three tests read it back, and three literals drift.
+const documentPart = "document"
+
 // Off by default, and the refusal is explicit: a platform that predates sendDocument answers
 // 501 for every artifact, so the flag is the operator's one place to say "mine has it".
 func TestSendDocumentIsRefusedUntilEnabled(t *testing.T) {
@@ -65,7 +69,7 @@ func TestSendDocumentUploadsTheFileWithItsBaseName(t *testing.T) {
 			switch part.FormName() {
 			case "chat_id":
 				gotChat = string(data)
-			case "document":
+			case documentPart:
 				gotName, gotBody = part.FileName(), string(data)
 			}
 		}
@@ -187,7 +191,7 @@ func TestUploadStreamsTheFileWithAKnownLength(t *testing.T) {
 			if err != nil {
 				break
 			}
-			if part.FormName() == "document" {
+			if part.FormName() == documentPart {
 				data, _ := io.ReadAll(part)
 				gotBody = string(data)
 			}
@@ -220,5 +224,59 @@ func TestUploadStreamsTheFileWithAKnownLength(t *testing.T) {
 	}
 	if gotLength <= int64(len(content)) {
 		t.Fatalf("content-length=%d, want the declared length of the whole multipart body", gotLength)
+	}
+}
+
+// The file name comes from an agent writing into the outbox directory, and on Linux a newline
+// is legal in one. multipart escapes only backslash and quote, so a name carrying CRLF would
+// append a header of its own to the part — and a doubled one would close the header block and
+// push the rest of the name into the file's bytes.
+func TestUploadSanitisesTheNameItPutsInTheHeader(t *testing.T) {
+	t.Parallel()
+	for name, tc := range map[string]struct{ given, want string }{
+		// The injected text carries a slash, so the base-name rule cuts at it first and the
+		// control strip finishes the job. What matters is not which letters survive but that
+		// nothing reaches the header able to open a second one.
+		"header injection": {"a\r\nContent-Type: text/html\r\n\r\nb.txt", "htmlb.txt"},
+		"path stripped":    {"/workspace/repo/report.pdf", "report.pdf"},
+		"control chars":    {"re\x00port\x7f.pdf", "report.pdf"},
+		"empty":            {"", "file"},
+		"only dots":        {"..", "file"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			var headers int
+			var gotName string
+			api := client(t, func(w http.ResponseWriter, r *http.Request) {
+				_, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+				if err != nil {
+					t.Errorf("content type: %v", err)
+				}
+				reader := multipart.NewReader(r.Body, params["boundary"])
+				for {
+					part, perr := reader.NextPart()
+					if perr != nil {
+						break
+					}
+					if part.FormName() == documentPart {
+						gotName, headers = part.FileName(), len(part.Header)
+					}
+				}
+				reply(w, `{"ok":true,"result":{"message_id":1}}`)
+			})
+
+			if err := lo.NewTransport(api, false).WithDocuments(true).
+				SendDocument(t.Context(), "77", tc.given, strings.NewReader("x")); err != nil {
+				t.Fatalf("SendDocument: %v", err)
+			}
+			if gotName != tc.want {
+				t.Fatalf("name %q became %q, want %q", tc.given, gotName, tc.want)
+			}
+			// Two headers and no more: Content-Disposition and Content-Type. A third means
+			// the name opened one of its own.
+			if headers != 2 {
+				t.Fatalf("the part carries %d headers, want the two multipart writes itself", headers)
+			}
+		})
 	}
 }

--- a/adapters/lo/documents_test.go
+++ b/adapters/lo/documents_test.go
@@ -243,6 +243,8 @@ func TestUploadSanitisesTheNameItPutsInTheHeader(t *testing.T) {
 		"control chars":    {"re\x00port\x7f.pdf", "report.pdf"},
 		"empty":            {"", "file"},
 		"only dots":        {"..", "file"},
+		// filepath.Base("/") answers "/", which a trim of dots and spaces leaves whole.
+		"bare separator": {"/", "file"},
 	} {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/adapters/lo/media.go
+++ b/adapters/lo/media.go
@@ -170,15 +170,12 @@ func documentFileName(messageID int64, mimeType string) string {
 	return fmt.Sprintf("document_%d%s", messageID, ext)
 }
 
-// photoFileName names a saved photo. LO photos arrive without a file name, and the file path
-// is a reference rather than something with an extension, so the name is generated from the
-// message: predictable for the agent and unique per message.
-
 // photoFileName names a saved photo BEFORE its bytes have been seen. LO photos arrive without a
 // file name, and the file path is a reference rather than something with an extension, so the
-// name is generated from the message: predictable for the agent and unique per message.//
+// name is generated from the message: predictable for the agent and unique per message.
+//
 // The extension here is a guess. It is corrected the moment the bytes are on disk — see
-// photoExtension — because something DOES read a media type out of this name: core/chat derives
+// nameByContent — because something DOES read a media type out of this name: core/chat derives
 // the vision block's type from the saved path, so a PNG named .jpg reaches the model declared as
 // a JPEG.
 func photoFileName(messageID int64) string {

--- a/adapters/lo/media.go
+++ b/adapters/lo/media.go
@@ -131,7 +131,8 @@ func (u *Uploader) Save(ctx context.Context, chatID, fileID, fileName string) (s
 // comes back as "txt text pot brf srt" and image/jpeg as "jpeg jpg jpe jfif". Picking the first
 // alphabetically — which an earlier version did, for stability — chose ".brf" for a text file
 // and ".jfif" for a photo, both worse than any of the obvious answers. These are the types a
-// chat actually carries; everything else is bytes nobody described, and ".bin" says so.
+// chat actually carries; anything NOT in this table gets ".bin" — including types that are
+// perfectly well known and simply absent here, which is the honest reading of "unknown to us".
 //
 //nolint:gochecknoglobals // A fixed table, read-only, kept beside the function that uses it.
 var documentExtensions = map[string]string{
@@ -142,10 +143,17 @@ var documentExtensions = map[string]string{
 	"text/markdown":    ".md",
 	"text/csv":         ".csv",
 	"text/html":        ".html",
-	"image/png":        ".png",
-	"image/jpeg":       ".jpg",
-	"image/gif":        ".gif",
-	"image/webp":       ".webp",
+	"text/xml":         ".xml",
+	"application/xml":  ".xml",
+	// The two a working chat actually carries when someone sends "the spec": without them a
+	// nameless .docx lands as .bin, which is the faceless path this whole fallback exists to
+	// avoid.
+	"application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx",
+	"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":       ".xlsx",
+	"image/png":  ".png",
+	"image/jpeg": ".jpg",
+	"image/gif":  ".gif",
+	"image/webp": ".webp",
 }
 
 // documentFileName names a saved document when the platform sent no file name. LO fills

--- a/adapters/lo/media.go
+++ b/adapters/lo/media.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"sync/atomic"
 
@@ -125,19 +124,39 @@ func (u *Uploader) Save(ctx context.Context, chatID, fileID, fileName string) (s
 	return saved, nil
 }
 
+// documentExtensions maps a declared type to the extension a saved document gets.
+//
+// An explicit table rather than mime.ExtensionsByType, and not for determinism alone. Go mixes
+// the host's /etc/mime.types into that table, so the answer depends on the container: text/plain
+// comes back as "txt text pot brf srt" and image/jpeg as "jpeg jpg jpe jfif". Picking the first
+// alphabetically — which an earlier version did, for stability — chose ".brf" for a text file
+// and ".jfif" for a photo, both worse than any of the obvious answers. These are the types a
+// chat actually carries; everything else is bytes nobody described, and ".bin" says so.
+//
+//nolint:gochecknoglobals // A fixed table, read-only, kept beside the function that uses it.
+var documentExtensions = map[string]string{
+	"application/pdf":  ".pdf",
+	"application/json": ".json",
+	"application/zip":  ".zip",
+	"text/plain":       ".txt",
+	"text/markdown":    ".md",
+	"text/csv":         ".csv",
+	"text/html":        ".html",
+	"image/png":        ".png",
+	"image/jpeg":       ".jpg",
+	"image/gif":        ".gif",
+	"image/webp":       ".webp",
+}
+
 // documentFileName names a saved document when the platform sent no file name. LO fills
 // file_name only "usually", and the fallback in fsutil is the bare word "upload" — an agent
 // handed a path with no extension is looking at exactly the opaque id this adapter's inbound
-// path exists to avoid. The declared MIME type is the only other thing the message carries,
-// so the extension comes from there, and from ".bin" when even that is missing or unknown.
+// path exists to avoid. The declared MIME type is the only other thing the message carries.
 func documentFileName(messageID int64, mimeType string) string {
 	ext := ".bin"
 	if media, _, err := mime.ParseMediaType(mimeType); err == nil {
-		// ExtensionsByType is not ordered by preference, so the list is sorted for a stable
-		// name: the same message must not produce ".jpe" on one host and ".jpg" on another.
-		if exts, err := mime.ExtensionsByType(media); err == nil && len(exts) > 0 {
-			sort.Strings(exts)
-			ext = exts[0]
+		if known, ok := documentExtensions[strings.ToLower(media)]; ok {
+			ext = known
 		}
 	}
 	return fmt.Sprintf("document_%d%s", messageID, ext)

--- a/adapters/lo/media.go
+++ b/adapters/lo/media.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"mime"
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync/atomic"
 
@@ -123,10 +125,31 @@ func (u *Uploader) Save(ctx context.Context, chatID, fileID, fileName string) (s
 	return saved, nil
 }
 
+// documentFileName names a saved document when the platform sent no file name. LO fills
+// file_name only "usually", and the fallback in fsutil is the bare word "upload" — an agent
+// handed a path with no extension is looking at exactly the opaque id this adapter's inbound
+// path exists to avoid. The declared MIME type is the only other thing the message carries,
+// so the extension comes from there, and from ".bin" when even that is missing or unknown.
+func documentFileName(messageID int64, mimeType string) string {
+	ext := ".bin"
+	if media, _, err := mime.ParseMediaType(mimeType); err == nil {
+		// ExtensionsByType is not ordered by preference, so the list is sorted for a stable
+		// name: the same message must not produce ".jpe" on one host and ".jpg" on another.
+		if exts, err := mime.ExtensionsByType(media); err == nil && len(exts) > 0 {
+			sort.Strings(exts)
+			ext = exts[0]
+		}
+	}
+	return fmt.Sprintf("document_%d%s", messageID, ext)
+}
+
+// photoFileName names a saved photo. LO photos arrive without a file name, and the file path
+// is a reference rather than something with an extension, so the name is generated from the
+// message: predictable for the agent and unique per message.
+
 // photoFileName names a saved photo BEFORE its bytes have been seen. LO photos arrive without a
 // file name, and the file path is a reference rather than something with an extension, so the
-// name is generated from the message: predictable for the agent and unique per message.
-//
+// name is generated from the message: predictable for the agent and unique per message.//
 // The extension here is a guess. It is corrected the moment the bytes are on disk — see
 // photoExtension — because something DOES read a media type out of this name: core/chat derives
 // the vision block's type from the saved path, so a PNG named .jpg reaches the model declared as

--- a/adapters/lo/receiver.go
+++ b/adapters/lo/receiver.go
@@ -466,7 +466,10 @@ type attachmentKind struct{ noun, advice string }
 
 //nolint:gochecknoglobals // Two fixed values, read-only, beside the function that uses them.
 var (
-	imageKind = attachmentKind{noun: "image", advice: "Describe what it shows, or send it as a file."}
+	// No "send it as a file" here: the sentence this advice joins is ErrNoBytes, and a document
+	// hits the same refusal on a platform that hands out no bytes. Advice that cannot work is
+	// worse than none.
+	imageKind = attachmentKind{noun: "image", advice: "Describe what it shows."}
 	fileKind  = attachmentKind{
 		noun:   "file",
 		advice: "Paste the contents, or point me at the file in a repository.",

--- a/adapters/lo/receiver.go
+++ b/adapters/lo/receiver.go
@@ -17,6 +17,7 @@ import (
 	"github.com/duckbugio/flock/core/chat"
 	"github.com/duckbugio/flock/core/goal"
 	"github.com/duckbugio/flock/core/schedule"
+	"github.com/duckbugio/flock/internal/fsutil"
 )
 
 const privateChatType = "private"
@@ -360,8 +361,14 @@ func (r *Receiver) attachments(
 		// model as a vision block, a document becomes words the agent opens with a tool. Its
 		// name is the sender's, so nothing sniffs it — that correction is for the name this
 		// adapter invented, not for one a person chose.
+		// The guard asks the SANITISER what the name will become, rather than re-deriving its
+		// rule here. A TrimSpace test passes ".", "..", "..." and "/" — all of which fsutil
+		// reduces to its own placeholder or to a bare separator, leaving the agent the
+		// extensionless path this fallback exists to prevent — and a rule copied by hand would
+		// drift the first time fsutil's changes.
 		name := msg.Document.FileName
-		if strings.TrimSpace(name) == "" {
+		if sanitized := fsutil.SanitizeUploadName(name); sanitized == fsutil.DefaultUploadName ||
+			strings.Trim(sanitized, `./\ `) == "" {
 			name = documentFileName(msg.ID, msg.Document.MimeType)
 		}
 		saved, note := r.download(ctx, chatID, msg.Document.FileID, name, fileKind)

--- a/adapters/lo/receiver.go
+++ b/adapters/lo/receiver.go
@@ -206,7 +206,7 @@ func (r *Receiver) HandleUpdate(ctx context.Context, update Update) {
 	// Attachments are answered BEFORE the empty-text check: a photo with no caption is a
 	// complete request ("look at this"), and dropping it silently is what made the bot
 	// look broken.
-	saved, confirmed, note := r.attachments(ctx, msg, chatID)
+	photo, document, confirmed, note := r.attachments(ctx, msg, chatID)
 	if note != "" {
 		// The file the request rests on never reached the agent, so the caption must not be
 		// answered on its own: "review this file" without the file invites a confident answer
@@ -214,12 +214,18 @@ func (r *Receiver) HandleUpdate(ctx context.Context, update Update) {
 		r.notify(ctx, chatID, note)
 		return
 	}
-	if text == "" && saved == "" {
+	if text == "" && photo == "" && document == "" {
 		return
 	}
-	if saved != "" {
-		r.handlePhoto(ctx, msg, chatID, replyToBot, text, saved, confirmed)
+	if photo != "" {
+		r.handlePhoto(ctx, msg, chatID, replyToBot, text, photo, confirmed)
 		return
+	}
+	if document != "" {
+		// core/chat's own wording, shared with the Telegram adapter: the caption belongs
+		// INSIDE the sentence that names the file, not appended after it, so the agent reads
+		// one request rather than a path followed by an unrelated line.
+		text = chat.DocumentPrompt(document, text)
 	}
 	r.cfg.Service.Handle(ctx, chatID, msg.From.ID, strconv.FormatInt(msg.ID, 10),
 		replyPrompt(msg, replyToBot, text))
@@ -301,22 +307,12 @@ var unservedKinds = []struct {
 			"Please send the request as text.",
 	},
 	{
+		// Before any arm that could also match it. Bot API fills `document` ALONGSIDE
+		// `animation` for a GIF, and this adapter READS documents — so without this order a
+		// GIF would be downloaded and handed to the agent as a file it cannot act on, instead
+		// of getting the sentence that says what is missing.
 		has:    func(m *Message) bool { return present(m.Animation) },
 		notice: "I cannot open animations on LO yet. A still screenshot sent as a photo works.",
-	},
-	{
-		// LAST of the refusals, and deliberately: Bot API fills `document` ALONGSIDE
-		// `animation` for a GIF and alongside `video_note` for a round video, so a document
-		// arm placed first would answer "I cannot read documents" to someone who sent an
-		// animation. Every kind with a name of its own is answered by that name first.
-		has: func(m *Message) bool { return m.Document != nil },
-		// Says what this ADAPTER does, not what the platform cannot do. The evidence for the
-		// platform claim would have been sendDocument's 501, and that is the OUTGOING method:
-		// whether getFile answers a document reference with a file_path is a separate
-		// question, unverified when this line was written, and answered by the change that
-		// follows it.
-		notice: "I cannot read documents yet. " +
-			"Paste the text, or point me at the file in a repository.",
 	},
 	{
 		has:    func(m *Message) bool { return present(m.Sticker) },
@@ -332,35 +328,42 @@ var unservedKinds = []struct {
 // arrive and deserves to know it did not reach the agent.
 func (r *Receiver) attachments(
 	ctx context.Context, msg *Message, chatID string,
-) (saved string, confirmed bool, notice string) {
+) (photo, document string, confirmed bool, notice string) {
 	// LargestPhoto is the ONLY reader of msg.Photo here, deliberately. hasServedMedia counts a
 	// non-empty array as work and spends guard budget on it, so a ladder whose every rung
 	// lacks a file_id must still end in a sentence — otherwise the message is dropped in
 	// silence, or worse, its caption reaches the agent without the picture it refers to. That
 	// is the "confident answer about nothing" every other arm here exists to prevent.
-	if len(msg.Photo) == 0 {
-		// No unserved-kind arm either: those are answered before the guards, without touching
-		// the network. See unservedNotice.
-		return "", false, ""
+	if len(msg.Photo) > 0 {
+		size, ok := LargestPhoto(msg.Photo)
+		if !ok {
+			return "", "", false, "I could not read that image. Please send it again."
+		}
+		saved, note := r.download(ctx, chatID, size.FileID, photoFileName(msg.ID), "image")
+		shown := false
+		if saved != "" {
+			var refusal string
+			if saved, shown, refusal = r.checkPhotoBytes(saved); refusal != "" {
+				note = refusal
+			}
+		}
+		return saved, "", shown, note
 	}
-	size, ok := LargestPhoto(msg.Photo)
-	if !ok {
-		return "", false, "I could not read that image. Please send it again."
+	if msg.Document != nil {
+		// The name comes from the chat and is sanitised on the way to disk; keeping it is what
+		// lets the agent see "spec.pdf" rather than an opaque id.
+		//
+		// A document is returned SEPARATELY from a photo even though both are just a saved
+		// path, because the caller does different things with them: a picture is shown to the
+		// model as a vision block, a document becomes words the agent opens with a tool. Its
+		// name is the sender's, so nothing sniffs it — that correction is for the name this
+		// adapter invented, not for one a person chose.
+		saved, note := r.download(ctx, chatID, msg.Document.FileID, msg.Document.FileName, "file")
+		return "", saved, false, note
 	}
-	if r.cfg.Uploads == nil {
-		return "", false, "I cannot read images in this deployment: no uploads directory is configured."
-	}
-	path, err := r.cfg.Uploads.Save(ctx, chatID, size.FileID, photoFileName(msg.ID))
-	switch {
-	case errors.Is(err, ErrUploadTooLarge):
-		return "", false, "That image is too large for me to open. Please send a smaller one."
-	case errors.Is(err, ErrNoBytes):
-		return "", false, "LO did not hand me the bytes of that image, so I cannot open it."
-	case err != nil:
-		r.cfg.Logger.Warn("lo: photo download failed", "error", err)
-		return "", false, "I could not download that image. Please try sending it again."
-	}
-	return r.checkPhotoBytes(path)
+	// No unserved-kind arm here any more: those are answered before the guards, without
+	// touching the network. See unservedNotice.
+	return "", "", false, ""
 }
 
 // checkPhotoBytes names a saved photo by what its bytes ARE, and decides whether the picture
@@ -438,6 +441,46 @@ func unservedNotice(msg *Message) string {
 // from spending guard budget.
 func hasServedMedia(msg *Message) bool {
 	return len(msg.Photo) > 0
+}
+
+// article picks "a" or "an" for the nouns this file uses. Small, but the prompt is read by a
+// model: "a image" is the kind of wrongness that makes the rest of the sentence less credible.
+func article(noun string) string {
+	if noun == "" {
+		return "a"
+	}
+	switch noun[0] {
+	case 'a', 'e', 'i', 'o', 'u':
+		return "an"
+	}
+	return "a"
+}
+
+// download saves one inbound attachment and phrases the outcome for both readers: the agent,
+// which needs a path it can open, and the user, who needs to know if their file did not arrive.
+//
+// kind is the word the user sees ("image", "file"). It is a parameter rather than a branch
+// because every outcome below reads the same for both — only the noun changes.
+func (r *Receiver) download(ctx context.Context, chatID, fileID, name, kind string) (saved, notice string) {
+	if r.cfg.Uploads == nil {
+		return "", "I cannot read attachments in this deployment: no uploads directory is configured."
+	}
+	path, err := r.cfg.Uploads.Save(ctx, chatID, fileID, name)
+	switch {
+	case errors.Is(err, ErrUploadTooLarge):
+		return "", "That " + kind + " is too large for me to open. Please send a smaller one."
+	case errors.Is(err, ErrNoBytes):
+		// The platform answered the reference and withheld the bytes — for a document that
+		// means this LO has not shipped document downloads yet.
+		return "", "This LO does not hand bots the bytes of that " + kind + ", so I cannot open it. " +
+			"Paste the contents, or point me at the file in a repository."
+	case err != nil:
+		r.cfg.Logger.Warn("lo: attachment download failed", "kind", kind, "error", err)
+		return "", "I could not download that " + kind + ". Please try sending it again."
+	}
+	// The SAVED PATH, not a sentence: a photo becomes a vision block and a document becomes
+	// words, and only the caller knows which. Phrasing here would have to guess.
+	return path, ""
 }
 
 func (r *Receiver) notify(ctx context.Context, chatID, text string) {

--- a/adapters/lo/receiver.go
+++ b/adapters/lo/receiver.go
@@ -351,14 +351,20 @@ func (r *Receiver) attachments(
 	}
 	if msg.Document != nil {
 		// The name comes from the chat and is sanitised on the way to disk; keeping it is what
-		// lets the agent see "spec.pdf" rather than an opaque id.
+		// lets the agent see "spec.pdf" rather than an opaque id. LO fills it only "usually",
+		// and a nameless document would land as an extensionless "upload" — so an absent name
+		// is rebuilt from the declared type instead.
 		//
 		// A document is returned SEPARATELY from a photo even though both are just a saved
 		// path, because the caller does different things with them: a picture is shown to the
 		// model as a vision block, a document becomes words the agent opens with a tool. Its
 		// name is the sender's, so nothing sniffs it — that correction is for the name this
 		// adapter invented, not for one a person chose.
-		saved, note := r.download(ctx, chatID, msg.Document.FileID, msg.Document.FileName, "file")
+		name := msg.Document.FileName
+		if strings.TrimSpace(name) == "" {
+			name = documentFileName(msg.ID, msg.Document.MimeType)
+		}
+		saved, note := r.download(ctx, chatID, msg.Document.FileID, name, "file")
 		return "", saved, false, note
 	}
 	// No unserved-kind arm here any more: those are answered before the guards, without

--- a/adapters/lo/receiver.go
+++ b/adapters/lo/receiver.go
@@ -350,7 +350,7 @@ func (r *Receiver) attachments(
 		}
 		return saved, "", shown, note
 	}
-	if msg.Document != nil {
+	if servedDocument(msg) {
 		// The name comes from the chat and is sanitised on the way to disk; keeping it is what
 		// lets the agent see "spec.pdf" rather than an opaque id. LO fills it only "usually",
 		// and a nameless document would land as an extensionless "upload" — so an absent name
@@ -453,7 +453,18 @@ func unservedNotice(msg *Message) string {
 // kinds that produce a sentence and nothing else, and that difference is what keeps a refusal
 // from spending guard budget.
 func hasServedMedia(msg *Message) bool {
-	return len(msg.Photo) > 0 || msg.Document != nil
+	return len(msg.Photo) > 0 || servedDocument(msg)
+}
+
+// servedDocument reports a document this adapter should READ, as opposed to one the platform
+// attached to something else.
+//
+// Bot API fills `document` ALONGSIDE `animation` for a GIF and alongside `video_note` for a
+// round video: the file is there, but the message is not a document — and downloading it would
+// hand the agent a video it cannot act on instead of the sentence that says so. The kind with
+// a name of its own wins, which is the same rule the refusal table follows.
+func servedDocument(msg *Message) bool {
+	return msg.Document != nil && !present(msg.Animation) && !present(msg.VideoNote)
 }
 
 // attachmentKind is what a refusal needs to say about one kind of attachment: the noun the

--- a/adapters/lo/receiver.go
+++ b/adapters/lo/receiver.go
@@ -339,7 +339,7 @@ func (r *Receiver) attachments(
 		if !ok {
 			return "", "", false, "I could not read that image. Please send it again."
 		}
-		saved, note := r.download(ctx, chatID, size.FileID, photoFileName(msg.ID), "image")
+		saved, note := r.download(ctx, chatID, size.FileID, photoFileName(msg.ID), imageKind)
 		shown := false
 		if saved != "" {
 			var refusal string
@@ -364,7 +364,7 @@ func (r *Receiver) attachments(
 		if strings.TrimSpace(name) == "" {
 			name = documentFileName(msg.ID, msg.Document.MimeType)
 		}
-		saved, note := r.download(ctx, chatID, msg.Document.FileID, name, "file")
+		saved, note := r.download(ctx, chatID, msg.Document.FileID, name, fileKind)
 		return "", saved, false, note
 	}
 	// No unserved-kind arm here any more: those are answered before the guards, without
@@ -446,7 +446,7 @@ func unservedNotice(msg *Message) string {
 // kinds that produce a sentence and nothing else, and that difference is what keeps a refusal
 // from spending guard budget.
 func hasServedMedia(msg *Message) bool {
-	return len(msg.Photo) > 0
+	return len(msg.Photo) > 0 || msg.Document != nil
 }
 
 // article picks "a" or "an" for the nouns this file uses. Small, but the prompt is read by a
@@ -462,27 +462,46 @@ func article(noun string) string {
 	return "a"
 }
 
+// attachmentKind is what a refusal needs to say about one kind of attachment: the noun the
+// user sees, and what they can do instead.
+//
+// The advice cannot be shared even though the sentence around it can. "Paste the contents" is
+// something the sender of a specification can do and the sender of a photograph cannot, and a
+// refusal that ends in impossible advice reads as a bot that did not look at what it got.
+type attachmentKind struct{ noun, advice string }
+
+//nolint:gochecknoglobals // Two fixed values, read-only, beside the function that uses them.
+var (
+	imageKind = attachmentKind{noun: "image", advice: "Describe what it shows, or send it as a file."}
+	fileKind  = attachmentKind{
+		noun:   "file",
+		advice: "Paste the contents, or point me at the file in a repository.",
+	}
+)
+
 // download saves one inbound attachment and phrases the outcome for both readers: the agent,
 // which needs a path it can open, and the user, who needs to know if their file did not arrive.
 //
-// kind is the word the user sees ("image", "file"). It is a parameter rather than a branch
-// because every outcome below reads the same for both — only the noun changes.
-func (r *Receiver) download(ctx context.Context, chatID, fileID, name, kind string) (saved, notice string) {
+// kind is a parameter rather than a branch because every outcome below reads the same for
+// both — only the noun changes, and in one case the advice after it.
+func (r *Receiver) download(
+	ctx context.Context, chatID, fileID, name string, kind attachmentKind,
+) (saved, notice string) {
 	if r.cfg.Uploads == nil {
 		return "", "I cannot read attachments in this deployment: no uploads directory is configured."
 	}
 	path, err := r.cfg.Uploads.Save(ctx, chatID, fileID, name)
 	switch {
 	case errors.Is(err, ErrUploadTooLarge):
-		return "", "That " + kind + " is too large for me to open. Please send a smaller one."
+		return "", "That " + kind.noun + " is too large for me to open. Please send a smaller one."
 	case errors.Is(err, ErrNoBytes):
 		// The platform answered the reference and withheld the bytes — for a document that
 		// means this LO has not shipped document downloads yet.
-		return "", "This LO does not hand bots the bytes of that " + kind + ", so I cannot open it. " +
-			"Paste the contents, or point me at the file in a repository."
+		return "", "This LO does not hand bots the bytes of that " + kind.noun + ", so I cannot open it. " +
+			kind.advice
 	case err != nil:
-		r.cfg.Logger.Warn("lo: attachment download failed", "kind", kind, "error", err)
-		return "", "I could not download that " + kind + ". Please try sending it again."
+		r.cfg.Logger.Warn("lo: attachment download failed", "kind", kind.noun, "error", err)
+		return "", "I could not download that " + kind.noun + ". Please try sending it again."
 	}
 	// The SAVED PATH, not a sentence: a photo becomes a vision block and a document becomes
 	// words, and only the caller knows which. Phrasing here would have to guess.

--- a/adapters/lo/receiver.go
+++ b/adapters/lo/receiver.go
@@ -449,19 +449,6 @@ func hasServedMedia(msg *Message) bool {
 	return len(msg.Photo) > 0 || msg.Document != nil
 }
 
-// article picks "a" or "an" for the nouns this file uses. Small, but the prompt is read by a
-// model: "a image" is the kind of wrongness that makes the rest of the sentence less credible.
-func article(noun string) string {
-	if noun == "" {
-		return "a"
-	}
-	switch noun[0] {
-	case 'a', 'e', 'i', 'o', 'u':
-		return "an"
-	}
-	return "a"
-}
-
 // attachmentKind is what a refusal needs to say about one kind of attachment: the noun the
 // user sees, and what they can do instead.
 //

--- a/adapters/lo/receiver_media_test.go
+++ b/adapters/lo/receiver_media_test.go
@@ -380,6 +380,41 @@ func TestGuardsRunBeforeTheDownload(t *testing.T) {
 	}
 }
 
+// LO fills file_name only "usually". Without a fallback the sanitiser turns an empty name into
+// the bare word "upload", and the agent is handed an extensionless path — the opaque id the
+// whole download path exists to avoid. The declared type is all the message carries, so the
+// extension comes from there, and ".bin" is the honest name for bytes nobody described.
+func TestNamelessDocumentIsNamedFromItsType(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct{ name, mime, wantExt string }{
+		{"a declared type", "application/pdf", ".pdf"},
+		{"a type nothing knows", "application/x-nonsense-not-a-type", ".bin"},
+		{"no type at all", "", ".bin"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			svc := &serviceSpy{}
+			api, _ := photoAPI(t, "bytes")
+			receiver := lo.NewReceiver(lo.ReceiverConfig{
+				Service: svc, Client: api, Transport: lo.NewTransport(api, false),
+				IsAllowed: func(int64) bool { return true },
+				Uploads:   lo.NewUploader(api, fakeUploads{dir: t.TempDir()}, 0, nil),
+			})
+
+			msg := inbound("что тут")
+			msg.Document = &lo.Attachment{FileID: "ref", MimeType: tc.mime}
+			receiver.HandleUpdate(t.Context(), lo.Update{Message: msg})
+
+			if len(svc.prompts) != 1 {
+				t.Fatalf("prompts=%v, want one run", svc.prompts)
+			}
+			if saved := savedPathFrom(t, svc.prompts[0]); !strings.HasSuffix(saved, tc.wantExt) {
+				t.Fatalf("saved as %q, want the %q the type implies", saved, tc.wantExt)
+			}
+		})
+	}
+}
+
 // The rung with the most BYTES wins, not the one with the most pixels. A rung can be the
 // largest on paper and the most compressed in fact, so bytes describe "most detail" better —
 // the rule the Telegram adapter already follows. A rung LO has not measured carries no

--- a/adapters/lo/receiver_media_test.go
+++ b/adapters/lo/receiver_media_test.go
@@ -393,6 +393,9 @@ func TestNamelessDocumentIsNamedFromItsType(t *testing.T) {
 		// answer is worse than any of the obvious ones.
 		{"plain text", "text/plain", ".txt"},
 		{"a jpeg", "image/jpeg", ".jpg"},
+		// The two a working chat actually carries when someone sends "the spec".
+		{"a word document", "application/vnd.openxmlformats-officedocument.wordprocessingml.document", ".docx"},
+		{"a spreadsheet", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", ".xlsx"},
 		{"parameters and case", "TEXT/PLAIN; charset=utf-8", ".txt"},
 		{"a type nothing knows", "application/x-nonsense-not-a-type", ".bin"},
 		{"no type at all", "", ".bin"},

--- a/adapters/lo/receiver_media_test.go
+++ b/adapters/lo/receiver_media_test.go
@@ -169,14 +169,12 @@ func TestUnreadableAttachmentsExplainThemselvesAndStopTheRun(t *testing.T) {
 	// The notice TEXT is asserted, not merely its count. Per-kind sentences are what this
 	// whole path is for — "I cannot read that" for everything would have been one line — so a
 	// test that counts notices would stay green through any mix-up in the table.
+	//
+	// Documents are absent: they are read now, and their own tests cover that.
 	for name, tc := range map[string]struct {
 		attach func(*lo.Message)
 		says   string
 	}{
-		"document": {
-			func(m *lo.Message) { m.Document = &lo.Attachment{FileID: "d", FileName: "spec.pdf"} },
-			"documents", // Names the kind; the sentence deliberately claims nothing about the platform.
-		},
 		"voice": {func(m *lo.Message) { m.Voice = lo.RawAttachment("v") }, "voice"},
 		"video": {func(m *lo.Message) { m.Video = lo.RawAttachment("m") }, "video"},
 		"audio": {func(m *lo.Message) { m.Audio = lo.RawAttachment("a") }, "audio"},
@@ -260,9 +258,12 @@ func savedPathFrom(t *testing.T, prompt string) string {
 	// The photo prompt is core/chat's, shared with Telegram and VK, and ends the path with
 	// ")". The document one is this adapter's and ends it with " —". Reading both keeps the
 	// helper usable from either side rather than duplicating it per kind.
+	// Both prompts come from core/chat and end the path differently: the photo one closes a
+	// parenthesis, the document one ends the line. Reading both keeps one helper usable from
+	// either side instead of a copy per kind.
 	for _, marker := range []struct{ start, end string }{
 		{"saved at ", ")"},
-		{"saved at ", " —"},
+		{"uploaded a file: ", "\n"},
 	} {
 		idx := strings.Index(prompt, marker.start)
 		if idx < 0 {
@@ -275,6 +276,76 @@ func savedPathFrom(t *testing.T, prompt string) string {
 	}
 	t.Fatalf("prompt names no saved file: %q", prompt)
 	return ""
+}
+
+// A document is downloaded exactly like a photo once the platform serves its bytes: the agent
+// gets a path to open, and the file keeps the name the user gave it.
+func TestDocumentReachesTheAgentAsAPath(t *testing.T) {
+	t.Parallel()
+	svc := &serviceSpy{}
+	api, notices := photoAPI(t, "%PDF-1.7")
+	receiver := lo.NewReceiver(lo.ReceiverConfig{
+		Service: svc, Client: api, Transport: lo.NewTransport(api, false),
+		IsAllowed: func(int64) bool { return true },
+		Uploads:   lo.NewUploader(api, fakeUploads{dir: t.TempDir()}, 0, nil),
+	})
+
+	msg := inbound("разбери этот файл")
+	msg.Document = &lo.Attachment{FileID: "ref", FileName: "spec.pdf", MimeType: "application/pdf"}
+	receiver.HandleUpdate(t.Context(), lo.Update{Message: msg})
+
+	if len(svc.prompts) != 1 {
+		t.Fatalf("prompts=%v, want the document to start one run", svc.prompts)
+	}
+	if !strings.Contains(svc.prompts[0], "uploaded a file") {
+		t.Fatalf("prompt does not name the attachment: %q", svc.prompts[0])
+	}
+	saved := savedPathFrom(t, svc.prompts[0])
+	if !strings.HasSuffix(saved, "spec.pdf") {
+		t.Fatalf("saved as %q, want the name the user gave it", saved)
+	}
+	data, err := os.ReadFile(saved) //nolint:gosec // Path comes from the prompt the code built.
+	if err != nil || string(data) != "%PDF-1.7" {
+		t.Fatalf("content=%q err=%v", data, err)
+	}
+	if len(*notices) != 0 {
+		t.Fatalf("a working download still sent a notice: %v", *notices)
+	}
+}
+
+// A platform that answers the reference but withholds the bytes — every LO that predates
+// document downloads — must say so instead of failing silently or blaming the user's file.
+func TestDocumentWithoutBytesIsExplained(t *testing.T) {
+	t.Parallel()
+	svc := &serviceSpy{}
+	var notices []string
+	api := client(t, func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/getFile") {
+			// A reference answered WITHOUT a file_path: real reference, no bytes.
+			reply(w, `{"ok":true,"result":{"file_id":"ref"}}`)
+			return
+		}
+		body := make([]byte, 4096)
+		n, _ := r.Body.Read(body)
+		notices = append(notices, string(body[:n]))
+		reply(w, `{"ok":true,"result":{"message_id":1}}`)
+	})
+	receiver := lo.NewReceiver(lo.ReceiverConfig{
+		Service: svc, Client: api, Transport: lo.NewTransport(api, false),
+		IsAllowed: func(int64) bool { return true },
+		Uploads:   lo.NewUploader(api, fakeUploads{dir: t.TempDir()}, 0, nil),
+	})
+
+	msg := inbound("посмотри")
+	msg.Document = &lo.Attachment{FileID: "ref", FileName: "spec.pdf"}
+	receiver.HandleUpdate(t.Context(), lo.Update{Message: msg})
+
+	if len(svc.prompts) != 0 {
+		t.Fatalf("a run started without the file: %v", svc.prompts)
+	}
+	if len(notices) != 1 || !strings.Contains(notices[0], "does not hand bots the bytes") {
+		t.Fatalf("notices=%v", notices)
+	}
 }
 
 // A rate limit or a spent cost cap is paid with a refusal, not with a download: doing the

--- a/adapters/lo/receiver_media_test.go
+++ b/adapters/lo/receiver_media_test.go
@@ -364,7 +364,7 @@ func TestGuardsRunBeforeTheDownload(t *testing.T) {
 	receiver := lo.NewReceiver(lo.ReceiverConfig{
 		Service: svc, Client: api, Transport: lo.NewTransport(api, false),
 		IsAllowed: func(int64) bool { return true },
-		Guards:    func(int64) (bool, string) { return false, "Daily cap reached." },
+		Guards:    func(int64) (bool, string) { return false, capReached },
 		Uploads:   lo.NewUploader(api, fakeUploads{dir: t.TempDir()}, 0, nil),
 	})
 
@@ -388,6 +388,12 @@ func TestNamelessDocumentIsNamedFromItsType(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct{ name, mime, wantExt string }{
 		{"a declared type", "application/pdf", ".pdf"},
+		// The two the host's mime.types table used to get wrong: it offers "txt text pot brf
+		// srt" for one and "jpeg jpg jpe jfif" for the other, and the alphabetically first
+		// answer is worse than any of the obvious ones.
+		{"plain text", "text/plain", ".txt"},
+		{"a jpeg", "image/jpeg", ".jpg"},
+		{"parameters and case", "TEXT/PLAIN; charset=utf-8", ".txt"},
 		{"a type nothing knows", "application/x-nonsense-not-a-type", ".bin"},
 		{"no type at all", "", ".bin"},
 	} {
@@ -412,6 +418,97 @@ func TestNamelessDocumentIsNamedFromItsType(t *testing.T) {
 				t.Fatalf("saved as %q, want the %q the type implies", saved, tc.wantExt)
 			}
 		})
+	}
+}
+
+// A refusal ends in advice the sender can actually act on. The two kinds share the sentence
+// that explains what happened and cannot share what to do about it: "paste the contents" is
+// something the sender of a specification can do and the sender of a photograph cannot.
+func TestRefusalAdviceFitsTheKindItRefused(t *testing.T) {
+	t.Parallel()
+	for name, tc := range map[string]struct {
+		attach func(*lo.Message)
+		says   string
+		avoids string
+	}{
+		"image": {
+			func(m *lo.Message) { m.Photo = []lo.PhotoSize{{FileID: "ref", Width: 800, Height: 600}} },
+			"Describe what it shows",
+			"Paste the contents",
+		},
+		"document": {
+			func(m *lo.Message) { m.Document = &lo.Attachment{FileID: "ref", FileName: "spec.pdf"} },
+			"Paste the contents",
+			"Describe what it shows",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			svc := &serviceSpy{}
+			var notices []string
+			api := client(t, func(w http.ResponseWriter, r *http.Request) {
+				if strings.HasSuffix(r.URL.Path, "/getFile") {
+					// A reference answered WITHOUT a file_path: real reference, no bytes.
+					reply(w, `{"ok":true,"result":{"file_id":"ref"}}`)
+					return
+				}
+				body := make([]byte, 4096)
+				n, _ := r.Body.Read(body)
+				notices = append(notices, string(body[:n]))
+				reply(w, `{"ok":true,"result":{"message_id":1}}`)
+			})
+			receiver := lo.NewReceiver(lo.ReceiverConfig{
+				Service: svc, Client: api, Transport: lo.NewTransport(api, false),
+				IsAllowed: func(int64) bool { return true },
+				Uploads:   lo.NewUploader(api, fakeUploads{dir: t.TempDir()}, 0, nil),
+			})
+
+			msg := inbound("посмотри")
+			tc.attach(msg)
+			receiver.HandleUpdate(t.Context(), lo.Update{Message: msg})
+
+			if len(notices) != 1 {
+				t.Fatalf("notices=%v, want exactly one", notices)
+			}
+			if !strings.Contains(notices[0], tc.says) {
+				t.Fatalf("the %s refusal does not say what to do instead: %s", name, notices[0])
+			}
+			if strings.Contains(notices[0], tc.avoids) {
+				t.Fatalf("the %s refusal gives the other kind's advice: %s", name, notices[0])
+			}
+		})
+	}
+}
+
+// A document is work, so a refused guard must cost the download nothing — the same rule the
+// photo path follows. Without Document in hasServedMedia a captionless document would skip the
+// guards entirely and be downloaded for free.
+func TestGuardsCoverACaptionlessDocument(t *testing.T) {
+	t.Parallel()
+	svc := &serviceSpy{}
+	var fetched int
+	api := client(t, func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/file/bot") || strings.HasSuffix(r.URL.Path, "/getFile") {
+			fetched++
+		}
+		reply(w, `{"ok":true,"result":{"message_id":1}}`)
+	})
+	receiver := lo.NewReceiver(lo.ReceiverConfig{
+		Service: svc, Client: api, Transport: lo.NewTransport(api, false),
+		IsAllowed: func(int64) bool { return true },
+		Guards:    func(int64) (bool, string) { return false, capReached },
+		Uploads:   lo.NewUploader(api, fakeUploads{dir: t.TempDir()}, 0, nil),
+	})
+
+	msg := inbound("")
+	msg.Document = &lo.Attachment{FileID: "ref", FileName: "spec.pdf"}
+	receiver.HandleUpdate(t.Context(), lo.Update{Message: msg})
+
+	if len(svc.prompts) != 0 {
+		t.Fatalf("a capped user still started a run: %v", svc.prompts)
+	}
+	if fetched != 0 {
+		t.Fatalf("the refusal still cost %d download calls", fetched)
 	}
 }
 

--- a/adapters/lo/receiver_media_test.go
+++ b/adapters/lo/receiver_media_test.go
@@ -716,3 +716,33 @@ func TestAnimationIsAnsweredAsAnAnimationNotAsADocument(t *testing.T) {
 		t.Fatalf("notices=%v, want the animation sentence, not the document one", *notices)
 	}
 }
+
+// The fallback must fire for every name the SANITISER reduces to nothing, not only for a blank
+// one. fsutil takes the base name and trims leading dots, so these all pass a TrimSpace test
+// and then leave the extensionless "upload" the fallback exists to prevent.
+func TestDocumentNamesThatSanitiseToNothingGetTheFallback(t *testing.T) {
+	t.Parallel()
+	for _, given := range []string{".", "..", "...", "/", "  ..  ", "/../"} {
+		t.Run(given, func(t *testing.T) {
+			t.Parallel()
+			svc := &serviceSpy{}
+			api, _ := photoAPI(t, "%PDF-1.7")
+			receiver := lo.NewReceiver(lo.ReceiverConfig{
+				Service: svc, Client: api, Transport: lo.NewTransport(api, false),
+				IsAllowed: func(int64) bool { return true },
+				Uploads:   lo.NewUploader(api, fakeUploads{dir: t.TempDir()}, 0, nil),
+			})
+
+			msg := inbound("разбери")
+			msg.Document = &lo.Attachment{FileID: "ref", FileName: given, MimeType: "application/pdf"}
+			receiver.HandleUpdate(t.Context(), lo.Update{Message: msg})
+
+			if len(svc.prompts) != 1 {
+				t.Fatalf("prompts=%v, want one run", svc.prompts)
+			}
+			if saved := savedPathFrom(t, svc.prompts[0]); !strings.HasSuffix(saved, ".pdf") {
+				t.Fatalf("name %q saved as %q, want the fallback's extension", given, saved)
+			}
+		})
+	}
+}

--- a/adapters/lo/receiver_media_test.go
+++ b/adapters/lo/receiver_media_test.go
@@ -80,6 +80,31 @@ func TestPhotoReachesTheAgentAsAPath(t *testing.T) {
 	}
 }
 
+// A document with no caption is a complete request too ("read this"), and it must survive the
+// same empty-text check. Its prompt takes DocumentPrompt's other form, which is why the helper
+// above knows both.
+func TestCaptionlessDocumentStillStartsARun(t *testing.T) {
+	t.Parallel()
+	svc := &serviceSpy{}
+	api, _ := photoAPI(t, "%PDF-1.7")
+	receiver := lo.NewReceiver(lo.ReceiverConfig{
+		Service: svc, Client: api, Transport: lo.NewTransport(api, false),
+		IsAllowed: func(int64) bool { return true },
+		Uploads:   lo.NewUploader(api, fakeUploads{dir: t.TempDir()}, 0, nil),
+	})
+
+	msg := inbound("")
+	msg.Document = &lo.Attachment{FileID: "ref", FileName: "spec.pdf", MimeType: "application/pdf"}
+	receiver.HandleUpdate(t.Context(), lo.Update{Message: msg})
+
+	if len(svc.prompts) != 1 {
+		t.Fatalf("prompts=%v, want the document to start one run on its own", svc.prompts)
+	}
+	if saved := savedPathFrom(t, svc.prompts[0]); !strings.HasSuffix(saved, "spec.pdf") {
+		t.Fatalf("saved as %q, want the sender's own name at the end", saved)
+	}
+}
+
 // A photo with no caption is a complete request ("look at this"), so it must not be
 // swallowed by the empty-text check that drops chatter.
 func TestCaptionlessPhotoStillStartsARun(t *testing.T) {
@@ -256,11 +281,13 @@ func TestPhotoWithoutUploaderIsRefusedExplicitly(t *testing.T) {
 func savedPathFrom(t *testing.T, prompt string) string {
 	t.Helper()
 	// Both prompts come from core/chat and end the path differently: the photo one closes a
-	// parenthesis, the document one ends the line. Reading both keeps one helper usable from
-	// either side instead of a copy per kind.
+	// parenthesis, and DocumentPrompt has TWO forms — with a caption the path ends the line,
+	// without one it is followed by ". Please read". Reading all three keeps one helper usable
+	// from either side instead of a copy per kind.
 	for _, marker := range []struct{ start, end string }{
 		{"saved at ", ")"},
 		{"uploaded a file: ", "\n"},
+		{"uploaded a file: ", ". Please read"},
 	} {
 		idx := strings.Index(prompt, marker.start)
 		if idx < 0 {

--- a/adapters/lo/receiver_media_test.go
+++ b/adapters/lo/receiver_media_test.go
@@ -255,9 +255,6 @@ func TestPhotoWithoutUploaderIsRefusedExplicitly(t *testing.T) {
 
 func savedPathFrom(t *testing.T, prompt string) string {
 	t.Helper()
-	// The photo prompt is core/chat's, shared with Telegram and VK, and ends the path with
-	// ")". The document one is this adapter's and ends it with " —". Reading both keeps the
-	// helper usable from either side rather than duplicating it per kind.
 	// Both prompts come from core/chat and end the path differently: the photo one closes a
 	// parenthesis, the document one ends the line. Reading both keeps one helper usable from
 	// either side instead of a copy per kind.

--- a/adapters/lo/receiver_test.go
+++ b/adapters/lo/receiver_test.go
@@ -19,6 +19,10 @@ import (
 
 const groupChatType = "group"
 
+// capReached is the refusal a spent guard sends. A constant because several tests assert the
+// same sentence, and a drifting literal would make one of them silently stop asserting it.
+const capReached = "Daily cap reached."
+
 type serviceSpy struct {
 	prompts     []string
 	stopped     int
@@ -127,7 +131,7 @@ func TestReceiverStopBypassesNewWorkGuards(t *testing.T) {
 	})
 	receiver := lo.NewReceiver(lo.ReceiverConfig{
 		Service: svc, Transport: lo.NewTransport(api, false), IsAllowed: func(int64) bool { return true },
-		Guards: func(int64) (bool, string) { return false, "Daily cap reached." },
+		Guards: func(int64) (bool, string) { return false, capReached },
 	})
 	receiver.HandleUpdate(t.Context(), lo.Update{Message: inbound("do work")})
 	receiver.HandleUpdate(t.Context(), lo.Update{Message: inbound("/stop")})

--- a/cmd/flock-lo/main.go
+++ b/cmd/flock-lo/main.go
@@ -103,7 +103,9 @@ func run() int {
 		}
 	}
 	ws := &workspace.Renderer{
-		FileDeliveryDisabled: true,
+		// Promises about files follow the flag: with documents off the workspace instructions
+		// tell the agent not to offer them, because the transport cannot deliver.
+		FileDeliveryDisabled: !cfg.LOEnableDocuments,
 		AutoApproveScope:     cfg.AutoApproveScopeLevel(),
 		BaseDir:              cfg.ApprovedDirectory,
 		TemplatePath:         cfg.TeamTemplatePath,
@@ -139,12 +141,17 @@ func run() int {
 	}()
 	transport := lo.NewTransport(api, cfg.LOEnableDrafts).WithDocuments(cfg.LOEnableDocuments)
 	postRun := autonomy.Build(cfg, logger)
+	// The outbox sweep is what turns an agent's file into a delivery. Always constructed, as
+	// in the Telegram and VK binaries: the core already skips the sweep when the transport
+	// reports it cannot send documents, so the flag is read in exactly one place.
+	outbox := chat.NewSweeper(ws, cfg.MaxOutboxBytes, cfg.MaxOutboxFiles, logger)
 	svc := chat.New(chat.Config{
 		Runner:     runner,
 		Transport:  transport,
 		Dispatcher: dispatcher,
 		Workspace:  ws,
 		Sessions:   sessions,
+		Outbox:     outbox,
 		Costs:      costs,
 		CostCapUSD: cfg.EffectiveCostCapUSD(),
 		PostRun:    postRun,
@@ -176,7 +183,8 @@ func run() int {
 		},
 	})
 	logger.Info("starting LO adapter", "bot_id", self.ID, "drafts", cfg.LOEnableDrafts, "workspace", cfg.ApprovedDirectory)
-	logger.Info("LO compatibility: text only; /stop replaces buttons; document outbox and native replies disabled")
+	logger.Info("LO compatibility: /stop replaces buttons; native replies disabled",
+		"documents", cfg.LOEnableDocuments)
 	if err := receiver.Run(ctx); err != nil && ctx.Err() == nil {
 		logger.Error("LO adapter stopped", "error", err)
 		return 1

--- a/cmd/flock-lo/main.go
+++ b/cmd/flock-lo/main.go
@@ -137,7 +137,7 @@ func run() int {
 			logger.Warn("dispatcher drain", "error", err)
 		}
 	}()
-	transport := lo.NewTransport(api, cfg.LOEnableDrafts)
+	transport := lo.NewTransport(api, cfg.LOEnableDrafts).WithDocuments(cfg.LOEnableDocuments)
 	postRun := autonomy.Build(cfg, logger)
 	svc := chat.New(chat.Config{
 		Runner:     runner,

--- a/docs/lo-telegram-compatibility.md
+++ b/docs/lo-telegram-compatibility.md
@@ -31,8 +31,8 @@ Flock live delivery remains to be verified with a dedicated bot token.
 | Native quoted reply | `reply_parameters` and legacy reply fields rejected | Completion notice is a separate message; inbound quoted text is included in the prompt when supplied |
 | Inbound photos | `getFile` returns a `file_path` for photos; bytes at `<base>/file/bot<token>/<file_path>` | Largest size downloaded into the chat's uploads dir, capped by `MAX_UPLOAD_BYTES`; the prompt carries the saved path AND the picture itself travels as a vision block, so the model sees it rather than a file name. The saved name is corrected to what the bytes actually are, and bytes that are not an image at all are refused with the download-failure sentence |
 | Inbound audio / video | `getFile` answers the reference WITHOUT a `file_path` (no address for the bytes exists) | Per-kind notice; the run is refused rather than answered without the file |
-| Inbound documents | `getFile` returns a `file_path` for documents; bytes at `<base>/file/bot<token>/<file_path>` | Downloaded into the chat's uploads dir under the sender's own file name, capped by `MAX_UPLOAD_BYTES`; a nameless document is renamed from its declared MIME type; a reference served without bytes gets its own notice |
-| Outbound files / generated artifacts | `sendDocument` accepts a multipart upload where it is implemented and answers 501 where it is not | Opt-in `LO_ENABLE_DOCUMENTS`; off by default, and with it off the agent's workspace instructions say the chat cannot deliver attachments so nothing is promised. On, the outbox sweep uploads each artifact after the run |
+| Inbound documents (where implemented) | `getFile` returns a `file_path` for documents; bytes at `<base>/file/bot<token>/<file_path>`. NOT yet on any deployed LO: the server side is LO/messenger#343, still open | Downloaded into the chat's uploads dir under the sender's own file name, capped by `MAX_UPLOAD_BYTES`; a nameless document is renamed from its declared MIME type; a reference served without bytes gets its own notice |
+| Outbound files / generated artifacts (where implemented) | `sendDocument` accepts a multipart upload where it is implemented and answers 501 where it is not. The implementation is LO/messenger#342, still open | Opt-in `LO_ENABLE_DOCUMENTS`; off by default, and with it off the agent's workspace instructions say the chat cannot deliver attachments so nothing is promised. On, the outbox sweep uploads each artifact after the run |
 | Outbound photos | `sendPhoto`'s upload branch answered 500 on the deployments exercised | Not attempted; an image the agent produces is delivered as a document |
 | Provider slash commands | No platform-specific requirement | Non-reserved commands such as `/loop` reach the configured agent backend |
 | Goals and scheduled work | Uses normal bot messaging | Shared Flock goal and scheduler services wired |
@@ -92,6 +92,11 @@ and quoted context. Core tests cover native draft completion and cleanup (includ
 cleanup failure), progress size limits,
 fallback to the persistent anchor and workspace instructions whose file-delivery
 promises follow the documents flag.
+
+The two document rows above describe what the adapter does WHERE the platform serves it. No
+deployed LO does yet — both server changes are open pull requests, named in the rows — which is
+why `LO_ENABLE_DOCUMENTS` is off by default. The validation note below covers this repository's
+own gate, not a live document round trip.
 
 Validation passed on 2026-09-06 using the repository dev-tools image (Go 1.26.6):
 

--- a/docs/lo-telegram-compatibility.md
+++ b/docs/lo-telegram-compatibility.md
@@ -31,7 +31,9 @@ Flock live delivery remains to be verified with a dedicated bot token.
 | Native quoted reply | `reply_parameters` and legacy reply fields rejected | Completion notice is a separate message; inbound quoted text is included in the prompt when supplied |
 | Inbound photos | `getFile` returns a `file_path` for photos; bytes at `<base>/file/bot<token>/<file_path>` | Largest size downloaded into the chat's uploads dir, capped by `MAX_UPLOAD_BYTES`; the prompt carries the saved path AND the picture itself travels as a vision block, so the model sees it rather than a file name. The saved name is corrected to what the bytes actually are, and bytes that are not an image at all are refused with the download-failure sentence |
 | Inbound audio / video | `getFile` answers the reference WITHOUT a `file_path` (no address for the bytes exists) | Per-kind notice; the run is refused rather than answered without the file |
-| Files / generated artifacts | `sendDocument` is a stub (501); `sendPhoto`'s upload branch answered 500 on the deployments exercised | Document outbox disabled; each unreadable attachment kind gets its own notice |
+| Inbound documents | `getFile` returns a `file_path` for documents; bytes at `<base>/file/bot<token>/<file_path>` | Downloaded into the chat's uploads dir under the sender's own file name, capped by `MAX_UPLOAD_BYTES`; a nameless document is renamed from its declared MIME type; a reference served without bytes gets its own notice |
+| Outbound files / generated artifacts | `sendDocument` accepts a multipart upload where it is implemented and answers 501 where it is not | Opt-in `LO_ENABLE_DOCUMENTS`; off by default, and with it off the agent's workspace instructions say the chat cannot deliver attachments so nothing is promised. On, the outbox sweep uploads each artifact after the run |
+| Outbound photos | `sendPhoto`'s upload branch answered 500 on the deployments exercised | Not attempted; an image the agent produces is delivered as a document |
 | Provider slash commands | No platform-specific requirement | Non-reserved commands such as `/loop` reach the configured agent backend |
 | Goals and scheduled work | Uses normal bot messaging | Shared Flock goal and scheduler services wired |
 | Rate limits | 429 with `retry_after` | Progress and final-delivery backoff use the LO classifier; polling backs off too |
@@ -49,9 +51,10 @@ LO draft support is private-chat-only; groups use the persistent anchor fallback
 2. **Callbacks and keyboards:** implement `reply_markup`, callback update delivery,
    `answerCallbackQuery`, and markup edits end to end. This restores inline Stop,
    confirmation and navigation flows used by existing Telegram bots.
-3. **Documents and inbound media:** complete upload, reusable file IDs, download,
-   metadata and limits. Flock needs repository artifacts and screenshots, not only
-   photo sends. The adapter will need corresponding download/outbox wiring.
+3. **Documents and inbound media:** inbound photos and documents and the outbound
+   document upload are done, the latter behind `LO_ENABLE_DOCUMENTS`. What remains
+   is the rest of the media surface: voice messages, media groups, and the
+   `sendPhoto` upload branch, none of which the adapter can use yet.
 4. **Formatting and reply parity:** wire the adapter to implemented parse modes/entities
    and complete native reply fields with visible client rendering. Test code blocks, escaping, emoji offsets,
    quote targets and edit behavior, not merely accepted JSON.
@@ -87,8 +90,8 @@ credential redaction, redirect refusal, malformed envelopes, draft identity,
 UTF-16 rejection, inbound gates, ordered polling acknowledgement, webhook conflicts
 and quoted context. Core tests cover native draft completion and cleanup (including cancellation and
 cleanup failure), progress size limits,
-fallback to the persistent anchor and workspace instructions without file-delivery
-promises.
+fallback to the persistent anchor and workspace instructions whose file-delivery
+promises follow the documents flag.
 
 Validation passed on 2026-09-06 using the repository dev-tools image (Go 1.26.6):
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -89,11 +89,15 @@ var (
 // core config is parsed once and reused.
 type Config struct {
 	// LO uses its own credentials and user-ID namespace; no Telegram defaults apply.
-	LOBotToken         string  `env:"LO_BOT_TOKEN"`
-	LOAPIURL           string  `env:"LO_API_URL"`
-	LOAllowedUsers     []int64 `env:"LO_ALLOWED_USERS" envSeparator:","`
-	LOEnableDrafts     bool    `env:"LO_ENABLE_DRAFTS" envDefault:"false"`
-	LORegisterCommands bool    `env:"LO_REGISTER_COMMANDS" envDefault:"false"`
+	LOBotToken     string  `env:"LO_BOT_TOKEN"`
+	LOAPIURL       string  `env:"LO_API_URL"`
+	LOAllowedUsers []int64 `env:"LO_ALLOWED_USERS" envSeparator:","`
+	LOEnableDrafts bool    `env:"LO_ENABLE_DRAFTS" envDefault:"false"`
+	// LOEnableDocuments turns on file delivery to LO. Opt-in because sendDocument is a
+	// platform method a deployment may predate: with it off the agent's files stay in the
+	// workspace instead of being promised and then refused.
+	LOEnableDocuments  bool `env:"LO_ENABLE_DOCUMENTS" envDefault:"false"`
+	LORegisterCommands bool `env:"LO_REGISTER_COMMANDS" envDefault:"false"`
 
 	// Telegram (cmd/flock-telegram). Validated by ValidateTelegram, not env-required.
 	TelegramBotToken    string `env:"TELEGRAM_BOT_TOKEN"`

--- a/internal/fsutil/upload.go
+++ b/internal/fsutil/upload.go
@@ -26,11 +26,16 @@ import (
 // the caller can turn it into one friendly notice.
 var ErrUploadTooLarge = errors.New("uploaded file exceeds the size limit")
 
+// DefaultUploadName is what a name that sanitises to nothing becomes. Exported so a caller can
+// recognise it and substitute something better — an adapter that knows the file's declared type
+// can build a name with an extension, where this package can only avoid an empty one.
+const DefaultUploadName = "upload"
+
 // SanitizeUploadName reduces a client-supplied file name to a safe basename that
 // can never escape the uploads dir: it normalizes Windows-style "\" separators
 // (filepath.Base only handles the OS separator), takes path.Base, drops leading
 // dots so "..", "..." and dotfiles can't traverse or hide, trims whitespace, and
-// falls back to a default when nothing safe remains.
+// falls back to DefaultUploadName when nothing safe remains.
 func SanitizeUploadName(name string) string {
 	// Normalize Windows separators so "..\..\x" collapses too, then take the base.
 	// path.Base operates on slash-separated paths regardless of host OS, so it
@@ -42,7 +47,7 @@ func SanitizeUploadName(name string) string {
 	name = strings.TrimLeft(name, ".")
 	name = strings.TrimSpace(name)
 	if name == "" {
-		return "upload"
+		return DefaultUploadName
 	}
 	return name
 }


### PR DESCRIPTION
Стоит на [#74](https://github.com/duckbugio/flock/pull/74) (входящие фото). Базовая ветка — `feat/lo-media`, после её мержа переставлю на `main`.

## Зачем

Фото-путь показал форму. Документы получают то же самое в обе стороны, и именно это нужно агенту: человек присылает спецификацию, агент отдаёт отчёт.

## Входящие

Документ скачивается как фотография и сохраняет имя, которое дал пользователь, поэтому агент открывает `spec.pdf`, а не безликий идентификатор.

LO, который ещё не умеет отдавать байты документов, отвечает на ссылку БЕЗ `file_path`. Это сообщается как «эта LO не отдаёт ботам байты», а не как неудачное скачивание: человеку, который это читает, нужны разные действия.

Скачивание теперь общее для обоих видов вложений: все исходы читаются одинаково для картинки и для файла, меняется только существительное.

## Исходящие

`SendDocument` загружает файл агента, под флагом `LO_ENABLE_DOCUMENTS`, по умолчанию выключенным.

Флаг, а не проба при старте: `sendDocument` — метод платформы, которого развёртывание может не иметь, и тогда каждый артефакт получает `501`. Проба не отличит «не реализовано» от временного сбоя, а флаг — одно решение в одном месте, которое оператор принимает после апгрейда.

С выключенным флагом `Capabilities` держит `CanSendDocument` в `false`, поэтому обход outbox в ядре не запускается и файлы агента не обещают пользователю, чтобы потом отказать.

Наружу уходит только базовое имя файла: полный путь описал бы файловую систему хоста всем участникам чата.

## Тесты

Документ, доезжающий до агента путём под своим именем; платформа, удерживающая байты; отказ при выключенном флаге; соответствие `Capabilities` флагу; multipart-загрузка с базовым именем; `501`, поднятый как таковой, а не как неудачная отправка; и путь ошибки, доказывающий, что токен бота не попадает в лог.

Гейт: `golangci-lint` без замечаний, `go test -race ./...` зелёный.

## Связь с платформой

Серверная часть — в LO: [LO/messenger#342](https://git.lo.ink/LO/messenger/pulls/342) реализует `sendDocument`, [#343](https://git.lo.ink/LO/messenger/pulls/343) отдаёт боту входящие документы и адрес их байтов. До их выката флаг остаётся выключенным, а входящие документы получают объяснение вместо файла — ровно то поведение, которое здесь и описано.