### PR TITLE
feat(lo): voice input, restart recovery and CI/review followups

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Everything else in [`.env.example`](adapters/telegram/.env.example) has sensible
 | `VK_GROUP_ID` | your community's numeric id (long-poll server + mention parse) |
 | `VK_ALLOWED_USERS` | comma-separated VK user IDs allowed to use the bot |
 
-**LO** has a text-first adapter with its own allow-list and workspace namespace. Its image is published as `ghcr.io/duckbugio/flock-lo`; start it using [`adapters/lo/`](adapters/lo/README.md). The LO entry point does not wire PR-comment polling, CI watch or interrupted-run recovery. See the [LO / Telegram compatibility audit](docs/lo-telegram-compatibility.md) for supported commands, optional streaming, and platform gaps.
+**LO** has a text-first adapter with its own allow-list and workspace namespace. Its image is published as `ghcr.io/duckbugio/flock-lo`; start it using [`adapters/lo/`](adapters/lo/README.md). The LO entry point supports interrupted-run recovery, optional CI watch and Gitea PR-comment polling restricted to its own checked-out branches. Voice input uses the shared transcription providers when enabled. See the [LO / Telegram compatibility audit](docs/lo-telegram-compatibility.md) for supported commands, optional streaming, and platform gaps.
 
 ## Highlights
 

--- a/adapters/lo/README.md
+++ b/adapters/lo/README.md
@@ -64,7 +64,9 @@ startup-check errors remain fatal. `getUpdates`
 retains queued messages, advances the offset after dispatch, and does not request
 callback/edited-message updates it cannot handle. As with ordinary long polling,
 a crash before the next offset acknowledgement can redeliver the last batch;
-this adapter does not promise exactly-once agent execution or automatic resume.
+this adapter does not promise exactly-once agent execution. Interrupted and queued runs
+are persisted and resumed on startup before new messages or background events.
+Startup refuses an unreadable pending store instead of silently losing recovery.
 
 ## Behavior
 
@@ -124,16 +126,13 @@ this adapter does not promise exactly-once agent execution or automatic resume.
   MIME type (`document_<id>.pdf`, and `.bin` for anything outside the short table of types a
   chat carries — `documentExtensions` in `media.go`) — an extensionless path is the same opaque
   id this whole paragraph exists to avoid.
-- **Every other attachment gets its own sentence and stops the run.** Answering the caption
-  without the file it refers to produces a confident answer about nothing, so the adapter
-  refuses instead. The sentences differ by what is actually known. Audio and video answer
-  `getFile` WITHOUT a `file_path` by design — an LO audio is a catalogue track, so no address
-  for the bytes exists — and can only be echoed by reference. Voice, video notes and animations
-  say only that this adapter does not read them yet: the `501` on the platform is about SENDING
-  them, which is the OUTGOING direction, and whether `getFile` serves their bytes is a separate
-  question this change does not answer. Stickers get their own sentence and a different one —
-  the bytes exist, but a sticker carries nothing an agent can act on, so the answer asks for
-  the request as text.
+- **Voice input** uses `ENABLE_VOICE_MESSAGES` and the shared `VOICE_PROVIDER` configuration.
+  Allowed senders pass mention and rate/cost guards before downloading or transcribing.
+  `getFile` must expose bytes, and `MAX_UPLOAD_BYTES` caps both declared and streamed size
+  before the paid transcription call. Empty transcripts, missing bytes and provider failures
+  produce a notice and never start an agent. LO must include the inbound voice relay implementation.
+- **Other unsupported attachments** get a per-kind explanation and stop the run.
+  The adapter does not answer a caption while pretending to have read unavailable media.
 - **Outbound files are opt-in via `LO_ENABLE_DOCUMENTS`.** With it off (the default) the
   outbox sweep stays disabled and agent-created files remain in the workspace — the honest
   behaviour on a LO that predates `sendDocument`, which answers `501`. With it on, artifacts
@@ -145,9 +144,15 @@ this adapter does not promise exactly-once agent execution or automatic resume.
   posts every regular file through `sendDocument`, a screenshot included, which is what the
   workspace's screenshot convention already promises the agent. Native callback buttons, rich
   messages and the interactive star nudge are unavailable.
-- The LO command does not yet wire Telegram's interrupted-run recovery, CI watch
-  or PR-comment polling. These are **Flock adapter gaps**, not missing LO API
-  methods. The scheduler and goal evaluator are supported.
+- Interrupted-run recovery replays the durable per-chat FIFO before polling starts;
+  markers remain until a clean terminal result. A missing old progress message does not block replay.
+- `ENABLE_CI_WATCH` enables the shared GitHub/Gitea watcher; `ENABLE_AUTO_MERGE` retains its
+  explicit opt-in behavior. Watch state lives in the LO namespace by default.
+- Gitea PR-comment polling uses `ENABLE_PR_REVIEW`, `GITEA_API_URL` and `GIT_TOKEN`.
+  Only an exact repository, branch and chat match in the LO workspace can trigger a run.
+  Unowned notifications stay unread. CI and review-triggered runs use the shared autonomy budget.
+  Use separate git accounts for adapters if both consume notifications: older adapters may
+  still acknowledge all routable team notifications from a shared account.
 
 The shared chunker currently measures runes rather than UTF-16. LO advertises a
 conservative 2048-rune limit, guaranteeing every chunk fits 4096 UTF-16 units even

--- a/adapters/lo/receiver.go
+++ b/adapters/lo/receiver.go
@@ -57,7 +57,9 @@ type ReceiverConfig struct {
 	// open them. Nil disables the download and every attachment gets the same explanatory
 	// notice it got before — the adapter must still run where no workspace is wired.
 	Uploads *Uploader
-	Logger  *slog.Logger
+	// Voice is optional; transcription is attempted only after admission and cost guards.
+	Voice  VoiceInput
+	Logger *slog.Logger
 }
 
 // Receiver serially admits updates while the shared dispatcher runs chats concurrently.
@@ -189,20 +191,26 @@ func (r *Receiver) HandleUpdate(ctx context.Context, update Update) {
 	// It costs no network call, no disk write and no agent run, and core/chat's contract is
 	// that a message which produces no work spends no limiter budget. Charging for it would
 	// not even save a message: the guard refusal sends one too.
-	if note := unservedNotice(msg); note != "" {
+	fileID := voiceReference(msg)
+	isVoice := r.cfg.Voice != nil && fileID != ""
+	if note := unservedNotice(msg); !isVoice && note != "" {
 		r.notify(ctx, chatID, note)
 		return
 	}
 	// Guards run BEFORE any attachment work that remains. A rate limit or a spent cost cap
 	// must be paid with a refusal, not with a download: doing the network call and the disk
 	// write first means a capped user still costs bandwidth and storage on every message.
-	if hasServedMedia(msg) || text != "" {
+	if isVoice || hasServedMedia(msg) || text != "" {
 		if r.cfg.Guards != nil {
 			if allowed, reason := r.cfg.Guards(msg.From.ID); !allowed {
 				r.notify(ctx, chatID, reason)
 				return
 			}
 		}
+	}
+	if isVoice {
+		r.handleVoice(ctx, msg, chatID, replyToBot, fileID)
+		return
 	}
 	// Attachments are answered BEFORE the empty-text check: a photo with no caption is a
 	// complete request ("look at this"), and dropping it silently is what made the bot

--- a/adapters/lo/voice.go
+++ b/adapters/lo/voice.go
@@ -1,0 +1,103 @@
+package lo
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/duckbugio/flock/core/voice"
+)
+
+// VoiceInput is the optional receiver seam for speech recognition.
+type VoiceInput interface {
+	Transcribe(ctx context.Context, fileID string) (string, error)
+}
+
+// VoiceTranscriber resolves LO's signed reference and transcribes bounded audio.
+// The download URL remains inside Client, including its credential redaction.
+type VoiceTranscriber struct {
+	source      fileSource
+	transcriber voice.Transcriber
+	maxBytes    int64
+}
+
+// NewVoiceTranscriber uses the shared upload cap when maxBytes is nonpositive.
+func NewVoiceTranscriber(source fileSource, transcriber voice.Transcriber, maxBytes int64) *VoiceTranscriber {
+	if maxBytes <= 0 {
+		maxBytes = defaultMaxUploadBytes
+	}
+	return &VoiceTranscriber{source: source, transcriber: transcriber, maxBytes: maxBytes}
+}
+
+const voiceTimeout = time.Minute
+
+// Transcribe reads the complete bounded recording before calling the configured provider.
+func (v *VoiceTranscriber) Transcribe(ctx context.Context, fileID string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, voiceTimeout)
+	defer cancel()
+	file, err := v.source.GetFile(ctx, fileID)
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(file.FilePath) == "" {
+		return "", ErrNoBytes
+	}
+	if file.FileSize > v.maxBytes {
+		return "", ErrUploadTooLarge
+	}
+	body, err := v.source.Download(ctx, file.FilePath)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = body.Close() }()
+	// Detect overflow before invoking a paid provider. A LimitReader alone silently
+	// truncates audio and would turn an incomplete recording into a partial request.
+	audio, err := io.ReadAll(io.LimitReader(body, v.maxBytes+1))
+	if err != nil {
+		return "", fmt.Errorf("read voice: %w", err)
+	}
+	if int64(len(audio)) > v.maxBytes {
+		return "", ErrUploadTooLarge
+	}
+	if len(audio) == 0 {
+		return "", errors.New("empty voice recording")
+	}
+	return v.transcriber.Transcribe(ctx, bytes.NewReader(audio), "voice.ogg")
+}
+
+// voiceReference keeps unknown voice fields forward-compatible, but requires a real ID.
+func voiceReference(msg *Message) string {
+	var attachment Attachment
+	if json.Unmarshal(msg.Voice, &attachment) != nil {
+		return ""
+	}
+	return strings.TrimSpace(attachment.FileID)
+}
+
+func (r *Receiver) handleVoice(ctx context.Context, msg *Message, chatID string, replyToBot bool, fileID string) {
+	transcript, err := r.cfg.Voice.Transcribe(ctx, fileID)
+	if err != nil {
+		r.cfg.Logger.Warn("lo: voice transcription failed", "error", err)
+		note := "Sorry, I couldn't transcribe that voice message. Please send the request as text."
+		if errors.Is(err, ErrNoBytes) {
+			note = "This LO deployment does not provide voice downloads yet. Please send the request as text."
+		}
+		if errors.Is(err, ErrUploadTooLarge) {
+			note = "That voice message is too large. Please send a shorter recording."
+		}
+		r.notify(ctx, chatID, note)
+		return
+	}
+	transcript = strings.TrimSpace(transcript)
+	if transcript == "" {
+		r.notify(ctx, chatID, "Sorry, I couldn't make out that voice message. Please send the request as text.")
+		return
+	}
+	r.cfg.Service.Handle(ctx, chatID, msg.From.ID, strconv.FormatInt(msg.ID, 10), replyPrompt(msg, replyToBot, transcript))
+}

--- a/adapters/lo/voice_test.go
+++ b/adapters/lo/voice_test.go
@@ -1,0 +1,93 @@
+package lo_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/duckbugio/flock/adapters/lo"
+)
+
+type speechSpy struct {
+	bytes string
+	calls int
+}
+
+func (s *speechSpy) Transcribe(_ context.Context, audio io.Reader, _ string) (string, error) {
+	raw, err := io.ReadAll(audio)
+	s.bytes = string(raw)
+	s.calls++
+	return "review the changes", err
+}
+
+func TestVoiceDownloadAndTranscription(t *testing.T) {
+	t.Parallel()
+	api, _ := photoAPI(t, "OggSvoice")
+	speech := &speechSpy{}
+	v := lo.NewVoiceTranscriber(api, speech, 100)
+	text, err := v.Transcribe(t.Context(), "voice-ref")
+	if err != nil || text != "review the changes" || speech.bytes != "OggSvoice" {
+		t.Fatalf("text=%q bytes=%q err=%v", text, speech.bytes, err)
+	}
+}
+
+func TestOversizeVoiceNeverCallsProvider(t *testing.T) {
+	t.Parallel()
+	api, _ := photoAPI(t, "OggSvoice")
+	speech := &speechSpy{}
+	_, err := lo.NewVoiceTranscriber(api, speech, 4).Transcribe(t.Context(), "voice-ref")
+	if !errors.Is(err, lo.ErrUploadTooLarge) || speech.calls != 0 {
+		t.Fatalf("err=%v calls=%d", err, speech.calls)
+	}
+}
+
+type voiceInputSpy struct {
+	calls int
+	text  string
+	err   error
+}
+
+func (v *voiceInputSpy) Transcribe(context.Context, string) (string, error) {
+	v.calls++
+	return v.text, v.err
+}
+
+func TestVoiceAdmissionAndFailures(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name                string
+		allowed, guard      bool
+		transcript          string
+		err                 error
+		wantCalls, wantRuns int
+	}{
+		{"success", true, true, "review changes", nil, 1, 1},
+		{"denied user", false, true, "review changes", nil, 0, 0},
+		{"cost cap", true, false, "review changes", nil, 0, 0},
+		{"empty transcript", true, true, " ", nil, 1, 0},
+		{"download failure", true, true, "", lo.ErrNoBytes, 1, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			api, _ := photoAPI(t, "")
+			svc := &serviceSpy{}
+			speech := &voiceInputSpy{text: tc.transcript, err: tc.err}
+			receiver := lo.NewReceiver(lo.ReceiverConfig{
+				Service: svc, Client: api, Transport: lo.NewTransport(api, false),
+				IsAllowed: func(int64) bool { return tc.allowed },
+				Guards:    func(int64) (bool, string) { return tc.guard, "budget spent" }, Voice: speech,
+			})
+			msg := inbound("")
+			msg.Voice = lo.RawAttachment("voice-ref")
+			receiver.HandleUpdate(t.Context(), lo.Update{Message: msg})
+			if speech.calls != tc.wantCalls || len(svc.prompts) != tc.wantRuns {
+				t.Fatalf("calls=%d prompts=%v", speech.calls, svc.prompts)
+			}
+			if tc.wantRuns > 0 && !strings.Contains(svc.prompts[0], tc.transcript) {
+				t.Fatalf("transcript lost: %v", svc.prompts)
+			}
+		})
+	}
+}

--- a/cmd/flock-lo/main.go
+++ b/cmd/flock-lo/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/duckbugio/flock/core/cost"
 	"github.com/duckbugio/flock/core/dispatch"
 	"github.com/duckbugio/flock/core/gitsetup"
+	"github.com/duckbugio/flock/core/pending"
 	"github.com/duckbugio/flock/core/ratelimit"
 	"github.com/duckbugio/flock/core/schedule"
 	"github.com/duckbugio/flock/core/session"
@@ -126,6 +127,11 @@ func run() int {
 		logger.Error("open costs", "error", err)
 		return 1
 	}
+	pendings, err := pending.Open(cfg.PendingStoreFile())
+	if err != nil {
+		logger.Error("open interrupted-run queue", "error", err)
+		return 1
+	}
 	limiter := ratelimit.New(cfg.RateLimitRequests, cfg.RateLimitWindow())
 	dispatcher := dispatch.New(cfg.MaxConcurrentChatRuns)
 	if cfg.ShutdownDrainClamped() {
@@ -151,6 +157,7 @@ func run() int {
 		Dispatcher: dispatcher,
 		Workspace:  ws,
 		Sessions:   sessions,
+		Pending:    pendings,
 		Outbox:     outbox,
 		Costs:      costs,
 		CostCapUSD: cfg.EffectiveCostCapUSD(),
@@ -160,12 +167,15 @@ func run() int {
 		RetryAfter: lo.RetryAfter,
 		Logger:     logger,
 	})
+	// Replay before any background or user submissions can enter the dispatcher.
+	resumePending(ctx, transport, svc, pendings, logger)
 	autonomy.StartFollowups(ctx, svc, postRun, logger)
+	startReviewPoller(ctx, cfg, svc, logger)
+	startCIWatch(ctx, cfg, transport, svc, logger)
 	scheduler := startScheduler(ctx, cfg, svc, logger)
 	// Inbound photo downloads. Always constructed: the uploader writes into the per-chat
-	// uploads directory, a sibling of the cloned repositories, so a user's image can never
-	// be swept into a commit. LO serves bytes for photos only — every other attachment gets
-	// an explanatory notice instead (see lo.Receiver.attachments).
+	// uploads directory, a sibling of the cloned repositories, so user media is not
+	// swept into a commit. Missing media bytes get a specific explanatory notice.
 	uploads := lo.NewUploader(api, ws, cfg.MaxUploadBytes, logger)
 	receiver := lo.NewReceiver(lo.ReceiverConfig{
 		Service:        svc,
@@ -177,13 +187,14 @@ func run() int {
 		RequireMention: cfg.RequireGroupMention,
 		Scheduler:      scheduler,
 		Uploads:        uploads,
+		Voice:          buildVoice(cfg, api, logger),
 		Logger:         logger,
 		Guards: func(id int64) (bool, string) {
 			return chat.CheckGuards(limiter, costs, chat.GuardConfig{CostCapUSD: cfg.EffectiveCostCapUSD()}, id)
 		},
 	})
 	logger.Info("starting LO adapter", "bot_id", self.ID, "drafts", cfg.LOEnableDrafts, "workspace", cfg.ApprovedDirectory)
-	logger.Info("LO compatibility: text and inbound photos; /stop replaces buttons; native replies disabled",
+	logger.Info("LO compatibility: text, photos, documents and optional voice; /stop replaces buttons; native replies disabled",
 		"documents", cfg.LOEnableDocuments)
 	if err := receiver.Run(ctx); err != nil && ctx.Err() == nil {
 		logger.Error("LO adapter stopped", "error", err)

--- a/cmd/flock-lo/recovery.go
+++ b/cmd/flock-lo/recovery.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"strconv"
+	"time"
+
+	"github.com/duckbugio/flock/core/pending"
+)
+
+const anchorCleanupTimeout = 5 * time.Second
+
+type pendingResumer interface {
+	ResumePending(chatID string, marker pending.Marker)
+}
+
+type anchorDeleter interface {
+	Delete(ctx context.Context, chatID, messageID string) error
+}
+
+// Resume only markers admitted by this adapter and persisted in its own store.
+// Keep each marker until the shared runtime records a clean terminal result.
+func resumePending(ctx context.Context, transport anchorDeleter, svc pendingResumer, store pending.Store, logger *slog.Logger) {
+	for chatID, queue := range store.All() {
+		id, err := strconv.ParseInt(chatID, 10, 64)
+		if err != nil || id == 0 {
+			logger.Warn("pending: invalid LO chat id; retaining queue", "chat_id", chatID)
+			continue
+		}
+		for _, marker := range queue {
+			if ctx.Err() != nil {
+				return
+			}
+			if marker.AnchorMsgID != "" {
+				cleanup, cancel := context.WithTimeout(ctx, anchorCleanupTimeout)
+				err := transport.Delete(cleanup, chatID, marker.AnchorMsgID)
+				cancel()
+				if err != nil {
+					logger.Debug("delete dangling LO anchor on resume", "chat_id", chatID, "error", err)
+				}
+			}
+			if ctx.Err() != nil {
+				return
+			}
+			svc.ResumePending(chatID, marker)
+		}
+	}
+}

--- a/cmd/flock-lo/recovery_test.go
+++ b/cmd/flock-lo/recovery_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"path/filepath"
+	"testing"
+
+	"github.com/duckbugio/flock/core/pending"
+)
+
+type recoveryRecorder struct {
+	markers []pending.Marker
+	deletes int
+}
+
+func (r *recoveryRecorder) ResumePending(_ string, marker pending.Marker) {
+	r.markers = append(r.markers, marker)
+}
+
+func (r *recoveryRecorder) Delete(_ context.Context, _, _ string) error {
+	r.deletes++
+	return errors.New("already deleted")
+}
+
+func TestResumePendingKeepsDurableFIFODespiteStaleAnchor(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pending.json")
+	store, err := pending.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, prompt := range []string{"first", "second"} {
+		if _, err := store.Enqueue("42", pending.Marker{Prompt: prompt, AnchorMsgID: "12"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := store.Enqueue("invalid", pending.Marker{Prompt: "retain invalid"}); err != nil {
+		t.Fatal(err)
+	}
+	restarted, err := pending.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	recorder := &recoveryRecorder{}
+	resumePending(context.Background(), recorder, recorder, restarted, slog.New(slog.DiscardHandler))
+	if len(recorder.markers) != 2 || recorder.markers[0].Prompt != "first" ||
+		recorder.markers[1].Prompt != "second" || recorder.deletes != 2 {
+		t.Fatalf("replay = %+v", recorder)
+	}
+	retained, err := pending.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(retained.All()["42"]) != 2 || len(retained.All()["invalid"]) != 1 {
+		t.Fatal("replay removed durable markers before clean terminal")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	resumePending(ctx, recorder, recorder, restarted, slog.New(slog.DiscardHandler))
+	if len(recorder.markers) != 2 || recorder.deletes != 2 {
+		t.Fatal("shutdown replayed more work")
+	}
+}

--- a/cmd/flock-lo/voice.go
+++ b/cmd/flock-lo/voice.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/duckbugio/flock/adapters/lo"
+	"github.com/duckbugio/flock/core/voice"
+	"github.com/duckbugio/flock/internal/config"
+)
+
+func buildVoice(cfg config.Config, api *lo.Client, logger *slog.Logger) lo.VoiceInput {
+	if !cfg.EnableVoiceMessages {
+		return nil
+	}
+	transcriber, err := voice.New(voice.Config{
+		Provider: cfg.VoiceProvider, MistralAPIKey: cfg.MistralAPIKey, OpenAIAPIKey: cfg.OpenAIAPIKey,
+		MistralModel: cfg.VoiceMistralModel, OpenAIModel: cfg.VoiceOpenAIModel, LocalCommand: cfg.VoiceLocalCommand,
+		HTTPClient: &http.Client{Timeout: time.Minute}, Logger: logger,
+	})
+	if err != nil {
+		logger.Warn("LO voice transcription disabled", "error", err)
+		return nil
+	}
+	logger.Info("LO voice transcription enabled", "provider", cfg.VoiceProvider)
+	return lo.NewVoiceTranscriber(api, transcriber, cfg.MaxUploadBytes)
+}

--- a/cmd/flock-lo/watch.go
+++ b/cmd/flock-lo/watch.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"strings"
+
+	"github.com/duckbugio/flock/adapters/lo"
+	"github.com/duckbugio/flock/core/chat"
+	"github.com/duckbugio/flock/core/ciwatch"
+	"github.com/duckbugio/flock/core/poller"
+	"github.com/duckbugio/flock/internal/config"
+)
+
+func ownsReview(base, chatID, repo, branch string) bool {
+	id, err := strconv.ParseInt(chatID, 10, 64)
+	if err != nil || id == 0 {
+		return false
+	}
+	for _, checkout := range ciwatch.Discover(base) {
+		if checkout.ChatID == chatID && checkout.Repo == repo && checkout.Branch == branch {
+			return true
+		}
+	}
+	return false
+}
+
+func startReviewPoller(ctx context.Context, cfg config.Config, svc *chat.Service, logger *slog.Logger) {
+	if !cfg.PollerEnabled() {
+		return
+	}
+	out := make(chan poller.PRComment)
+	go func() {
+		err := poller.Run(ctx, poller.Config{
+			BaseURL: cfg.GiteaAPIURL, Token: cfg.GitToken, SelfLogin: strings.ToLower(cfg.GitUser),
+			Interval: cfg.GiteaPollDuration(), Logger: logger,
+			Accept: func(chatID, repo, branch string) bool { return ownsReview(cfg.ApprovedDirectory, chatID, repo, branch) },
+		}, out)
+		if err != nil && ctx.Err() == nil {
+			logger.Error("LO review poller stopped", "error", err)
+		}
+	}()
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case comment := <-out:
+				svc.InjectAuto(ctx, comment.ChatID, fmt.Sprintf(
+					"A reviewer left a comment on pull request #%d in %s.\n\nComment by @%s:\n%s\n\n"+
+						"Address this review following the Phase 2 review workflow in the existing PR.",
+					comment.PRIndex, comment.Repo, comment.Author, comment.Body))
+			}
+		}
+	}()
+}
+
+func startCIWatch(ctx context.Context, cfg config.Config, transport *lo.Transport, svc *chat.Service, logger *slog.Logger) {
+	if !cfg.CIWatchEnabled() {
+		return
+	}
+	var host ciwatch.Host
+	if cfg.CIWatchGitHub() {
+		host = ciwatch.NewGitHub(cfg.GitToken, nil)
+	} else {
+		host = ciwatch.NewGitea(cfg.GiteaAPIURL, cfg.GitToken, nil)
+	}
+	state, err := ciwatch.OpenState(cfg.CIStateFile())
+	if err != nil {
+		logger.Error("open LO ci-watch state; watcher disabled", "error", err)
+		return
+	}
+	out := make(chan ciwatch.Event)
+	go func() {
+		err := ciwatch.Run(ctx, ciwatch.Config{
+			BaseDir: cfg.ApprovedDirectory, Host: host,
+			Interval: cfg.CIPollDuration(), AutoMerge: cfg.EnableAutoMerge, State: state, Logger: logger,
+		}, out)
+		if err != nil && ctx.Err() == nil {
+			logger.Error("LO CI watch stopped", "error", err)
+		}
+	}()
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case event := <-out:
+				id, err := strconv.ParseInt(event.ChatID, 10, 64)
+				if err != nil || id == 0 {
+					logger.Warn("LO CI watch: invalid chat id", "chat_id", event.ChatID)
+					continue
+				}
+				switch event.Kind {
+				case ciwatch.CIFailed:
+					svc.InjectAuto(ctx, event.ChatID, formatCIFailure(event))
+				case ciwatch.CIGreen:
+					svc.InjectAuto(ctx, event.ChatID, formatCIGreen(event))
+				case ciwatch.PRMerged:
+					_, err := transport.Send(ctx, event.ChatID, fmt.Sprintf("CI is green on %s (%s) — auto-merged PR #%d.",
+						event.Branch, event.Repo, event.PRIndex), "", false)
+					if err != nil {
+						logger.Warn("announce LO PR merge", "chat_id", event.ChatID, "error", err)
+					}
+				}
+			}
+		}
+	}()
+}
+
+// shortSHALen is how many SHA characters the CI fix-up prompt shows.
+const shortSHALen = 10
+
+// formatCIFailure builds the injected prompt for a red build. Neutral English,
+// no token, mirrors formatPRComment's tone.
+func formatCIFailure(ev ciwatch.Event) string {
+	sha := ev.SHA
+	if len(sha) > shortSHALen {
+		sha = sha[:shortSHALen]
+	}
+	detail := ev.Detail
+	if detail == "" {
+		detail = "no failing-check details were reported"
+	}
+	return fmt.Sprintf(
+		"CI is RED on branch %s in %s (commit %s) — %s.\n\n"+
+			"Read the failing check logs via the git host, reproduce the failure locally with the repo's "+
+			"own runner, fix it (never weaken or skip tests to get green), and push the fix to the SAME branch.",
+		ev.Branch, ev.Repo, sha, detail)
+}
+
+// formatCIGreen builds the injected prompt for a green build. Its whole job is
+// to WAKE the session: an agent that told its user "I'll report when CI
+// finishes" has no other wake-up signal for success (the poller only relays
+// new PR comments), so a green build would otherwise end the conversation
+// until the user pings.
+func formatCIGreen(ev ciwatch.Event) string {
+	sha := ev.SHA
+	if len(sha) > shortSHALen {
+		sha = sha[:shortSHALen]
+	}
+	return fmt.Sprintf(
+		"CI completed SUCCESSFULLY on branch %s in %s (commit %s).\n\n"+
+			"If you told the user you would report the CI result, do that now, in their language. "+
+			"Otherwise confirm the green build briefly and continue any follow-up you deferred on it "+
+			"(e.g. asking the human to merge). Do not re-run the checks.",
+		ev.Branch, ev.Repo, sha)
+}

--- a/cmd/flock-lo/watch_test.go
+++ b/cmd/flock-lo/watch_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReviewOwnershipRequiresLOCheckoutAndExactBranch(t *testing.T) {
+	base := t.TempDir()
+	for _, adapter := range []string{"telegram", "lo"} {
+		gitDir := filepath.Join(base, adapter, "chat_42", "repo", ".git")
+		if err := os.MkdirAll(gitDir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte("ref: refs/heads/duck/42/"+adapter+"-task\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		config := []byte("[remote \"origin\"]\n url = https://git.example/owner/repo.git\n")
+		if err := os.WriteFile(filepath.Join(gitDir, "config"), config, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	loBase := filepath.Join(base, "lo")
+	if !ownsReview(loBase, "42", "owner/repo", "duck/42/lo-task") {
+		t.Fatal("own LO checkout not recognized")
+	}
+	for _, candidate := range []struct{ chatID, repo, branch string }{
+		{"42", "owner/repo", "duck/42/telegram-task"},
+		{"42", "other/repo", "duck/42/lo-task"},
+		{"43", "owner/repo", "duck/42/lo-task"},
+	} {
+		if ownsReview(loBase, candidate.chatID, candidate.repo, candidate.branch) {
+			t.Fatalf("accepted unrelated checkout: %+v", candidate)
+		}
+	}
+}

--- a/core/poller/poller.go
+++ b/core/poller/poller.go
@@ -28,8 +28,13 @@ type PRComment struct {
 	Author  string
 }
 
+// RouteFilter limits notifications to checkouts owned by the receiving adapter.
+// Rejected notifications stay unread so another adapter can consume them.
+type RouteFilter func(chatID, repo, branch string) bool
+
 // Config configures the poller.
 type Config struct {
+	Accept    RouteFilter   // nil preserves unrestricted legacy routing
 	BaseURL   string        // GITEA_API_URL (trailing slash trimmed)
 	Token     string        // GIT_TOKEN — sent as "Authorization: token <token>"
 	SelfLogin string        // GIT_USER, lowercased — comments by this login are ignored (no self-trigger)
@@ -47,6 +52,7 @@ const defaultClientTimeout = 20 * time.Second
 
 // poller holds the resolved runtime state for one Run.
 type poller struct {
+	accept    RouteFilter
 	base      string
 	token     string
 	selfLogin string
@@ -71,6 +77,7 @@ func Run(ctx context.Context, cfg Config, out chan<- PRComment) error {
 		log = slog.Default()
 	}
 	p := &poller{
+		accept:    cfg.Accept,
 		base:      strings.TrimRight(cfg.BaseURL, "/"),
 		token:     cfg.Token,
 		selfLogin: cfg.SelfLogin,
@@ -151,7 +158,9 @@ func (p *poller) pollOnce(ctx context.Context, out chan<- PRComment) {
 func (p *poller) handleThread(ctx context.Context, t *notification, out chan<- PRComment) error {
 	threadID := t.ID.String()
 	if t.Subject.URL == "" {
-		p.markRead(ctx, threadID)
+		if p.accept == nil {
+			p.markRead(ctx, threadID)
+		}
 		return nil
 	}
 
@@ -166,13 +175,20 @@ func (p *poller) handleThread(ctx context.Context, t *notification, out chan<- P
 		// Transient — leave unread, retry next cycle.
 		return nil
 	}
+	repo := pr.Base.Repo.FullName
+	if repo == "" {
+		repo = t.Repository.FullName
+	}
+	ref := pr.Head.Ref
+	chatID, ok := teambranch.ChatID(ref)
+	if p.accept != nil && (!ok || !p.accept(chatID, repo, ref)) {
+		return nil
+	}
 	// Only act on OPEN PRs — the human merges; nothing to fix on a merged/closed PR.
 	if pr.State != "open" || pr.Merged {
 		p.markRead(ctx, threadID)
 		return nil
 	}
-	ref := pr.Head.Ref
-	chatID, ok := teambranch.ChatID(ref)
 	if !ok {
 		p.markRead(ctx, threadID) // not a (routable) team branch — clear it
 		return nil
@@ -194,11 +210,6 @@ func (p *poller) handleThread(ctx context.Context, t *notification, out chan<- P
 	if author != "" && p.selfLogin != "" && author == p.selfLogin {
 		p.markRead(ctx, threadID)
 		return nil
-	}
-
-	repo := pr.Base.Repo.FullName
-	if repo == "" {
-		repo = t.Repository.FullName
 	}
 
 	select {

--- a/core/poller/poller_test.go
+++ b/core/poller/poller_test.go
@@ -43,7 +43,7 @@ func newFakeGitea(t *testing.T, pr pull, c comment) *fakeGitea {
 				"url":                base + "/repos/owner/repo/issues/7",
 				"latest_comment_url": base + "/repos/owner/repo/issues/comments/100",
 			},
-			"repository": map[string]any{"full_name": "owner/repo"},
+			"repository": map[string]any{"full_name": testRepo},
 		}}
 		writeJSON(w, threads)
 	})
@@ -99,7 +99,10 @@ func writeJSON(w http.ResponseWriter, v any) {
 }
 
 // selfLogin is the bot's own Gitea login used across the poller tests.
-const selfLogin = "duckbot"
+const (
+	selfLogin = "duckbot"
+	testRepo  = "owner/repo"
+)
 
 // newPoller builds a poller pointed at the fake server.
 func newPoller(f *fakeGitea) *poller {
@@ -117,7 +120,7 @@ func openPull(ref string) pull {
 	p.Number = 7
 	p.State = "open"
 	p.Head.Ref = ref
-	p.Base.Repo.FullName = "owner/repo"
+	p.Base.Repo.FullName = testRepo
 	return p
 }
 
@@ -139,7 +142,7 @@ func TestPollOnceEmitsComment(t *testing.T) {
 		if c.ChatID != "-5164159101" {
 			t.Errorf("ChatID = %q, want -5164159101", c.ChatID)
 		}
-		if c.Repo != "owner/repo" {
+		if c.Repo != testRepo {
 			t.Errorf("Repo = %q, want owner/repo", c.Repo)
 		}
 		if c.PRIndex != 7 {
@@ -317,5 +320,38 @@ func TestRunCancels(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("Run did not return after cancel")
+	}
+}
+
+func TestRouteFilterLeavesOtherAdapterNotificationUnread(t *testing.T) {
+	for _, state := range []string{"open", "closed"} {
+		t.Run(state, func(t *testing.T) {
+			pr := openPull("duck/42/telegram-task")
+			pr.State = state
+			f := newFakeGitea(t, pr, comment{})
+			p := newPoller(f)
+			p.accept = func(chatID, repo, branch string) bool {
+				if chatID != "42" || repo != testRepo || branch != "duck/42/telegram-task" {
+					t.Fatal("incorrect filter arguments")
+				}
+				return false
+			}
+			out := make(chan PRComment, 1)
+			p.pollOnce(context.Background(), out)
+			if len(out) != 0 || len(f.markedRead()) != 0 {
+				t.Fatal("consumed another adapter's notification")
+			}
+		})
+	}
+}
+
+func TestRouteFilterAcceptsOwnedNotification(t *testing.T) {
+	f := newFakeGitea(t, openPull("duck/42/lo-task"), comment{Body: "review"})
+	p := newPoller(f)
+	p.accept = func(_, _, _ string) bool { return true }
+	out := make(chan PRComment, 1)
+	p.pollOnce(context.Background(), out)
+	if len(out) != 1 || len(f.markedRead()) != 1 {
+		t.Fatal("owned comment was not emitted and acknowledged")
 	}
 }

--- a/docs/lo-telegram-compatibility.md
+++ b/docs/lo-telegram-compatibility.md
@@ -31,8 +31,8 @@ Flock live delivery remains to be verified with a dedicated bot token.
 | Native quoted reply | `reply_parameters` and legacy reply fields rejected | Completion notice is a separate message; inbound quoted text is included in the prompt when supplied |
 | Inbound photos | `getFile` returns a `file_path` for photos; bytes at `<base>/file/bot<token>/<file_path>` | Largest size downloaded into the chat's uploads dir, capped by `MAX_UPLOAD_BYTES`; the prompt carries the saved path AND the picture itself travels as a vision block, so the model sees it rather than a file name. The saved name is corrected to what the bytes actually are, and bytes that are not an image at all are refused with the download-failure sentence |
 | Inbound audio / video | `getFile` answers the reference WITHOUT a `file_path` (no address for the bytes exists) | Per-kind notice; the run is refused rather than answered without the file |
-| Inbound documents (where implemented) | `getFile` returns a `file_path` for documents; bytes at `<base>/file/bot<token>/<file_path>`. NOT yet on any deployed LO: the server side is LO/messenger#343, still open | Downloaded into the chat's uploads dir under the sender's own file name, capped by `MAX_UPLOAD_BYTES`; a nameless document is renamed from its declared MIME type; a reference served without bytes gets its own notice |
-| Outbound files / generated artifacts (where implemented) | `sendDocument` accepts a multipart upload where it is implemented and answers 501 where it is not. The implementation is LO/messenger#342, still open | Opt-in `LO_ENABLE_DOCUMENTS`; off by default, and with it off the agent's workspace instructions say the chat cannot deliver attachments so nothing is promised. On, the outbox sweep uploads each artifact after the run |
+| Inbound documents (where implemented) | `getFile` returns a `file_path` for documents; bytes at `<base>/file/bot<token>/<file_path>`. Server implementation merged as LO/messenger#343; live acceptance remains to be verified | Downloaded into the chat's uploads dir under the sender's own file name, capped by `MAX_UPLOAD_BYTES`; a nameless document is renamed from its declared MIME type; a reference served without bytes gets its own notice |
+| Outbound files / generated artifacts (where implemented) | `sendDocument` accepts a multipart upload where it is implemented and answers 501 where it is not. Server implementation merged as LO/messenger#342; live acceptance remains to be verified | Opt-in `LO_ENABLE_DOCUMENTS`; off by default, and with it off the agent's workspace instructions say the chat cannot deliver attachments so nothing is promised. On, the outbox sweep uploads each artifact after the run |
 | Outbound photos | `sendPhoto`'s upload branch answered 500 on the deployments exercised | Not attempted; an image the agent produces is delivered as a document |
 | Provider slash commands | No platform-specific requirement | Non-reserved commands such as `/loop` reach the configured agent backend |
 | Goals and scheduled work | Uses normal bot messaging | Shared Flock goal and scheduler services wired |
@@ -53,8 +53,8 @@ LO draft support is private-chat-only; groups use the persistent anchor fallback
    confirmation and navigation flows used by existing Telegram bots.
 3. **Documents and inbound media:** inbound photos and documents and the outbound
    document upload are done, the latter behind `LO_ENABLE_DOCUMENTS`. What remains
-   is the rest of the media surface: voice messages, media groups, and the
-   `sendPhoto` upload branch, none of which the adapter can use yet.
+   is deployed acceptance for voice input, media groups and the `sendPhoto` upload branch.
+   The adapter now supports voice transcription when enabled and served by the platform.
 4. **Formatting and reply parity:** wire the adapter to implemented parse modes/entities
    and complete native reply fields with visible client rendering. Test code blocks, escaping, emoji offsets,
    quote targets and edit behavior, not merely accepted JSON.
@@ -70,9 +70,9 @@ its own integration test and is outside this chatbot adapter.
 
 These are adapter/runtime limitations, not evidence of missing LO endpoints:
 
-- The LO entry point does not yet wire Flock's PR-comment polling, CI watcher,
-  pending-run restart recovery or star nudges. Do not advertise full operational
-  parity with the Telegram entry point.
+- Interrupted-run recovery, CI watch and scoped Gitea PR-comment polling are wired.
+  Review-triggered runs and CI events use the shared autonomy budget. Star nudges still
+  require callback support. Production acceptance remains separate from local contract tests.
 - Polling advances its in-memory offset after admission, not after an agent run
   completes. A restart can redeliver the last unacknowledged batch; this is not an
   exactly-once job queue. Run one polling instance per bot token.
@@ -93,10 +93,9 @@ cleanup failure), progress size limits,
 fallback to the persistent anchor and workspace instructions whose file-delivery
 promises follow the documents flag.
 
-The two document rows above describe what the adapter does WHERE the platform serves it. No
-deployed LO does yet — both server changes are open pull requests, named in the rows — which is
-why `LO_ENABLE_DOCUMENTS` is off by default. The validation note below covers this repository's
-own gate, not a live document round trip.
+The document rows describe behavior where the platform serves those methods. Both server
+changes are merged; source merge and publication do not establish a live document round trip.
+`LO_ENABLE_DOCUMENTS` remains off until the operator verifies the deployment.
 
 Validation passed on 2026-09-06 using the repository dev-tools image (Go 1.26.6):
 


### PR DESCRIPTION
LO bots can now transcribe voice input using Flock's configured speech provider, resume queued and interrupted runs after restart, and react to CI results and Gitea PR reviews. Voice downloads enforce the upload cap before calling the provider; admission and rate/cost guards run first.

Recovery uses the existing durable per-chat queue and runs before new submissions. Review notifications must match an exact checkout in the LO workspace before acknowledgement, keeping unrelated adapters' notifications unread. CI and review events use the shared autonomy budget; auto-merge remains opt-in.

Validation: canonical dev-tools Go 1.26.6 `task default` and `task security-scan` pass, including race tests. Added HTTP voice/size/admission tests, durable restart/FIFO/cancellation tests, and cross-adapter review-routing tests. Platform source for documents and outbound voice is merged; deployed inbound voice and real bot acceptance remain separate rollout checks. Polling does not promise exactly-once execution.
