### PR TITLE
fix(lo): keep polling responsive during durable voice processing

### DIFF
--- a/adapters/lo/README.md
+++ b/adapters/lo/README.md
@@ -68,6 +68,14 @@ this adapter does not promise exactly-once agent execution. Interrupted and queu
 are persisted and resumed on startup before new messages or background events.
 Startup refuses an unreadable pending store instead of silently losing recovery.
 
+With voice input enabled, raw message references are persisted separately in
+`voice-inputs.json` before asynchronous transcription. Up to 32 voice messages
+can wait across chats; excess requests receive a busy notice. Transcription does
+not block polling, `/stop`, or `/new`. Both commands cancel that chat's voice
+queue, including late provider results. Restart replays interrupted preparation
+after checking the sender's current access. A crash during the handoff to the
+agent's pending store can replay work; this is at-least-once recovery.
+
 ## Behavior
 
 - Private chats and groups; group prompts require an exact `@botname` token or

--- a/adapters/lo/commands.go
+++ b/adapters/lo/commands.go
@@ -20,8 +20,8 @@ const HelpText = `Flock LO assistant
 /schedule — manage scheduled jobs
 
 Send text to work with the assistant. Use /stop instead of a Stop button.
-Send a photo, with or without a caption, and I will look at it. Other attachments,
-rich messages and native replies are not supported yet.`
+Send a photo or document to work with its contents. Voice messages are transcribed
+when enabled. Rich messages and native replies are not supported yet.`
 
 func (r *Receiver) reserved(ctx context.Context, chatID string, userID int64, name, args string) {
 	switch name {
@@ -29,11 +29,13 @@ func (r *Receiver) reserved(ctx context.Context, chatID string, userID int64, na
 		r.notify(ctx, chatID, HelpText)
 	case "stop":
 		text := "No active run."
-		if r.cfg.Service.StopChat(chatID) {
+		voiceStopped := r.cancelVoice(chatID)
+		if r.cfg.Service.StopChat(chatID) || voiceStopped {
 			text = "Stopping the current run."
 		}
 		r.notify(ctx, chatID, text)
 	case "new":
+		r.cancelVoice(chatID)
 		if err := r.cfg.Service.NewSession(chatID); err != nil {
 			r.cfg.Logger.Warn("lo: reset session failed", "error", err)
 			r.notify(ctx, chatID, "Could not reset the session. Please retry.")

--- a/adapters/lo/receiver.go
+++ b/adapters/lo/receiver.go
@@ -11,11 +11,14 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/duckbugio/flock/core/agent"
 	"github.com/duckbugio/flock/core/chat"
+	"github.com/duckbugio/flock/core/dispatch"
 	"github.com/duckbugio/flock/core/goal"
+	"github.com/duckbugio/flock/core/pending"
 	"github.com/duckbugio/flock/core/schedule"
 	"github.com/duckbugio/flock/internal/fsutil"
 )
@@ -58,12 +61,19 @@ type ReceiverConfig struct {
 	// notice it got before — the adapter must still run where no workspace is wired.
 	Uploads *Uploader
 	// Voice is optional; transcription is attempted only after admission and cost guards.
-	Voice  VoiceInput
-	Logger *slog.Logger
+	Voice VoiceInput
+	// VoiceStore enables bounded, durable asynchronous transcription.
+	VoiceStore       pending.Store
+	VoiceConcurrency int
+	Logger           *slog.Logger
 }
 
 // Receiver serially admits updates while the shared dispatcher runs chats concurrently.
-type Receiver struct{ cfg ReceiverConfig }
+type Receiver struct {
+	cfg       ReceiverConfig
+	voiceJobs *dispatch.Dispatcher
+	voiceMu   sync.Mutex
+}
 
 // NewReceiver defaults to denying users unless an allow-list is wired.
 func NewReceiver(cfg ReceiverConfig) *Receiver {
@@ -76,12 +86,20 @@ func NewReceiver(cfg ReceiverConfig) *Receiver {
 	if cfg.Logger == nil {
 		cfg.Logger = slog.Default()
 	}
-	return &Receiver{cfg: cfg}
+	receiver := &Receiver{cfg: cfg}
+	if cfg.Voice != nil && cfg.VoiceStore != nil {
+		receiver.voiceJobs = dispatch.New(cfg.VoiceConcurrency)
+	}
+	return receiver
 }
 
 // Run uses normal positive-offset acknowledgement, retaining queued updates on startup.
 // Only one polling process should run for a bot token; persistent conflicts stop polling.
 func (r *Receiver) Run(ctx context.Context) error {
+	if r.voiceJobs != nil {
+		defer r.voiceJobs.Close()
+		r.resumeVoice(ctx)
+	}
 	var offset int64
 	conflicts := 0
 	for ctx.Err() == nil {
@@ -209,6 +227,10 @@ func (r *Receiver) HandleUpdate(ctx context.Context, update Update) {
 		}
 	}
 	if isVoice {
+		if r.voiceJobs != nil {
+			r.queueVoice(ctx, msg, chatID, replyToBot, fileID)
+			return
+		}
 		r.handleVoice(ctx, msg, chatID, replyToBot, fileID)
 		return
 	}

--- a/adapters/lo/voice.go
+++ b/adapters/lo/voice.go
@@ -82,6 +82,9 @@ func voiceReference(msg *Message) string {
 
 func (r *Receiver) handleVoice(ctx context.Context, msg *Message, chatID string, replyToBot bool, fileID string) {
 	transcript, err := r.cfg.Voice.Transcribe(ctx, fileID)
+	if ctx.Err() != nil {
+		return
+	}
 	if err != nil {
 		r.cfg.Logger.Warn("lo: voice transcription failed", "error", err)
 		note := "Sorry, I couldn't transcribe that voice message. Please send the request as text."
@@ -97,6 +100,12 @@ func (r *Receiver) handleVoice(ctx context.Context, msg *Message, chatID string,
 	transcript = strings.TrimSpace(transcript)
 	if transcript == "" {
 		r.notify(ctx, chatID, "Sorry, I couldn't make out that voice message. Please send the request as text.")
+		return
+	}
+	// Serialize the handoff with /stop so a late provider response cannot start a new run.
+	r.voiceMu.Lock()
+	defer r.voiceMu.Unlock()
+	if ctx.Err() != nil {
 		return
 	}
 	r.cfg.Service.Handle(ctx, chatID, msg.From.ID, strconv.FormatInt(msg.ID, 10), replyPrompt(msg, replyToBot, transcript))

--- a/adapters/lo/voice_queue.go
+++ b/adapters/lo/voice_queue.go
@@ -1,0 +1,106 @@
+package lo
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strconv"
+	"time"
+
+	"github.com/duckbugio/flock/core/dispatch"
+	"github.com/duckbugio/flock/core/pending"
+)
+
+// This total cap is below the dispatcher's per-chat capacity, so enqueue never
+// blocks the polling loop waiting for a transcription slot.
+const maxQueuedVoices = 32
+
+func (r *Receiver) queueVoice(ctx context.Context, msg *Message, chatID string, replyToBot bool, fileID string) {
+	raw, err := json.Marshal(msg)
+	if err != nil {
+		r.cfg.Logger.Error("encode pending voice", "error", err)
+		return
+	}
+	r.voiceMu.Lock()
+	total := 0
+	for _, queue := range r.cfg.VoiceStore.All() {
+		total += len(queue)
+	}
+	if total >= maxQueuedVoices {
+		r.voiceMu.Unlock()
+		r.notify(ctx, chatID, "Voice processing is busy. Please retry in a moment or send text.")
+		return
+	}
+	marker := pending.Marker{Prompt: string(raw), StartedAt: time.Now().UnixMilli()}
+	marker.ID, err = r.cfg.VoiceStore.Enqueue(chatID, marker)
+	if err != nil {
+		r.voiceMu.Unlock()
+		r.cfg.Logger.Error("persist pending voice", "error", err)
+		r.notify(ctx, chatID, "Could not queue that voice message. Please retry or send text.")
+		return
+	}
+	r.submitVoice(ctx, msg, chatID, replyToBot, fileID, marker)
+	r.voiceMu.Unlock()
+}
+
+func (r *Receiver) submitVoice(
+	ctx context.Context, msg *Message, chatID string, replyToBot bool, fileID string, marker pending.Marker,
+) {
+	// The dispatcher owns the job lifetime and shutdown cause; the poll context
+	// only controls admission. A cancelled admission remains durable for restart.
+	if ctx.Err() != nil {
+		return
+	}
+	//nolint:contextcheck // Dispatcher owns cancellation and ErrShutdown, which controls durable replay.
+	r.voiceJobs.Submit(chatID, func(ctx context.Context) {
+		r.handleVoice(ctx, msg, chatID, replyToBot, fileID)
+		// Interrupted preparation is replayed after restart. On success the shared
+		// service has already persisted its own pending agent run before this removal.
+		// A crash between stores may replay work; this is intentionally at-least-once.
+		if errors.Is(context.Cause(ctx), dispatch.ErrShutdown) {
+			return
+		}
+		if err := r.cfg.VoiceStore.Remove(chatID, marker.ID); err != nil {
+			r.cfg.Logger.Error("remove completed voice preparation", "error", err)
+		}
+	})
+}
+
+func (r *Receiver) resumeVoice(ctx context.Context) {
+	total := 0
+	for chatID, queue := range r.cfg.VoiceStore.All() {
+		for _, marker := range queue {
+			if ctx.Err() != nil {
+				return
+			}
+			var msg Message
+			err := json.Unmarshal([]byte(marker.Prompt), &msg)
+			_, replyToBot, allowed := r.admits(&msg)
+			fileID := voiceReference(&msg)
+			if err != nil || !allowed || strconv.FormatInt(msg.Chat.ID, 10) != chatID || fileID == "" {
+				r.cfg.Logger.Warn("pending voice is invalid or sender is no longer allowed; retaining record", "chat_id", chatID)
+				continue
+			}
+			if total >= maxQueuedVoices {
+				r.cfg.Logger.Warn("pending voice queue exceeds capacity; remaining records retained")
+				return
+			}
+			total++
+			r.submitVoice(ctx, &msg, chatID, replyToBot, fileID, marker)
+		}
+	}
+}
+
+func (r *Receiver) cancelVoice(chatID string) bool {
+	if r.voiceJobs == nil {
+		return false
+	}
+	r.voiceMu.Lock()
+	defer r.voiceMu.Unlock()
+	active := len(r.cfg.VoiceStore.All()[chatID]) > 0
+	r.voiceJobs.Cancel(chatID)
+	if err := r.cfg.VoiceStore.Clear(chatID); err != nil {
+		r.cfg.Logger.Error("clear cancelled voice queue", "error", err)
+	}
+	return active
+}

--- a/adapters/lo/voice_queue_test.go
+++ b/adapters/lo/voice_queue_test.go
@@ -1,0 +1,189 @@
+package lo_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/duckbugio/flock/adapters/lo"
+	"github.com/duckbugio/flock/core/pending"
+)
+
+type queuedService struct {
+	serviceSpy
+	runs  atomic.Int32
+	stops atomic.Int32
+}
+
+func (s *queuedService) Handle(context.Context, string, int64, string, string) { s.runs.Add(1) }
+func (s *queuedService) StopChat(string) bool                                  { s.stops.Add(1); return false }
+
+type heldVoice struct {
+	started       chan struct{}
+	release       chan struct{}
+	respectCancel bool
+}
+
+func (v *heldVoice) Transcribe(ctx context.Context, _ string) (string, error) {
+	select {
+	case v.started <- struct{}{}:
+	default:
+	}
+	if v.respectCancel {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-v.release:
+		}
+	} else {
+		<-v.release
+	}
+	return "late transcript", nil
+}
+
+type observedStore struct {
+	pending.Store
+	removed chan struct{}
+}
+
+func (s *observedStore) Remove(chatID, id string) error {
+	err := s.Store.Remove(chatID, id)
+	select {
+	case s.removed <- struct{}{}:
+	default:
+	}
+	return err
+}
+
+func awaitVoiceSignal(t *testing.T, signal <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(time.Second):
+		t.Fatal("voice operation blocked polling or failed to complete")
+	}
+}
+
+func voiceQueueReceiver(t *testing.T, speech lo.VoiceInput, store pending.Store, svc *queuedService) (*lo.Receiver, func()) {
+	t.Helper()
+	polled := make(chan struct{}, 1)
+	api := client(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/bot"+testToken+"/getUpdates" {
+			select {
+			case polled <- struct{}{}:
+			default:
+			}
+			reply(w, `{"ok":true,"result":[]}`)
+			return
+		}
+		reply(w, `{"ok":true,"result":{"message_id":1}}`)
+	})
+	receiver := lo.NewReceiver(lo.ReceiverConfig{
+		Client: api, Transport: lo.NewTransport(api, false),
+		Service: svc, Voice: speech, VoiceStore: store, VoiceConcurrency: 1, IsAllowed: func(int64) bool { return true },
+	})
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() { defer close(done); _ = receiver.Run(ctx) }()
+	awaitVoiceSignal(t, polled)
+	stop := func() { cancel(); awaitVoiceSignal(t, done) }
+	t.Cleanup(stop)
+	return receiver, stop
+}
+
+func TestQueuedVoiceDoesNotDelayStopAndLateTranscriptCannotStartRun(t *testing.T) {
+	store, err := pending.Open(filepath.Join(t.TempDir(), "voice.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	observed := &observedStore{Store: store, removed: make(chan struct{}, 1)}
+	speech := &heldVoice{started: make(chan struct{}, 1), release: make(chan struct{})}
+	svc := &queuedService{}
+	receiver, _ := voiceQueueReceiver(t, speech, observed, svc)
+	msg := inbound("")
+	msg.Voice = lo.RawAttachment("voice-ref")
+	admitted := make(chan struct{})
+	go func() { receiver.HandleUpdate(t.Context(), lo.Update{Message: msg}); close(admitted) }()
+	awaitVoiceSignal(t, admitted)
+	awaitVoiceSignal(t, speech.started)
+	if len(store.All()["77"]) != 1 {
+		t.Fatal("voice was acknowledged before durable queue write")
+	}
+	receiver.HandleUpdate(t.Context(), lo.Update{Message: inbound("/stop")})
+	if svc.stops.Load() != 1 || len(store.All()["77"]) != 0 {
+		t.Fatal("stop did not cancel and clear pending voice")
+	}
+	close(speech.release)
+	awaitVoiceSignal(t, observed.removed)
+	if svc.runs.Load() != 0 {
+		t.Fatal("late transcript started a stopped run")
+	}
+}
+
+func TestInterruptedVoiceIsReplayedFromDurableReference(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "voice.json")
+	store, err := pending.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	msg := inbound("")
+	msg.Voice = lo.RawAttachment("voice-ref")
+	raw, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Enqueue("77", pending.Marker{Prompt: string(raw)}); err != nil {
+		t.Fatal(err)
+	}
+	speech := &heldVoice{started: make(chan struct{}, 1), release: make(chan struct{}), respectCancel: true}
+	svc := &queuedService{}
+	_, stop := voiceQueueReceiver(t, speech, store, svc)
+	awaitVoiceSignal(t, speech.started)
+	stop()
+	restored, err := pending.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(restored.All()["77"]) != 1 {
+		t.Fatal("shutdown discarded interrupted transcription")
+	}
+	observed := &observedStore{Store: restored, removed: make(chan struct{}, 1)}
+	resumed := &heldVoice{started: make(chan struct{}, 1), release: make(chan struct{})}
+	close(resumed.release)
+	_, _ = voiceQueueReceiver(t, resumed, observed, svc)
+	awaitVoiceSignal(t, observed.removed)
+	if svc.runs.Load() != 1 || len(restored.All()["77"]) != 0 {
+		t.Fatal("restart did not finish exactly the pending reference")
+	}
+}
+
+func TestVoiceQueueCapacityDoesNotBlockPolling(t *testing.T) {
+	store, err := pending.Open(filepath.Join(t.TempDir(), "voice.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	speech := &heldVoice{started: make(chan struct{}, 1), release: make(chan struct{}), respectCancel: true}
+	svc := &queuedService{}
+	receiver, _ := voiceQueueReceiver(t, speech, store, svc)
+	admitted := make(chan struct{})
+	go func() {
+		for range 40 {
+			msg := inbound("")
+			msg.Voice = lo.RawAttachment("voice-ref")
+			receiver.HandleUpdate(t.Context(), lo.Update{Message: msg})
+		}
+		close(admitted)
+	}()
+	awaitVoiceSignal(t, admitted)
+	if got := len(store.All()["77"]); got != 32 {
+		t.Fatalf("durable queue size = %d, want 32", got)
+	}
+	receiver.HandleUpdate(t.Context(), lo.Update{Message: inbound("/stop")})
+	if len(store.All()["77"]) != 0 || svc.stops.Load() != 1 || svc.runs.Load() != 0 {
+		t.Fatal("full voice queue prevented Stop")
+	}
+}

--- a/cmd/flock-lo/main.go
+++ b/cmd/flock-lo/main.go
@@ -177,18 +177,30 @@ func run() int {
 	// uploads directory, a sibling of the cloned repositories, so user media is not
 	// swept into a commit. Missing media bytes get a specific explanatory notice.
 	uploads := lo.NewUploader(api, ws, cfg.MaxUploadBytes, logger)
+	voiceInput := buildVoice(cfg, api, logger)
+	var voiceStore pending.Store
+	if voiceInput != nil {
+		stored, err := pending.Open(filepath.Join(cfg.ApprovedDirectory, "voice-inputs.json"))
+		if err != nil {
+			logger.Error("open pending voice inputs", "error", err)
+			return 1
+		}
+		voiceStore = stored
+	}
 	receiver := lo.NewReceiver(lo.ReceiverConfig{
-		Service:        svc,
-		Client:         api,
-		Transport:      transport,
-		Username:       self.Username,
-		BotID:          self.ID,
-		IsAllowed:      cfg.IsLOAllowed,
-		RequireMention: cfg.RequireGroupMention,
-		Scheduler:      scheduler,
-		Uploads:        uploads,
-		Voice:          buildVoice(cfg, api, logger),
-		Logger:         logger,
+		Service:          svc,
+		Client:           api,
+		Transport:        transport,
+		Username:         self.Username,
+		BotID:            self.ID,
+		IsAllowed:        cfg.IsLOAllowed,
+		RequireMention:   cfg.RequireGroupMention,
+		Scheduler:        scheduler,
+		Uploads:          uploads,
+		Voice:            voiceInput,
+		VoiceStore:       voiceStore,
+		VoiceConcurrency: cfg.MaxConcurrentChatRuns,
+		Logger:           logger,
 		Guards: func(id int64) (bool, string) {
 			return chat.CheckGuards(limiter, costs, chat.GuardConfig{CostCapUSD: cfg.EffectiveCostCapUSD()}, id)
 		},


### PR DESCRIPTION
Voice transcription previously ran in the polling loop, delaying `/stop` and other updates until the provider returned. Persist incoming voice references before dispatching bounded asynchronous preparation; `/stop` and `/new` cancel queued work and prevent late transcripts from starting a run. Restart resumes interrupted preparation after rechecking sender access. Recovery is at-least-once across the voice-to-agent store handoff.

Validation: full `task default` and `task security-scan` passed, including cancellation against a late provider result, durable restart replay, and queue saturation without blocking Stop. Production voice setup now opens its pending store fail-closed.
